### PR TITLE
Fix content_view_version_cleanup_role version listing in test

### DIFF
--- a/tests/test_playbooks/content_view_version_cleanup_role.yml
+++ b/tests/test_playbooks/content_view_version_cleanup_role.yml
@@ -70,8 +70,8 @@
     - name: check remaining content view versions
       assert:
         that:
-          - remaining_cvs.resources[0].versions|map(attribute='version')|list == ['3.0', '4.0', '5.0']
-          - remaining_cvs.resources[1].versions|map(attribute='version')|list == ['3.0', '4.0', '5.0']
+          - remaining_cvs.resources[0].versions|map(attribute='version')|list | difference(['3.0', '4.0', '5.0'])|length == 0
+          - remaining_cvs.resources[1].versions|map(attribute='version')|list | difference(['3.0', '4.0', '5.0'])|length == 0
     - name: clean up all unused CVs
       include_role:
         name: content_view_version_cleanup

--- a/tests/test_playbooks/fixtures/content_view_version_cleanup_role-0.yml
+++ b/tests/test_playbooks/fixtures/content_view_version_cleanup_role-0.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"2.5.0","api_version":2}'
+      string: '{"satellite_version":"6.16.0","result":"ok","status":200,"version":"3.12.0-develop","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '100'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.5.0
+      - 3.12.0-develop
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -50,8 +50,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '62'
     status:
       code: 200
       message: OK
@@ -70,17 +68,18 @@ interactions:
     uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
-        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\"\
-        :\"Test_Organization\",\"created_at\":\"2021-06-29 08:33:23 UTC\",\"updated_at\"\
-        :\"2021-06-29 08:33:25 UTC\",\"id\":7,\"name\":\"Test Organization\",\"title\"\
-        :\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+        4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2024-07-09
+        14:29:57 UTC\",\"updated_at\":\"2024-07-09 14:29:59 UTC\",\"id\":26,\"name\":\"Test
+        Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '389'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -94,13 +93,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.5.0
+      - 3.12.0-develop
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -111,8 +108,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '388'
     status:
       code: 200
       message: OK
@@ -128,32 +123,42 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/7/content_views?search=name+~+cleanup&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/26/content_views?search=name+~+cleanup&per_page=4294967296
   response:
     body:
-      string: '{"total":3,"subtotal":2,"page":1,"per_page":"4294967296","error":null,"search":"name
-        ~ cleanup","sort":{"by":"name","order":"asc"},"results":[{"composite":true,"component_ids":[21],"default":false,"version_count":5,"latest_version":"5.0","latest_version_id":26,"auto_publish":false,"solve_dependencies":false,"import_only":false,"repository_ids":[],"id":10,"name":"cleanup-testccv","label":"cleanup-testccv","description":null,"organization_id":7,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":7},"created_at":"2021-06-29
-        08:33:29 UTC","updated_at":"2021-06-29 08:34:22 UTC","last_task":{"id":"23e7eca9-3adb-48a2-9778-a4f4e6db4435","result":"successful","last_sync_words":"less
-        than a minute"},"latest_version_environments":[{"id":6,"name":"Library","label":"Library"}],"environments":[{"id":6,"name":"Library","label":"Library","permissions":{"readable":true}}],"repositories":[],"versions":[{"id":22,"version":"1.0","published":"2021-06-29
-        08:34:00 UTC","environment_ids":[]},{"id":23,"version":"2.0","published":"2021-06-29
-        08:34:05 UTC","environment_ids":[]},{"id":24,"version":"3.0","published":"2021-06-29
-        08:34:11 UTC","environment_ids":[]},{"id":25,"version":"4.0","published":"2021-06-29
-        08:34:16 UTC","environment_ids":[]},{"id":26,"version":"5.0","published":"2021-06-29
-        08:34:22 UTC","environment_ids":[6]}],"components":[{"id":21,"name":"cleanup-testcv
-        5.0","content_view_id":9,"version":"5.0","environments":[{"id":6,"name":"Library","label":"Library"}],"content_view":{"id":9,"name":"cleanup-testcv","label":"cleanup-testcv","description":null,"next_version":6,"latest_version":"5.0"},"repositories":[]}],"content_view_components":[{"latest":true,"id":2,"created_at":"2021-06-29
-        08:33:29 UTC","updated_at":"2021-06-29 08:33:29 UTC","composite_content_view":{"id":10,"name":"cleanup-testccv","label":"cleanup-testccv","description":null,"next_version":6,"latest_version":"5.0","version_count":5},"content_view":{"id":9,"name":"cleanup-testcv","label":"cleanup-testcv","description":null,"next_version":6,"latest_version":"5.0","version_count":5},"content_view_version":{"id":21,"name":"cleanup-testcv
-        5.0","content_view_id":9,"version":"5.0","content_view":{"id":9,"name":"cleanup-testcv","label":"cleanup-testcv","description":null},"environments":[{"id":6,"name":"Library","label":"Library"}],"repositories":[]}}],"activation_keys":[],"hosts":[],"next_version":"6.0","last_published":"2021-06-29
-        08:34:22 UTC","permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}},{"composite":false,"component_ids":[],"default":false,"version_count":5,"latest_version":"5.0","latest_version_id":21,"auto_publish":false,"solve_dependencies":false,"import_only":false,"repository_ids":[],"id":9,"name":"cleanup-testcv","label":"cleanup-testcv","description":null,"organization_id":7,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":7},"created_at":"2021-06-29
-        08:33:27 UTC","updated_at":"2021-06-29 08:33:54 UTC","last_task":{"id":"d23c2127-d267-416e-87bd-3d856a80fdd2","result":"successful","last_sync_words":"1
-        minute"},"latest_version_environments":[{"id":6,"name":"Library","label":"Library"}],"environments":[{"id":6,"name":"Library","label":"Library","permissions":{"readable":true}}],"repositories":[],"versions":[{"id":17,"version":"1.0","published":"2021-06-29
-        08:33:31 UTC","environment_ids":[]},{"id":18,"version":"2.0","published":"2021-06-29
-        08:33:37 UTC","environment_ids":[]},{"id":19,"version":"3.0","published":"2021-06-29
-        08:33:43 UTC","environment_ids":[]},{"id":20,"version":"4.0","published":"2021-06-29
-        08:33:48 UTC","environment_ids":[]},{"id":21,"version":"5.0","published":"2021-06-29
-        08:33:54 UTC","environment_ids":[6]}],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"6.0","last_published":"2021-06-29
-        08:33:54 UTC","permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
+      string: '{"total":3,"subtotal":2,"selectable":2,"page":1,"per_page":"4294967296","error":null,"search":"name
+        ~ cleanup","sort":{"by":"name","order":"asc"},"results":[{"composite":true,"component_ids":[46],"duplicate_repositories_to_publish":[],"default":false,"version_count":5,"latest_version":"5.0","latest_version_id":51,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":1,"related_composite_cvs":[],"filtered":false,"repository_ids":[],"id":19,"name":"cleanup-testccv","label":"cleanup-testccv","description":null,"organization_id":26,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":26},"created_at":"2024-07-09
+        14:30:02 UTC","updated_at":"2024-07-09 14:30:58 UTC","last_task":{"id":"aec3029e-8c8f-4ae7-bba9-cb504e1b4d0e","started_at":"2024-07-09
+        14:30:58 UTC","result":"success","last_sync_words":"less than a minute"},"latest_version_environments":[{"id":15,"name":"Library","label":"Library"}],"repositories":[],"versions":[{"id":51,"version":"5.0","published":"2024-07-09
+        14:30:58 UTC","description":null,"environment_ids":[15],"filters_applied":false,"published_at_words":"less
+        than a minute"},{"id":50,"version":"4.0","published":"2024-07-09 14:30:52
+        UTC","description":null,"environment_ids":[],"filters_applied":false,"published_at_words":"less
+        than a minute"},{"id":49,"version":"3.0","published":"2024-07-09 14:30:47
+        UTC","description":null,"environment_ids":[],"filters_applied":false,"published_at_words":"less
+        than a minute"},{"id":48,"version":"2.0","published":"2024-07-09 14:30:41
+        UTC","description":null,"environment_ids":[],"filters_applied":false,"published_at_words":"less
+        than a minute"},{"id":47,"version":"1.0","published":"2024-07-09 14:30:35
+        UTC","description":null,"environment_ids":[],"filters_applied":false,"published_at_words":"less
+        than a minute"}],"components":[{"id":46,"name":"cleanup-testcv 5.0","content_view_id":18,"version":"5.0","environments":[{"id":15,"name":"Library","label":"Library"}],"content_view":{"id":18,"name":"cleanup-testcv","label":"cleanup-testcv","description":null,"next_version":6,"latest_version":"5.0"},"repositories":[]}],"content_view_components":[{"latest":true,"id":2,"created_at":"2024-07-09
+        14:30:03 UTC","updated_at":"2024-07-09 14:30:03 UTC","composite_content_view":{"id":19,"name":"cleanup-testccv","label":"cleanup-testccv","description":null,"next_version":6,"latest_version":"5.0","version_count":5},"content_view":{"id":18,"name":"cleanup-testcv","label":"cleanup-testcv","description":null,"next_version":6,"latest_version":"5.0","version_count":5},"content_view_version":{"id":46,"name":"cleanup-testcv
+        5.0","content_view_id":18,"version":"5.0","content_view":{"id":18,"name":"cleanup-testcv","label":"cleanup-testcv","description":null},"environments":[{"id":15,"name":"Library","label":"Library"}],"repositories":[]},"component_content_view_versions":[{"id":46,"version":"5.0","description":null,"published_at_words":"1
+        minute"},{"id":45,"version":"4.0","description":null,"published_at_words":"1
+        minute"},{"id":44,"version":"3.0","description":null,"published_at_words":"1
+        minute"},{"id":43,"version":"2.0","description":null,"published_at_words":"1
+        minute"},{"id":42,"version":"1.0","description":null,"published_at_words":"1
+        minute"}]}],"activation_keys":[],"hosts":[],"next_version":"6.0","last_published":"2024-07-09
+        14:30:58 UTC","environments":[{"id":15,"label":"Library","name":"Library","activation_keys":[],"hosts":[],"permissions":{"readable":true}}]},{"composite":false,"component_ids":[],"duplicate_repositories_to_publish":[],"default":false,"version_count":5,"latest_version":"5.0","latest_version_id":46,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":1,"related_composite_cvs":[{"id":19,"name":"cleanup-testccv"}],"filtered":false,"repository_ids":[],"id":18,"name":"cleanup-testcv","label":"cleanup-testcv","description":null,"organization_id":26,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":26},"created_at":"2024-07-09
+        14:30:00 UTC","updated_at":"2024-07-09 14:30:29 UTC","last_task":{"id":"6da31077-1ece-4449-882a-4057308558e4","started_at":"2024-07-09
+        14:30:29 UTC","result":"success","last_sync_words":"1 minute"},"latest_version_environments":[{"id":15,"name":"Library","label":"Library"}],"repositories":[],"versions":[{"id":46,"version":"5.0","published":"2024-07-09
+        14:30:29 UTC","description":null,"environment_ids":[15],"filters_applied":false,"published_at_words":"1
+        minute"},{"id":45,"version":"4.0","published":"2024-07-09 14:30:24 UTC","description":null,"environment_ids":[],"filters_applied":false,"published_at_words":"1
+        minute"},{"id":44,"version":"3.0","published":"2024-07-09 14:30:18 UTC","description":null,"environment_ids":[],"filters_applied":false,"published_at_words":"1
+        minute"},{"id":43,"version":"2.0","published":"2024-07-09 14:30:12 UTC","description":null,"environment_ids":[],"filters_applied":false,"published_at_words":"1
+        minute"},{"id":42,"version":"1.0","published":"2024-07-09 14:30:06 UTC","description":null,"environment_ids":[],"filters_applied":false,"published_at_words":"1
+        minute"}],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"6.0","last_published":"2024-07-09
+        14:30:29 UTC","environments":[{"id":15,"label":"Library","name":"Library","activation_keys":[],"hosts":[],"permissions":{"readable":true}}]}]}
 
         '
     headers:
@@ -161,6 +166,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '5471'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -172,15 +179,13 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 7; Test Organization
+      - 26; Test Organization
       Foreman_version:
-      - 2.5.0
+      - 3.12.0-develop
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -191,8 +196,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '4123'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/content_view_version_cleanup_role-1.yml
+++ b/tests/test_playbooks/fixtures/content_view_version_cleanup_role-1.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"2.5.0","api_version":2}'
+      string: '{"satellite_version":"6.16.0","result":"ok","status":200,"version":"3.12.0-develop","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '100'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.5.0
+      - 3.12.0-develop
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -50,8 +50,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '62'
     status:
       code: 200
       message: OK
@@ -70,17 +68,18 @@ interactions:
     uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
-        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\"\
-        :\"Test_Organization\",\"created_at\":\"2021-06-29 08:33:23 UTC\",\"updated_at\"\
-        :\"2021-06-29 08:33:25 UTC\",\"id\":7,\"name\":\"Test Organization\",\"title\"\
-        :\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+        4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2024-07-09
+        14:29:57 UTC\",\"updated_at\":\"2024-07-09 14:29:59 UTC\",\"id\":26,\"name\":\"Test
+        Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '389'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -94,13 +93,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.5.0
+      - 3.12.0-develop
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -111,8 +108,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '388'
     status:
       code: 200
       message: OK
@@ -128,22 +123,31 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/7/content_views?search=name%3D%22cleanup-testccv%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/26/content_views?search=name%3D%22cleanup-testccv%22&per_page=4294967296
   response:
     body:
-      string: '{"total":3,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"cleanup-testccv\"","sort":{"by":"name","order":"asc"},"results":[{"composite":true,"component_ids":[21],"default":false,"version_count":5,"latest_version":"5.0","latest_version_id":26,"auto_publish":false,"solve_dependencies":false,"import_only":false,"repository_ids":[],"id":10,"name":"cleanup-testccv","label":"cleanup-testccv","description":null,"organization_id":7,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":7},"created_at":"2021-06-29
-        08:33:29 UTC","updated_at":"2021-06-29 08:34:22 UTC","last_task":{"id":"23e7eca9-3adb-48a2-9778-a4f4e6db4435","result":"successful","last_sync_words":"less
-        than a minute"},"latest_version_environments":[{"id":6,"name":"Library","label":"Library"}],"environments":[{"id":6,"name":"Library","label":"Library","permissions":{"readable":true}}],"repositories":[],"versions":[{"id":22,"version":"1.0","published":"2021-06-29
-        08:34:00 UTC","environment_ids":[]},{"id":23,"version":"2.0","published":"2021-06-29
-        08:34:05 UTC","environment_ids":[]},{"id":24,"version":"3.0","published":"2021-06-29
-        08:34:11 UTC","environment_ids":[]},{"id":25,"version":"4.0","published":"2021-06-29
-        08:34:16 UTC","environment_ids":[]},{"id":26,"version":"5.0","published":"2021-06-29
-        08:34:22 UTC","environment_ids":[6]}],"components":[{"id":21,"name":"cleanup-testcv
-        5.0","content_view_id":9,"version":"5.0","environments":[{"id":6,"name":"Library","label":"Library"}],"content_view":{"id":9,"name":"cleanup-testcv","label":"cleanup-testcv","description":null,"next_version":6,"latest_version":"5.0"},"repositories":[]}],"content_view_components":[{"latest":true,"id":2,"created_at":"2021-06-29
-        08:33:29 UTC","updated_at":"2021-06-29 08:33:29 UTC","composite_content_view":{"id":10,"name":"cleanup-testccv","label":"cleanup-testccv","description":null,"next_version":6,"latest_version":"5.0","version_count":5},"content_view":{"id":9,"name":"cleanup-testcv","label":"cleanup-testcv","description":null,"next_version":6,"latest_version":"5.0","version_count":5},"content_view_version":{"id":21,"name":"cleanup-testcv
-        5.0","content_view_id":9,"version":"5.0","content_view":{"id":9,"name":"cleanup-testcv","label":"cleanup-testcv","description":null},"environments":[{"id":6,"name":"Library","label":"Library"}],"repositories":[]}}],"activation_keys":[],"hosts":[],"next_version":"6.0","last_published":"2021-06-29
-        08:34:22 UTC","permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
+      string: '{"total":3,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"cleanup-testccv\"","sort":{"by":"name","order":"asc"},"results":[{"composite":true,"component_ids":[46],"duplicate_repositories_to_publish":[],"default":false,"version_count":5,"latest_version":"5.0","latest_version_id":51,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":1,"related_composite_cvs":[],"filtered":false,"repository_ids":[],"id":19,"name":"cleanup-testccv","label":"cleanup-testccv","description":null,"organization_id":26,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":26},"created_at":"2024-07-09
+        14:30:02 UTC","updated_at":"2024-07-09 14:30:58 UTC","last_task":{"id":"aec3029e-8c8f-4ae7-bba9-cb504e1b4d0e","started_at":"2024-07-09
+        14:30:58 UTC","result":"success","last_sync_words":"less than a minute"},"latest_version_environments":[{"id":15,"name":"Library","label":"Library"}],"repositories":[],"versions":[{"id":51,"version":"5.0","published":"2024-07-09
+        14:30:58 UTC","description":null,"environment_ids":[15],"filters_applied":false,"published_at_words":"less
+        than a minute"},{"id":50,"version":"4.0","published":"2024-07-09 14:30:52
+        UTC","description":null,"environment_ids":[],"filters_applied":false,"published_at_words":"less
+        than a minute"},{"id":49,"version":"3.0","published":"2024-07-09 14:30:47
+        UTC","description":null,"environment_ids":[],"filters_applied":false,"published_at_words":"less
+        than a minute"},{"id":48,"version":"2.0","published":"2024-07-09 14:30:41
+        UTC","description":null,"environment_ids":[],"filters_applied":false,"published_at_words":"less
+        than a minute"},{"id":47,"version":"1.0","published":"2024-07-09 14:30:35
+        UTC","description":null,"environment_ids":[],"filters_applied":false,"published_at_words":"less
+        than a minute"}],"components":[{"id":46,"name":"cleanup-testcv 5.0","content_view_id":18,"version":"5.0","environments":[{"id":15,"name":"Library","label":"Library"}],"content_view":{"id":18,"name":"cleanup-testcv","label":"cleanup-testcv","description":null,"next_version":6,"latest_version":"5.0"},"repositories":[]}],"content_view_components":[{"latest":true,"id":2,"created_at":"2024-07-09
+        14:30:03 UTC","updated_at":"2024-07-09 14:30:03 UTC","composite_content_view":{"id":19,"name":"cleanup-testccv","label":"cleanup-testccv","description":null,"next_version":6,"latest_version":"5.0","version_count":5},"content_view":{"id":18,"name":"cleanup-testcv","label":"cleanup-testcv","description":null,"next_version":6,"latest_version":"5.0","version_count":5},"content_view_version":{"id":46,"name":"cleanup-testcv
+        5.0","content_view_id":18,"version":"5.0","content_view":{"id":18,"name":"cleanup-testcv","label":"cleanup-testcv","description":null},"environments":[{"id":15,"name":"Library","label":"Library"}],"repositories":[]},"component_content_view_versions":[{"id":46,"version":"5.0","description":null,"published_at_words":"1
+        minute"},{"id":45,"version":"4.0","description":null,"published_at_words":"1
+        minute"},{"id":44,"version":"3.0","description":null,"published_at_words":"1
+        minute"},{"id":43,"version":"2.0","description":null,"published_at_words":"1
+        minute"},{"id":42,"version":"1.0","description":null,"published_at_words":"1
+        minute"}]}],"activation_keys":[],"hosts":[],"next_version":"6.0","last_published":"2024-07-09
+        14:30:58 UTC","environments":[{"id":15,"label":"Library","name":"Library","activation_keys":[],"hosts":[],"permissions":{"readable":true}}]}]}
 
         '
     headers:
@@ -151,6 +155,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '3536'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -162,15 +168,13 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 7; Test Organization
+      - 26; Test Organization
       Foreman_version:
-      - 2.5.0
+      - 3.12.0-develop
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -181,8 +185,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '2633'
     status:
       code: 200
       message: OK
@@ -198,21 +200,20 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_view_versions?search=content_view_id%3D10%2Cversion%3D2.0&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_view_versions?search=content_view_id%3D19%2Cversion%3D2.0&per_page=4294967296
   response:
     body:
-      string: '{"total":13,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"content_view_id=10,version=2.0","sort":{"by":"version","order":"desc"},"results":[{"version":"2.0","major":2,"minor":0,"composite_content_view_ids":[],"published_in_composite_content_view_ids":[],"content_view_id":10,"default":false,"description":null,"id":23,"name":"cleanup-testccv
-        2.0","created_at":"2021-06-29 08:34:05 UTC","updated_at":"2021-06-29 08:34:06
-        UTC","content_view":{"id":10,"name":"cleanup-testccv","label":"cleanup-testccv"},"composite_content_views":[],"composite_content_view_versions":[],"published_in_composite_content_views":[],"environments":[],"repositories":[],"last_event":{"user":"admin","status":"successful","description":null,"action":"publish","created_at":"2021-06-29
-        08:34:05 UTC","updated_at":"2021-06-29 08:34:06 UTC","environment":null,"task":{"id":"44a1d730-d421-4726-bfea-f01831cd22f5","label":"Actions::Katello::ContentView::Publish","pending":false,"action":"Publish
-        content view ''cleanup-testccv''; organization ''Test Organization''","username":"admin","started_at":"2021-06-29
-        08:34:05 UTC","ended_at":"2021-06-29 08:34:06 UTC","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":10,"name":"cleanup-testccv","label":"cleanup-testccv"},"organization":{"id":7,"name":"Test
-        Organization","label":"Test_Organization"},"services_checked":["candlepin","candlepin_auth"],"history_id":22,"content_view_id":10,"auto_publish_composite_ids":[],"content_view_version_name":"cleanup-testccv
-        2.0","content_view_version_id":23,"environment_id":6,"user_id":4,"skip_promotion":null,"current_request_id":"93658368-901c-4816-a7d5-65cb776775da","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{"content_view_id":10,"content_view_version_id":23,"skip_promotion":null},"humanized":{"action":"Publish","input":[["content_view",{"text":"content
-        view ''cleanup-testccv''","link":"/content_views/10/versions"}],["organization",{"text":"organization
-        ''Test Organization''","link":"/organizations/7/edit"}]],"output":"","errors":[]},"cli_example":null,"start_at":"2021-06-29
-        08:34:05 UTC","available_actions":{"cancellable":false,"resumable":false}},"version":"2.0","publish":true,"version_id":23,"triggered_by":null,"triggered_by_id":null},"active_history":[],"ansible
-        collection_count":0,"deb_count":0,"docker_manifest_count":0,"docker_manifest_list_count":0,"docker_tag_count":0,"file_count":0,"rpm_count":0,"modulemd_count":0,"erratum_count":0,"package_group_count":0,"srpm_count":0,"module_stream_count":0,"package_count":0,"ostree_branch_count":null,"errata_counts":{"security":null,"bugfix":0,"enhancement":0,"total":null},"permissions":{"deletable":true}}]}
+      string: '{"total":12,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"content_view_id=19,version=2.0","sort":{"by":"version","order":"desc"},"results":[{"version":"2.0","major":2,"minor":0,"composite_content_view_ids":[],"published_in_composite_content_view_ids":[],"content_view_id":19,"default":false,"description":null,"id":48,"name":"cleanup-testccv
+        2.0","created_at":"2024-07-09 14:30:41 UTC","updated_at":"2024-07-09 14:30:41
+        UTC","content_view":{"id":19,"name":"cleanup-testccv","label":"cleanup-testccv","generated_for":"none"},"composite_content_views":[],"composite_content_view_versions":[],"published_in_composite_content_views":[],"environments":[],"repositories":[],"last_event":{"user":"admin","status":"successful","description":null,"action":"publish","created_at":"2024-07-09
+        14:30:41 UTC","updated_at":"2024-07-09 14:30:41 UTC","environment":null,"task":{"id":"64323767-4bc7-439f-b6b6-72351561ed23","label":"Actions::Katello::ContentView::Publish","pending":false,"action":"Publish
+        content view ''cleanup-testccv''; organization ''Test Organization''","username":"admin","started_at":"2024-07-09
+        14:30:41 UTC","ended_at":"2024-07-09 14:30:41 UTC","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":19,"name":"cleanup-testccv","label":"cleanup-testccv"},"organization":{"id":26,"name":"Test
+        Organization","label":"Test_Organization"},"services_checked":["candlepin","candlepin_auth"],"history_id":72,"content_view_id":19,"auto_publish_composite_ids":[],"content_view_version_name":"cleanup-testccv
+        2.0","content_view_version_id":48,"environment_id":15,"user_id":4,"skip_promotion":null,"current_request_id":"deaf3a03-847f-4854-bb60-d49f33463e12","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{"content_view_id":19,"content_view_version_id":48,"skip_promotion":null,"history_id":72},"humanized":{"action":"Publish","input":[["content_view",{"text":"content
+        view ''cleanup-testccv''","link":"/content_views/19/versions"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/26/edit"}]],"output":"","errors":[]},"cli_example":null,"start_at":"2024-07-09
+        14:30:41 UTC","available_actions":{"cancellable":false,"resumable":false}},"version":"2.0","publish":true,"version_id":48,"triggered_by":null,"triggered_by_id":null},"active_history":[],"ansible_collection_count":0,"docker_manifest_count":0,"docker_manifest_list_count":0,"docker_tag_count":0,"file_count":0,"rpm_count":0,"modulemd_count":0,"erratum_count":0,"package_group_count":0,"srpm_count":0,"module_stream_count":0,"package_count":0,"component_view_count":1,"ansible_collection_repository_count":0,"docker_repository_count":0,"file_repository_count":0,"yum_repository_count":0,"errata_counts":{"security":0,"bugfix":0,"enhancement":0,"total":0},"permissions":{"deletable":true},"filters_applied":false}]}
 
         '
     headers:
@@ -220,6 +221,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '2929'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -233,13 +236,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.5.0
+      - 3.12.0-develop
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -250,8 +251,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '2751'
     status:
       code: 200
       message: OK
@@ -269,12 +268,12 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: DELETE
-    uri: https://foreman.example.org/katello/api/content_view_versions/23
+    uri: https://foreman.example.org/katello/api/content_view_versions/48
   response:
     body:
-      string: '  {"id":"7d7de55b-e5bd-427a-ad0c-d488725218be","label":"Actions::Katello::ContentViewVersion::Destroy","pending":true,"action":"Destroy","username":"admin","started_at":"2021-06-29
-        08:34:29 UTC","ended_at":null,"state":"planned","result":"pending","progress":0.0,"input":{"id":23,"current_request_id":"8a9eba5d-4217-49cf-b41b-89a0e9a668f1","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{},"humanized":{"action":"Destroy","input":"","output":"","errors":[]},"cli_example":null,"start_at":"2021-06-29
-        08:34:29 UTC","available_actions":{"cancellable":false,"resumable":false}}
+      string: '  {"id":"ce8f7223-dc73-48e7-87a8-3d537157e645","label":"Actions::Katello::ContentViewVersion::Destroy","pending":true,"action":"Destroy","username":"admin","started_at":"2024-07-09
+        14:31:05 UTC","ended_at":null,"state":"planned","result":"pending","progress":0.0,"input":{"id":48,"docker_cleanup":false,"current_request_id":"c178c346-28c3-4f1e-8f5d-64b50347e15e","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{},"humanized":{"action":"Destroy","input":"","output":"","errors":[]},"cli_example":null,"start_at":"2024-07-09
+        14:31:05 UTC","available_actions":{"cancellable":false,"resumable":false}}
 
         '
     headers:
@@ -295,7 +294,7 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.5.0
+      - 3.12.0-develop
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
@@ -327,17 +326,19 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/foreman_tasks/api/tasks/7d7de55b-e5bd-427a-ad0c-d488725218be
+    uri: https://foreman.example.org/foreman_tasks/api/tasks/ce8f7223-dc73-48e7-87a8-3d537157e645
   response:
     body:
-      string: '{"id":"7d7de55b-e5bd-427a-ad0c-d488725218be","label":"Actions::Katello::ContentViewVersion::Destroy","pending":false,"action":"Destroy","username":"admin","started_at":"2021-06-29
-        08:34:29 UTC","ended_at":"2021-06-29 08:34:29 UTC","state":"stopped","result":"success","progress":1.0,"input":{"id":23,"current_request_id":"8a9eba5d-4217-49cf-b41b-89a0e9a668f1","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{},"humanized":{"action":"Destroy","input":"","output":"","errors":[]},"cli_example":null,"start_at":"2021-06-29
-        08:34:29 UTC","available_actions":{"cancellable":false,"resumable":false}}'
+      string: '{"id":"ce8f7223-dc73-48e7-87a8-3d537157e645","label":"Actions::Katello::ContentViewVersion::Destroy","pending":false,"action":"Destroy","username":"admin","started_at":"2024-07-09
+        14:31:05 UTC","ended_at":"2024-07-09 14:31:05 UTC","duration":"0.081428","state":"stopped","result":"success","progress":1.0,"input":{"id":48,"docker_cleanup":false,"current_request_id":"c178c346-28c3-4f1e-8f5d-64b50347e15e","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{},"humanized":{"action":"Destroy","input":"","output":"","errors":[]},"cli_example":null,"start_at":"2024-07-09
+        14:31:05 UTC","available_actions":{"cancellable":false,"resumable":false}}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '705'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -351,13 +352,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.5.0
+      - 3.12.0-develop
       Keep-Alive:
       - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -368,8 +367,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '660'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/content_view_version_cleanup_role-10.yml
+++ b/tests/test_playbooks/fixtures/content_view_version_cleanup_role-10.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"2.5.0","api_version":2}'
+      string: '{"satellite_version":"6.16.0","result":"ok","status":200,"version":"3.12.0-develop","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '100'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.5.0
+      - 3.12.0-develop
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -50,8 +50,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '62'
     status:
       code: 200
       message: OK
@@ -70,17 +68,18 @@ interactions:
     uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
-        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\"\
-        :\"Test_Organization\",\"created_at\":\"2021-06-29 08:33:23 UTC\",\"updated_at\"\
-        :\"2021-06-29 08:33:25 UTC\",\"id\":7,\"name\":\"Test Organization\",\"title\"\
-        :\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+        4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2024-07-09
+        14:29:57 UTC\",\"updated_at\":\"2024-07-09 14:29:59 UTC\",\"id\":26,\"name\":\"Test
+        Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '389'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -94,13 +93,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.5.0
+      - 3.12.0-develop
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -111,8 +108,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '388'
     status:
       code: 200
       message: OK
@@ -128,44 +123,41 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/9/content_view_versions?organization_id=7&search=&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_views/18/content_view_versions?organization_id=26&per_page=4294967296
   response:
     body:
-      string: '{"total":3,"subtotal":3,"page":1,"per_page":"4294967296","error":null,"search":"","sort":{"by":"version","order":"desc"},"results":[{"version":"5.0","major":5,"minor":0,"composite_content_view_ids":[],"published_in_composite_content_view_ids":[10],"content_view_id":9,"default":false,"description":null,"id":21,"name":"cleanup-testcv
-        5.0","created_at":"2021-06-29 08:33:54 UTC","updated_at":"2021-06-29 08:33:54
-        UTC","content_view":{"id":9,"name":"cleanup-testcv","label":"cleanup-testcv"},"composite_content_views":[],"composite_content_view_versions":[{"id":26,"content_view_id":10,"version":"5.0"}],"published_in_composite_content_views":[{"id":10,"name":"cleanup-testccv","label":"cleanup-testccv"}],"environments":[{"id":6,"name":"Library","label":"Library","publish_date":"1
-        minute","permissions":{"readable":true,"promotable_or_removable":true,"all_hosts_editable":true,"all_keys_editable":true},"host_count":0,"activation_key_count":0}],"repositories":[],"last_event":{"user":"admin","status":"successful","description":null,"action":"publish","created_at":"2021-06-29
-        08:33:54 UTC","updated_at":"2021-06-29 08:33:54 UTC","environment":null,"task":{"id":"d23c2127-d267-416e-87bd-3d856a80fdd2","label":"Actions::Katello::ContentView::Publish","pending":false,"action":"Publish
-        content view ''cleanup-testcv''; organization ''Test Organization''","username":"admin","started_at":"2021-06-29
-        08:33:54 UTC","ended_at":"2021-06-29 08:33:54 UTC","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":9,"name":"cleanup-testcv","label":"cleanup-testcv"},"organization":{"id":7,"name":"Test
-        Organization","label":"Test_Organization"},"services_checked":["candlepin","candlepin_auth"],"history_id":20,"content_view_id":9,"auto_publish_composite_ids":[],"content_view_version_name":"cleanup-testcv
-        5.0","content_view_version_id":21,"environment_id":6,"user_id":4,"skip_promotion":null,"current_request_id":"45b52809-4914-42af-8014-890a6cd395ef","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{"content_view_id":9,"content_view_version_id":21,"skip_promotion":null},"humanized":{"action":"Publish","input":[["content_view",{"text":"content
-        view ''cleanup-testcv''","link":"/content_views/9/versions"}],["organization",{"text":"organization
-        ''Test Organization''","link":"/organizations/7/edit"}]],"output":"","errors":[]},"cli_example":null,"start_at":"2021-06-29
-        08:33:54 UTC","available_actions":{"cancellable":false,"resumable":false}},"version":"5.0","publish":true,"version_id":21,"triggered_by":null,"triggered_by_id":null},"active_history":[],"ansible
-        collection_count":0,"deb_count":0,"docker_manifest_count":0,"docker_manifest_list_count":0,"docker_tag_count":0,"file_count":0,"rpm_count":0,"modulemd_count":0,"erratum_count":0,"package_group_count":0,"srpm_count":0,"module_stream_count":0,"package_count":0,"ostree_branch_count":null,"errata_counts":{"security":null,"bugfix":0,"enhancement":0,"total":null},"permissions":{"deletable":true}},{"version":"4.0","major":4,"minor":0,"composite_content_view_ids":[],"published_in_composite_content_view_ids":[],"content_view_id":9,"default":false,"description":null,"id":20,"name":"cleanup-testcv
-        4.0","created_at":"2021-06-29 08:33:48 UTC","updated_at":"2021-06-29 08:33:49
-        UTC","content_view":{"id":9,"name":"cleanup-testcv","label":"cleanup-testcv"},"composite_content_views":[],"composite_content_view_versions":[],"published_in_composite_content_views":[],"environments":[],"repositories":[],"last_event":{"user":"admin","status":"successful","description":null,"action":"publish","created_at":"2021-06-29
-        08:33:48 UTC","updated_at":"2021-06-29 08:33:49 UTC","environment":null,"task":{"id":"c970bcf1-8d24-4aee-bc57-ac1cd80dd29a","label":"Actions::Katello::ContentView::Publish","pending":false,"action":"Publish
-        content view ''cleanup-testcv''; organization ''Test Organization''","username":"admin","started_at":"2021-06-29
-        08:33:48 UTC","ended_at":"2021-06-29 08:33:49 UTC","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":9,"name":"cleanup-testcv","label":"cleanup-testcv"},"organization":{"id":7,"name":"Test
-        Organization","label":"Test_Organization"},"services_checked":["candlepin","candlepin_auth"],"history_id":19,"content_view_id":9,"auto_publish_composite_ids":[],"content_view_version_name":"cleanup-testcv
-        4.0","content_view_version_id":20,"environment_id":6,"user_id":4,"skip_promotion":null,"current_request_id":"05876deb-2d9f-480c-8c81-9e9cb09c4deb","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{"content_view_id":9,"content_view_version_id":20,"skip_promotion":null},"humanized":{"action":"Publish","input":[["content_view",{"text":"content
-        view ''cleanup-testcv''","link":"/content_views/9/versions"}],["organization",{"text":"organization
-        ''Test Organization''","link":"/organizations/7/edit"}]],"output":"","errors":[]},"cli_example":null,"start_at":"2021-06-29
-        08:33:48 UTC","available_actions":{"cancellable":false,"resumable":false}},"version":"4.0","publish":true,"version_id":20,"triggered_by":null,"triggered_by_id":null},"active_history":[],"ansible
-        collection_count":0,"deb_count":0,"docker_manifest_count":0,"docker_manifest_list_count":0,"docker_tag_count":0,"file_count":0,"rpm_count":0,"modulemd_count":0,"erratum_count":0,"package_group_count":0,"srpm_count":0,"module_stream_count":0,"package_count":0,"ostree_branch_count":null,"errata_counts":{"security":null,"bugfix":0,"enhancement":0,"total":null},"permissions":{"deletable":true}},{"version":"3.0","major":3,"minor":0,"composite_content_view_ids":[],"published_in_composite_content_view_ids":[],"content_view_id":9,"default":false,"description":null,"id":19,"name":"cleanup-testcv
-        3.0","created_at":"2021-06-29 08:33:43 UTC","updated_at":"2021-06-29 08:33:43
-        UTC","content_view":{"id":9,"name":"cleanup-testcv","label":"cleanup-testcv"},"composite_content_views":[],"composite_content_view_versions":[],"published_in_composite_content_views":[],"environments":[],"repositories":[],"last_event":{"user":"admin","status":"successful","description":null,"action":"publish","created_at":"2021-06-29
-        08:33:43 UTC","updated_at":"2021-06-29 08:33:43 UTC","environment":null,"task":{"id":"b7961aca-72f7-4491-a00a-c9e4b56d4ab6","label":"Actions::Katello::ContentView::Publish","pending":false,"action":"Publish
-        content view ''cleanup-testcv''; organization ''Test Organization''","username":"admin","started_at":"2021-06-29
-        08:33:43 UTC","ended_at":"2021-06-29 08:33:43 UTC","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":9,"name":"cleanup-testcv","label":"cleanup-testcv"},"organization":{"id":7,"name":"Test
-        Organization","label":"Test_Organization"},"services_checked":["candlepin","candlepin_auth"],"history_id":18,"content_view_id":9,"auto_publish_composite_ids":[],"content_view_version_name":"cleanup-testcv
-        3.0","content_view_version_id":19,"environment_id":6,"user_id":4,"skip_promotion":null,"current_request_id":"5a0f139b-237f-4ef2-854d-d92e9e1d6a50","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{"content_view_id":9,"content_view_version_id":19,"skip_promotion":null},"humanized":{"action":"Publish","input":[["content_view",{"text":"content
-        view ''cleanup-testcv''","link":"/content_views/9/versions"}],["organization",{"text":"organization
-        ''Test Organization''","link":"/organizations/7/edit"}]],"output":"","errors":[]},"cli_example":null,"start_at":"2021-06-29
-        08:33:43 UTC","available_actions":{"cancellable":false,"resumable":false}},"version":"3.0","publish":true,"version_id":19,"triggered_by":null,"triggered_by_id":null},"active_history":[],"ansible
-        collection_count":0,"deb_count":0,"docker_manifest_count":0,"docker_manifest_list_count":0,"docker_tag_count":0,"file_count":0,"rpm_count":0,"modulemd_count":0,"erratum_count":0,"package_group_count":0,"srpm_count":0,"module_stream_count":0,"package_count":0,"ostree_branch_count":null,"errata_counts":{"security":null,"bugfix":0,"enhancement":0,"total":null},"permissions":{"deletable":true}}]}
+      string: '{"total":3,"subtotal":3,"selectable":3,"page":1,"per_page":"4294967296","error":null,"search":null,"sort":{"by":"version","order":"desc"},"results":[{"version":"5.0","major":5,"minor":0,"composite_content_view_ids":[],"published_in_composite_content_view_ids":[19],"content_view_id":18,"default":false,"description":null,"id":46,"name":"cleanup-testcv
+        5.0","created_at":"2024-07-09 14:30:29 UTC","updated_at":"2024-07-09 14:30:30
+        UTC","content_view":{"id":18,"name":"cleanup-testcv","label":"cleanup-testcv","generated_for":"none"},"composite_content_views":[],"composite_content_view_versions":[{"id":51,"content_view_id":19,"version":"5.0"}],"published_in_composite_content_views":[{"id":19,"name":"cleanup-testccv","label":"cleanup-testccv"}],"environments":[{"id":15,"name":"Library","label":"Library","publish_date":"1
+        minute","permissions":{"readable":true,"promotable_or_removable":true,"all_hosts_editable":true,"all_keys_editable":true},"host_count":0,"activation_key_count":0}],"repositories":[],"last_event":{"user":"admin","status":"successful","description":null,"action":"publish","created_at":"2024-07-09
+        14:30:29 UTC","updated_at":"2024-07-09 14:30:30 UTC","environment":null,"task":{"id":"6da31077-1ece-4449-882a-4057308558e4","label":"Actions::Katello::ContentView::Publish","pending":false,"action":"Publish
+        content view ''cleanup-testcv''; organization ''Test Organization''","username":"admin","started_at":"2024-07-09
+        14:30:29 UTC","ended_at":"2024-07-09 14:30:30 UTC","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":18,"name":"cleanup-testcv","label":"cleanup-testcv"},"organization":{"id":26,"name":"Test
+        Organization","label":"Test_Organization"},"services_checked":["candlepin","candlepin_auth"],"history_id":70,"content_view_id":18,"auto_publish_composite_ids":[],"content_view_version_name":"cleanup-testcv
+        5.0","content_view_version_id":46,"environment_id":15,"user_id":4,"skip_promotion":null,"current_request_id":"184f0380-81b1-439e-8f68-eda7128e7fbf","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{"content_view_id":18,"content_view_version_id":46,"skip_promotion":null,"history_id":70},"humanized":{"action":"Publish","input":[["content_view",{"text":"content
+        view ''cleanup-testcv''","link":"/content_views/18/versions"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/26/edit"}]],"output":"","errors":[]},"cli_example":null,"start_at":"2024-07-09
+        14:30:29 UTC","available_actions":{"cancellable":false,"resumable":false}},"version":"5.0","publish":true,"version_id":46,"triggered_by":null,"triggered_by_id":null},"active_history":[],"ansible_collection_count":0,"docker_manifest_count":0,"docker_manifest_list_count":0,"docker_tag_count":0,"file_count":0,"rpm_count":0,"modulemd_count":0,"erratum_count":0,"package_group_count":0,"srpm_count":0,"module_stream_count":0,"package_count":0,"component_view_count":0,"ansible_collection_repository_count":0,"docker_repository_count":0,"file_repository_count":0,"yum_repository_count":0,"errata_counts":{"security":0,"bugfix":0,"enhancement":0,"total":0},"permissions":{"deletable":true},"filters_applied":false},{"version":"4.0","major":4,"minor":0,"composite_content_view_ids":[],"published_in_composite_content_view_ids":[],"content_view_id":18,"default":false,"description":null,"id":45,"name":"cleanup-testcv
+        4.0","created_at":"2024-07-09 14:30:24 UTC","updated_at":"2024-07-09 14:30:24
+        UTC","content_view":{"id":18,"name":"cleanup-testcv","label":"cleanup-testcv","generated_for":"none"},"composite_content_views":[],"composite_content_view_versions":[],"published_in_composite_content_views":[],"environments":[],"repositories":[],"last_event":{"user":"admin","status":"successful","description":null,"action":"publish","created_at":"2024-07-09
+        14:30:24 UTC","updated_at":"2024-07-09 14:30:24 UTC","environment":null,"task":{"id":"3467c3a4-2d6d-4e03-89cb-d4c671a10bb0","label":"Actions::Katello::ContentView::Publish","pending":false,"action":"Publish
+        content view ''cleanup-testcv''; organization ''Test Organization''","username":"admin","started_at":"2024-07-09
+        14:30:24 UTC","ended_at":"2024-07-09 14:30:24 UTC","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":18,"name":"cleanup-testcv","label":"cleanup-testcv"},"organization":{"id":26,"name":"Test
+        Organization","label":"Test_Organization"},"services_checked":["candlepin","candlepin_auth"],"history_id":69,"content_view_id":18,"auto_publish_composite_ids":[],"content_view_version_name":"cleanup-testcv
+        4.0","content_view_version_id":45,"environment_id":15,"user_id":4,"skip_promotion":null,"current_request_id":"678d454c-a0d7-4e44-95f2-148e0e2fbe20","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{"content_view_id":18,"content_view_version_id":45,"skip_promotion":null,"history_id":69},"humanized":{"action":"Publish","input":[["content_view",{"text":"content
+        view ''cleanup-testcv''","link":"/content_views/18/versions"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/26/edit"}]],"output":"","errors":[]},"cli_example":null,"start_at":"2024-07-09
+        14:30:24 UTC","available_actions":{"cancellable":false,"resumable":false}},"version":"4.0","publish":true,"version_id":45,"triggered_by":null,"triggered_by_id":null},"active_history":[],"ansible_collection_count":0,"docker_manifest_count":0,"docker_manifest_list_count":0,"docker_tag_count":0,"file_count":0,"rpm_count":0,"modulemd_count":0,"erratum_count":0,"package_group_count":0,"srpm_count":0,"module_stream_count":0,"package_count":0,"component_view_count":0,"ansible_collection_repository_count":0,"docker_repository_count":0,"file_repository_count":0,"yum_repository_count":0,"errata_counts":{"security":0,"bugfix":0,"enhancement":0,"total":0},"permissions":{"deletable":true},"filters_applied":false},{"version":"3.0","major":3,"minor":0,"composite_content_view_ids":[],"published_in_composite_content_view_ids":[],"content_view_id":18,"default":false,"description":null,"id":44,"name":"cleanup-testcv
+        3.0","created_at":"2024-07-09 14:30:18 UTC","updated_at":"2024-07-09 14:30:18
+        UTC","content_view":{"id":18,"name":"cleanup-testcv","label":"cleanup-testcv","generated_for":"none"},"composite_content_views":[],"composite_content_view_versions":[],"published_in_composite_content_views":[],"environments":[],"repositories":[],"last_event":{"user":"admin","status":"successful","description":null,"action":"publish","created_at":"2024-07-09
+        14:30:18 UTC","updated_at":"2024-07-09 14:30:18 UTC","environment":null,"task":{"id":"ed9ca23c-1f5e-42b1-9553-b9c729892a63","label":"Actions::Katello::ContentView::Publish","pending":false,"action":"Publish
+        content view ''cleanup-testcv''; organization ''Test Organization''","username":"admin","started_at":"2024-07-09
+        14:30:18 UTC","ended_at":"2024-07-09 14:30:18 UTC","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":18,"name":"cleanup-testcv","label":"cleanup-testcv"},"organization":{"id":26,"name":"Test
+        Organization","label":"Test_Organization"},"services_checked":["candlepin","candlepin_auth"],"history_id":68,"content_view_id":18,"auto_publish_composite_ids":[],"content_view_version_name":"cleanup-testcv
+        3.0","content_view_version_id":44,"environment_id":15,"user_id":4,"skip_promotion":null,"current_request_id":"9220a1fe-1b71-4192-b645-7711e3f1a41b","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{"content_view_id":18,"content_view_version_id":44,"skip_promotion":null,"history_id":68},"humanized":{"action":"Publish","input":[["content_view",{"text":"content
+        view ''cleanup-testcv''","link":"/content_views/18/versions"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/26/edit"}]],"output":"","errors":[]},"cli_example":null,"start_at":"2024-07-09
+        14:30:18 UTC","available_actions":{"cancellable":false,"resumable":false}},"version":"3.0","publish":true,"version_id":44,"triggered_by":null,"triggered_by_id":null},"active_history":[],"ansible_collection_count":0,"docker_manifest_count":0,"docker_manifest_list_count":0,"docker_tag_count":0,"file_count":0,"rpm_count":0,"modulemd_count":0,"erratum_count":0,"package_group_count":0,"srpm_count":0,"module_stream_count":0,"package_count":0,"component_view_count":0,"ansible_collection_repository_count":0,"docker_repository_count":0,"file_repository_count":0,"yum_repository_count":0,"errata_counts":{"security":0,"bugfix":0,"enhancement":0,"total":0},"permissions":{"deletable":true},"filters_applied":false}]}
 
         '
     headers:
@@ -173,6 +165,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '8706'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -184,15 +178,13 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 7; Test Organization
+      - 26; Test Organization
       Foreman_version:
-      - 2.5.0
+      - 3.12.0-develop
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -203,8 +195,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '8181'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/content_view_version_cleanup_role-11.yml
+++ b/tests/test_playbooks/fixtures/content_view_version_cleanup_role-11.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"2.5.0","api_version":2}'
+      string: '{"satellite_version":"6.16.0","result":"ok","status":200,"version":"3.12.0-develop","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '100'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.5.0
+      - 3.12.0-develop
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -50,8 +50,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '62'
     status:
       code: 200
       message: OK
@@ -70,17 +68,18 @@ interactions:
     uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
-        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\"\
-        :\"Test_Organization\",\"created_at\":\"2021-06-29 08:33:23 UTC\",\"updated_at\"\
-        :\"2021-06-29 08:33:25 UTC\",\"id\":7,\"name\":\"Test Organization\",\"title\"\
-        :\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+        4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2024-07-09
+        14:29:57 UTC\",\"updated_at\":\"2024-07-09 14:29:59 UTC\",\"id\":26,\"name\":\"Test
+        Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '389'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -94,13 +93,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.5.0
+      - 3.12.0-develop
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -111,8 +108,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '388'
     status:
       code: 200
       message: OK
@@ -128,17 +123,18 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/7/content_views?search=name%3D%22cleanup-testcv%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/26/content_views?search=name%3D%22cleanup-testcv%22&per_page=4294967296
   response:
     body:
-      string: '{"total":3,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"cleanup-testcv\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":3,"latest_version":"5.0","latest_version_id":21,"auto_publish":false,"solve_dependencies":false,"import_only":false,"repository_ids":[],"id":9,"name":"cleanup-testcv","label":"cleanup-testcv","description":null,"organization_id":7,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":7},"created_at":"2021-06-29
-        08:33:27 UTC","updated_at":"2021-06-29 08:33:54 UTC","last_task":{"id":"d23c2127-d267-416e-87bd-3d856a80fdd2","result":"successful","last_sync_words":"1
-        minute"},"latest_version_environments":[{"id":6,"name":"Library","label":"Library"}],"environments":[{"id":6,"name":"Library","label":"Library","permissions":{"readable":true}}],"repositories":[],"versions":[{"id":19,"version":"3.0","published":"2021-06-29
-        08:33:43 UTC","environment_ids":[]},{"id":20,"version":"4.0","published":"2021-06-29
-        08:33:48 UTC","environment_ids":[]},{"id":21,"version":"5.0","published":"2021-06-29
-        08:33:54 UTC","environment_ids":[6]}],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"6.0","last_published":"2021-06-29
-        08:33:54 UTC","permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
+      string: '{"total":3,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"cleanup-testcv\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"duplicate_repositories_to_publish":[],"default":false,"version_count":3,"latest_version":"5.0","latest_version_id":46,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":1,"related_composite_cvs":[{"id":19,"name":"cleanup-testccv"}],"filtered":false,"repository_ids":[],"id":18,"name":"cleanup-testcv","label":"cleanup-testcv","description":null,"organization_id":26,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":26},"created_at":"2024-07-09
+        14:30:00 UTC","updated_at":"2024-07-09 14:30:29 UTC","last_task":{"id":"6da31077-1ece-4449-882a-4057308558e4","started_at":"2024-07-09
+        14:30:29 UTC","result":"success","last_sync_words":"1 minute"},"latest_version_environments":[{"id":15,"name":"Library","label":"Library"}],"repositories":[],"versions":[{"id":46,"version":"5.0","published":"2024-07-09
+        14:30:29 UTC","description":null,"environment_ids":[15],"filters_applied":false,"published_at_words":"1
+        minute"},{"id":45,"version":"4.0","published":"2024-07-09 14:30:24 UTC","description":null,"environment_ids":[],"filters_applied":false,"published_at_words":"1
+        minute"},{"id":44,"version":"3.0","published":"2024-07-09 14:30:18 UTC","description":null,"environment_ids":[],"filters_applied":false,"published_at_words":"1
+        minute"}],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"6.0","last_published":"2024-07-09
+        14:30:29 UTC","environments":[{"id":15,"label":"Library","name":"Library","activation_keys":[],"hosts":[],"permissions":{"readable":true}}]}]}
 
         '
     headers:
@@ -146,6 +142,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1793'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -157,15 +155,13 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 7; Test Organization
+      - 26; Test Organization
       Foreman_version:
-      - 2.5.0
+      - 3.12.0-develop
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -176,8 +172,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '1483'
     status:
       code: 200
       message: OK
@@ -193,21 +187,20 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_view_versions?search=content_view_id%3D9%2Cversion%3D4.0&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_view_versions?search=content_view_id%3D18%2Cversion%3D4.0&per_page=4294967296
   response:
     body:
-      string: '{"total":7,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"content_view_id=9,version=4.0","sort":{"by":"version","order":"desc"},"results":[{"version":"4.0","major":4,"minor":0,"composite_content_view_ids":[],"published_in_composite_content_view_ids":[],"content_view_id":9,"default":false,"description":null,"id":20,"name":"cleanup-testcv
-        4.0","created_at":"2021-06-29 08:33:48 UTC","updated_at":"2021-06-29 08:33:49
-        UTC","content_view":{"id":9,"name":"cleanup-testcv","label":"cleanup-testcv"},"composite_content_views":[],"composite_content_view_versions":[],"published_in_composite_content_views":[],"environments":[],"repositories":[],"last_event":{"user":"admin","status":"successful","description":null,"action":"publish","created_at":"2021-06-29
-        08:33:48 UTC","updated_at":"2021-06-29 08:33:49 UTC","environment":null,"task":{"id":"c970bcf1-8d24-4aee-bc57-ac1cd80dd29a","label":"Actions::Katello::ContentView::Publish","pending":false,"action":"Publish
-        content view ''cleanup-testcv''; organization ''Test Organization''","username":"admin","started_at":"2021-06-29
-        08:33:48 UTC","ended_at":"2021-06-29 08:33:49 UTC","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":9,"name":"cleanup-testcv","label":"cleanup-testcv"},"organization":{"id":7,"name":"Test
-        Organization","label":"Test_Organization"},"services_checked":["candlepin","candlepin_auth"],"history_id":19,"content_view_id":9,"auto_publish_composite_ids":[],"content_view_version_name":"cleanup-testcv
-        4.0","content_view_version_id":20,"environment_id":6,"user_id":4,"skip_promotion":null,"current_request_id":"05876deb-2d9f-480c-8c81-9e9cb09c4deb","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{"content_view_id":9,"content_view_version_id":20,"skip_promotion":null},"humanized":{"action":"Publish","input":[["content_view",{"text":"content
-        view ''cleanup-testcv''","link":"/content_views/9/versions"}],["organization",{"text":"organization
-        ''Test Organization''","link":"/organizations/7/edit"}]],"output":"","errors":[]},"cli_example":null,"start_at":"2021-06-29
-        08:33:48 UTC","available_actions":{"cancellable":false,"resumable":false}},"version":"4.0","publish":true,"version_id":20,"triggered_by":null,"triggered_by_id":null},"active_history":[],"ansible
-        collection_count":0,"deb_count":0,"docker_manifest_count":0,"docker_manifest_list_count":0,"docker_tag_count":0,"file_count":0,"rpm_count":0,"modulemd_count":0,"erratum_count":0,"package_group_count":0,"srpm_count":0,"module_stream_count":0,"package_count":0,"ostree_branch_count":null,"errata_counts":{"security":null,"bugfix":0,"enhancement":0,"total":null},"permissions":{"deletable":true}}]}
+      string: '{"total":6,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"content_view_id=18,version=4.0","sort":{"by":"version","order":"desc"},"results":[{"version":"4.0","major":4,"minor":0,"composite_content_view_ids":[],"published_in_composite_content_view_ids":[],"content_view_id":18,"default":false,"description":null,"id":45,"name":"cleanup-testcv
+        4.0","created_at":"2024-07-09 14:30:24 UTC","updated_at":"2024-07-09 14:30:24
+        UTC","content_view":{"id":18,"name":"cleanup-testcv","label":"cleanup-testcv","generated_for":"none"},"composite_content_views":[],"composite_content_view_versions":[],"published_in_composite_content_views":[],"environments":[],"repositories":[],"last_event":{"user":"admin","status":"successful","description":null,"action":"publish","created_at":"2024-07-09
+        14:30:24 UTC","updated_at":"2024-07-09 14:30:24 UTC","environment":null,"task":{"id":"3467c3a4-2d6d-4e03-89cb-d4c671a10bb0","label":"Actions::Katello::ContentView::Publish","pending":false,"action":"Publish
+        content view ''cleanup-testcv''; organization ''Test Organization''","username":"admin","started_at":"2024-07-09
+        14:30:24 UTC","ended_at":"2024-07-09 14:30:24 UTC","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":18,"name":"cleanup-testcv","label":"cleanup-testcv"},"organization":{"id":26,"name":"Test
+        Organization","label":"Test_Organization"},"services_checked":["candlepin","candlepin_auth"],"history_id":69,"content_view_id":18,"auto_publish_composite_ids":[],"content_view_version_name":"cleanup-testcv
+        4.0","content_view_version_id":45,"environment_id":15,"user_id":4,"skip_promotion":null,"current_request_id":"678d454c-a0d7-4e44-95f2-148e0e2fbe20","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{"content_view_id":18,"content_view_version_id":45,"skip_promotion":null,"history_id":69},"humanized":{"action":"Publish","input":[["content_view",{"text":"content
+        view ''cleanup-testcv''","link":"/content_views/18/versions"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/26/edit"}]],"output":"","errors":[]},"cli_example":null,"start_at":"2024-07-09
+        14:30:24 UTC","available_actions":{"cancellable":false,"resumable":false}},"version":"4.0","publish":true,"version_id":45,"triggered_by":null,"triggered_by_id":null},"active_history":[],"ansible_collection_count":0,"docker_manifest_count":0,"docker_manifest_list_count":0,"docker_tag_count":0,"file_count":0,"rpm_count":0,"modulemd_count":0,"erratum_count":0,"package_group_count":0,"srpm_count":0,"module_stream_count":0,"package_count":0,"component_view_count":0,"ansible_collection_repository_count":0,"docker_repository_count":0,"file_repository_count":0,"yum_repository_count":0,"errata_counts":{"security":0,"bugfix":0,"enhancement":0,"total":0},"permissions":{"deletable":true},"filters_applied":false}]}
 
         '
     headers:
@@ -215,6 +208,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '2920'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -228,13 +223,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.5.0
+      - 3.12.0-develop
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -245,8 +238,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '2735'
     status:
       code: 200
       message: OK
@@ -264,12 +255,12 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: DELETE
-    uri: https://foreman.example.org/katello/api/content_view_versions/20
+    uri: https://foreman.example.org/katello/api/content_view_versions/45
   response:
     body:
-      string: '  {"id":"53adea5b-d548-4220-aa8a-f2baa5ef662a","label":"Actions::Katello::ContentViewVersion::Destroy","pending":true,"action":"Destroy","username":"admin","started_at":"2021-06-29
-        08:35:07 UTC","ended_at":null,"state":"planned","result":"pending","progress":0.0,"input":{"id":20,"current_request_id":"7a6121ee-3564-4c5b-9c94-9c1413ec3726","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{},"humanized":{"action":"Destroy","input":"","output":"","errors":[]},"cli_example":null,"start_at":"2021-06-29
-        08:35:07 UTC","available_actions":{"cancellable":false,"resumable":false}}
+      string: '  {"id":"3a77af5a-682c-4680-9e4b-0f48f5d1dbf2","label":"Actions::Katello::ContentViewVersion::Destroy","pending":true,"action":"Destroy","username":"admin","started_at":"2024-07-09
+        14:31:45 UTC","ended_at":null,"state":"planned","result":"pending","progress":0.0,"input":{"id":45,"docker_cleanup":false,"current_request_id":"1a4839f2-f397-48c4-98bc-642963842749","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{},"humanized":{"action":"Destroy","input":"","output":"","errors":[]},"cli_example":null,"start_at":"2024-07-09
+        14:31:45 UTC","available_actions":{"cancellable":false,"resumable":false}}
 
         '
     headers:
@@ -290,7 +281,7 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.5.0
+      - 3.12.0-develop
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
@@ -322,17 +313,19 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/foreman_tasks/api/tasks/53adea5b-d548-4220-aa8a-f2baa5ef662a
+    uri: https://foreman.example.org/foreman_tasks/api/tasks/3a77af5a-682c-4680-9e4b-0f48f5d1dbf2
   response:
     body:
-      string: '{"id":"53adea5b-d548-4220-aa8a-f2baa5ef662a","label":"Actions::Katello::ContentViewVersion::Destroy","pending":false,"action":"Destroy","username":"admin","started_at":"2021-06-29
-        08:35:07 UTC","ended_at":"2021-06-29 08:35:07 UTC","state":"stopped","result":"success","progress":1.0,"input":{"id":20,"current_request_id":"7a6121ee-3564-4c5b-9c94-9c1413ec3726","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{},"humanized":{"action":"Destroy","input":"","output":"","errors":[]},"cli_example":null,"start_at":"2021-06-29
-        08:35:07 UTC","available_actions":{"cancellable":false,"resumable":false}}'
+      string: '{"id":"3a77af5a-682c-4680-9e4b-0f48f5d1dbf2","label":"Actions::Katello::ContentViewVersion::Destroy","pending":false,"action":"Destroy","username":"admin","started_at":"2024-07-09
+        14:31:45 UTC","ended_at":"2024-07-09 14:31:45 UTC","duration":"0.07719","state":"stopped","result":"success","progress":1.0,"input":{"id":45,"docker_cleanup":false,"current_request_id":"1a4839f2-f397-48c4-98bc-642963842749","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{},"humanized":{"action":"Destroy","input":"","output":"","errors":[]},"cli_example":null,"start_at":"2024-07-09
+        14:31:45 UTC","available_actions":{"cancellable":false,"resumable":false}}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '704'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -346,13 +339,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.5.0
+      - 3.12.0-develop
       Keep-Alive:
       - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -363,8 +354,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '660'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/content_view_version_cleanup_role-12.yml
+++ b/tests/test_playbooks/fixtures/content_view_version_cleanup_role-12.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"2.5.0","api_version":2}'
+      string: '{"satellite_version":"6.16.0","result":"ok","status":200,"version":"3.12.0-develop","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '100'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.5.0
+      - 3.12.0-develop
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -50,8 +50,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '62'
     status:
       code: 200
       message: OK
@@ -70,17 +68,18 @@ interactions:
     uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
-        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\"\
-        :\"Test_Organization\",\"created_at\":\"2021-06-29 08:33:23 UTC\",\"updated_at\"\
-        :\"2021-06-29 08:33:25 UTC\",\"id\":7,\"name\":\"Test Organization\",\"title\"\
-        :\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+        4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2024-07-09
+        14:29:57 UTC\",\"updated_at\":\"2024-07-09 14:29:59 UTC\",\"id\":26,\"name\":\"Test
+        Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '389'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -94,13 +93,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.5.0
+      - 3.12.0-develop
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -111,8 +108,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '388'
     status:
       code: 200
       message: OK
@@ -128,16 +123,17 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/7/content_views?search=name%3D%22cleanup-testcv%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/26/content_views?search=name%3D%22cleanup-testcv%22&per_page=4294967296
   response:
     body:
-      string: '{"total":3,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"cleanup-testcv\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":2,"latest_version":"5.0","latest_version_id":21,"auto_publish":false,"solve_dependencies":false,"import_only":false,"repository_ids":[],"id":9,"name":"cleanup-testcv","label":"cleanup-testcv","description":null,"organization_id":7,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":7},"created_at":"2021-06-29
-        08:33:27 UTC","updated_at":"2021-06-29 08:33:54 UTC","last_task":{"id":"d23c2127-d267-416e-87bd-3d856a80fdd2","result":"successful","last_sync_words":"1
-        minute"},"latest_version_environments":[{"id":6,"name":"Library","label":"Library"}],"environments":[{"id":6,"name":"Library","label":"Library","permissions":{"readable":true}}],"repositories":[],"versions":[{"id":19,"version":"3.0","published":"2021-06-29
-        08:33:43 UTC","environment_ids":[]},{"id":21,"version":"5.0","published":"2021-06-29
-        08:33:54 UTC","environment_ids":[6]}],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"6.0","last_published":"2021-06-29
-        08:33:54 UTC","permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
+      string: '{"total":3,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"cleanup-testcv\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"duplicate_repositories_to_publish":[],"default":false,"version_count":2,"latest_version":"5.0","latest_version_id":46,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":1,"related_composite_cvs":[{"id":19,"name":"cleanup-testccv"}],"filtered":false,"repository_ids":[],"id":18,"name":"cleanup-testcv","label":"cleanup-testcv","description":null,"organization_id":26,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":26},"created_at":"2024-07-09
+        14:30:00 UTC","updated_at":"2024-07-09 14:30:29 UTC","last_task":{"id":"6da31077-1ece-4449-882a-4057308558e4","started_at":"2024-07-09
+        14:30:29 UTC","result":"success","last_sync_words":"1 minute"},"latest_version_environments":[{"id":15,"name":"Library","label":"Library"}],"repositories":[],"versions":[{"id":46,"version":"5.0","published":"2024-07-09
+        14:30:29 UTC","description":null,"environment_ids":[15],"filters_applied":false,"published_at_words":"1
+        minute"},{"id":44,"version":"3.0","published":"2024-07-09 14:30:18 UTC","description":null,"environment_ids":[],"filters_applied":false,"published_at_words":"2
+        minutes"}],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"6.0","last_published":"2024-07-09
+        14:30:29 UTC","environments":[{"id":15,"label":"Library","name":"Library","activation_keys":[],"hosts":[],"permissions":{"readable":true}}]}]}
 
         '
     headers:
@@ -145,6 +141,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1634'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -156,15 +154,13 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 7; Test Organization
+      - 26; Test Organization
       Foreman_version:
-      - 2.5.0
+      - 3.12.0-develop
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -175,8 +171,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '1398'
     status:
       code: 200
       message: OK
@@ -192,21 +186,20 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_view_versions?search=content_view_id%3D9%2Cversion%3D3.0&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_view_versions?search=content_view_id%3D18%2Cversion%3D3.0&per_page=4294967296
   response:
     body:
-      string: '{"total":6,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"content_view_id=9,version=3.0","sort":{"by":"version","order":"desc"},"results":[{"version":"3.0","major":3,"minor":0,"composite_content_view_ids":[],"published_in_composite_content_view_ids":[],"content_view_id":9,"default":false,"description":null,"id":19,"name":"cleanup-testcv
-        3.0","created_at":"2021-06-29 08:33:43 UTC","updated_at":"2021-06-29 08:33:43
-        UTC","content_view":{"id":9,"name":"cleanup-testcv","label":"cleanup-testcv"},"composite_content_views":[],"composite_content_view_versions":[],"published_in_composite_content_views":[],"environments":[],"repositories":[],"last_event":{"user":"admin","status":"successful","description":null,"action":"publish","created_at":"2021-06-29
-        08:33:43 UTC","updated_at":"2021-06-29 08:33:43 UTC","environment":null,"task":{"id":"b7961aca-72f7-4491-a00a-c9e4b56d4ab6","label":"Actions::Katello::ContentView::Publish","pending":false,"action":"Publish
-        content view ''cleanup-testcv''; organization ''Test Organization''","username":"admin","started_at":"2021-06-29
-        08:33:43 UTC","ended_at":"2021-06-29 08:33:43 UTC","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":9,"name":"cleanup-testcv","label":"cleanup-testcv"},"organization":{"id":7,"name":"Test
-        Organization","label":"Test_Organization"},"services_checked":["candlepin","candlepin_auth"],"history_id":18,"content_view_id":9,"auto_publish_composite_ids":[],"content_view_version_name":"cleanup-testcv
-        3.0","content_view_version_id":19,"environment_id":6,"user_id":4,"skip_promotion":null,"current_request_id":"5a0f139b-237f-4ef2-854d-d92e9e1d6a50","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{"content_view_id":9,"content_view_version_id":19,"skip_promotion":null},"humanized":{"action":"Publish","input":[["content_view",{"text":"content
-        view ''cleanup-testcv''","link":"/content_views/9/versions"}],["organization",{"text":"organization
-        ''Test Organization''","link":"/organizations/7/edit"}]],"output":"","errors":[]},"cli_example":null,"start_at":"2021-06-29
-        08:33:43 UTC","available_actions":{"cancellable":false,"resumable":false}},"version":"3.0","publish":true,"version_id":19,"triggered_by":null,"triggered_by_id":null},"active_history":[],"ansible
-        collection_count":0,"deb_count":0,"docker_manifest_count":0,"docker_manifest_list_count":0,"docker_tag_count":0,"file_count":0,"rpm_count":0,"modulemd_count":0,"erratum_count":0,"package_group_count":0,"srpm_count":0,"module_stream_count":0,"package_count":0,"ostree_branch_count":null,"errata_counts":{"security":null,"bugfix":0,"enhancement":0,"total":null},"permissions":{"deletable":true}}]}
+      string: '{"total":5,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"content_view_id=18,version=3.0","sort":{"by":"version","order":"desc"},"results":[{"version":"3.0","major":3,"minor":0,"composite_content_view_ids":[],"published_in_composite_content_view_ids":[],"content_view_id":18,"default":false,"description":null,"id":44,"name":"cleanup-testcv
+        3.0","created_at":"2024-07-09 14:30:18 UTC","updated_at":"2024-07-09 14:30:18
+        UTC","content_view":{"id":18,"name":"cleanup-testcv","label":"cleanup-testcv","generated_for":"none"},"composite_content_views":[],"composite_content_view_versions":[],"published_in_composite_content_views":[],"environments":[],"repositories":[],"last_event":{"user":"admin","status":"successful","description":null,"action":"publish","created_at":"2024-07-09
+        14:30:18 UTC","updated_at":"2024-07-09 14:30:18 UTC","environment":null,"task":{"id":"ed9ca23c-1f5e-42b1-9553-b9c729892a63","label":"Actions::Katello::ContentView::Publish","pending":false,"action":"Publish
+        content view ''cleanup-testcv''; organization ''Test Organization''","username":"admin","started_at":"2024-07-09
+        14:30:18 UTC","ended_at":"2024-07-09 14:30:18 UTC","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":18,"name":"cleanup-testcv","label":"cleanup-testcv"},"organization":{"id":26,"name":"Test
+        Organization","label":"Test_Organization"},"services_checked":["candlepin","candlepin_auth"],"history_id":68,"content_view_id":18,"auto_publish_composite_ids":[],"content_view_version_name":"cleanup-testcv
+        3.0","content_view_version_id":44,"environment_id":15,"user_id":4,"skip_promotion":null,"current_request_id":"9220a1fe-1b71-4192-b645-7711e3f1a41b","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{"content_view_id":18,"content_view_version_id":44,"skip_promotion":null,"history_id":68},"humanized":{"action":"Publish","input":[["content_view",{"text":"content
+        view ''cleanup-testcv''","link":"/content_views/18/versions"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/26/edit"}]],"output":"","errors":[]},"cli_example":null,"start_at":"2024-07-09
+        14:30:18 UTC","available_actions":{"cancellable":false,"resumable":false}},"version":"3.0","publish":true,"version_id":44,"triggered_by":null,"triggered_by_id":null},"active_history":[],"ansible_collection_count":0,"docker_manifest_count":0,"docker_manifest_list_count":0,"docker_tag_count":0,"file_count":0,"rpm_count":0,"modulemd_count":0,"erratum_count":0,"package_group_count":0,"srpm_count":0,"module_stream_count":0,"package_count":0,"component_view_count":0,"ansible_collection_repository_count":0,"docker_repository_count":0,"file_repository_count":0,"yum_repository_count":0,"errata_counts":{"security":0,"bugfix":0,"enhancement":0,"total":0},"permissions":{"deletable":true},"filters_applied":false}]}
 
         '
     headers:
@@ -214,6 +207,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '2920'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -227,13 +222,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.5.0
+      - 3.12.0-develop
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -244,8 +237,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '2735'
     status:
       code: 200
       message: OK
@@ -263,12 +254,12 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: DELETE
-    uri: https://foreman.example.org/katello/api/content_view_versions/19
+    uri: https://foreman.example.org/katello/api/content_view_versions/44
   response:
     body:
-      string: '  {"id":"7681d373-50bc-4c98-86c8-601c84cef16c","label":"Actions::Katello::ContentViewVersion::Destroy","pending":true,"action":"Destroy","username":"admin","started_at":"2021-06-29
-        08:35:12 UTC","ended_at":null,"state":"planned","result":"pending","progress":0.0,"input":{"id":19,"current_request_id":"287eb2f2-aefb-440c-acf5-0b084ed8c54d","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{},"humanized":{"action":"Destroy","input":"","output":"","errors":[]},"cli_example":null,"start_at":"2021-06-29
-        08:35:12 UTC","available_actions":{"cancellable":false,"resumable":false}}
+      string: '  {"id":"5f126427-9f97-47e4-a657-881c99cac9f6","label":"Actions::Katello::ContentViewVersion::Destroy","pending":true,"action":"Destroy","username":"admin","started_at":"2024-07-09
+        14:31:50 UTC","ended_at":null,"state":"planned","result":"pending","progress":0.0,"input":{"id":44,"docker_cleanup":false,"current_request_id":"2188584c-85ec-4d33-9cca-c2b8dbf5f845","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{},"humanized":{"action":"Destroy","input":"","output":"","errors":[]},"cli_example":null,"start_at":"2024-07-09
+        14:31:50 UTC","available_actions":{"cancellable":false,"resumable":false}}
 
         '
     headers:
@@ -289,7 +280,7 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.5.0
+      - 3.12.0-develop
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
@@ -321,17 +312,19 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/foreman_tasks/api/tasks/7681d373-50bc-4c98-86c8-601c84cef16c
+    uri: https://foreman.example.org/foreman_tasks/api/tasks/5f126427-9f97-47e4-a657-881c99cac9f6
   response:
     body:
-      string: '{"id":"7681d373-50bc-4c98-86c8-601c84cef16c","label":"Actions::Katello::ContentViewVersion::Destroy","pending":false,"action":"Destroy","username":"admin","started_at":"2021-06-29
-        08:35:12 UTC","ended_at":"2021-06-29 08:35:12 UTC","state":"stopped","result":"success","progress":1.0,"input":{"id":19,"current_request_id":"287eb2f2-aefb-440c-acf5-0b084ed8c54d","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{},"humanized":{"action":"Destroy","input":"","output":"","errors":[]},"cli_example":null,"start_at":"2021-06-29
-        08:35:12 UTC","available_actions":{"cancellable":false,"resumable":false}}'
+      string: '{"id":"5f126427-9f97-47e4-a657-881c99cac9f6","label":"Actions::Katello::ContentViewVersion::Destroy","pending":false,"action":"Destroy","username":"admin","started_at":"2024-07-09
+        14:31:50 UTC","ended_at":"2024-07-09 14:31:50 UTC","duration":"0.075128","state":"stopped","result":"success","progress":1.0,"input":{"id":44,"docker_cleanup":false,"current_request_id":"2188584c-85ec-4d33-9cca-c2b8dbf5f845","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{},"humanized":{"action":"Destroy","input":"","output":"","errors":[]},"cli_example":null,"start_at":"2024-07-09
+        14:31:50 UTC","available_actions":{"cancellable":false,"resumable":false}}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '705'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -345,13 +338,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.5.0
+      - 3.12.0-develop
       Keep-Alive:
       - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -362,8 +353,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '660'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/content_view_version_cleanup_role-13.yml
+++ b/tests/test_playbooks/fixtures/content_view_version_cleanup_role-13.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"2.5.0","api_version":2}'
+      string: '{"satellite_version":"6.16.0","result":"ok","status":200,"version":"3.12.0-develop","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '100'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.5.0
+      - 3.12.0-develop
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -50,8 +50,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '62'
     status:
       code: 200
       message: OK
@@ -70,17 +68,18 @@ interactions:
     uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
-        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\"\
-        :\"Test_Organization\",\"created_at\":\"2021-06-29 08:33:23 UTC\",\"updated_at\"\
-        :\"2021-06-29 08:33:25 UTC\",\"id\":7,\"name\":\"Test Organization\",\"title\"\
-        :\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+        4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2024-07-09
+        14:29:57 UTC\",\"updated_at\":\"2024-07-09 14:29:59 UTC\",\"id\":26,\"name\":\"Test
+        Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '389'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -94,13 +93,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.5.0
+      - 3.12.0-develop
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -111,8 +108,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '388'
     status:
       code: 200
       message: OK
@@ -128,24 +123,26 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/7/content_views?search=name+~+cleanup&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/26/content_views?search=name+~+cleanup&per_page=4294967296
   response:
     body:
-      string: '{"total":3,"subtotal":2,"page":1,"per_page":"4294967296","error":null,"search":"name
-        ~ cleanup","sort":{"by":"name","order":"asc"},"results":[{"composite":true,"component_ids":[21],"default":false,"version_count":1,"latest_version":"5.0","latest_version_id":26,"auto_publish":false,"solve_dependencies":false,"import_only":false,"repository_ids":[],"id":10,"name":"cleanup-testccv","label":"cleanup-testccv","description":null,"organization_id":7,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":7},"created_at":"2021-06-29
-        08:33:29 UTC","updated_at":"2021-06-29 08:34:22 UTC","last_task":{"id":"23e7eca9-3adb-48a2-9778-a4f4e6db4435","result":"successful","last_sync_words":"1
-        minute"},"latest_version_environments":[{"id":6,"name":"Library","label":"Library"}],"environments":[{"id":6,"name":"Library","label":"Library","permissions":{"readable":true}}],"repositories":[],"versions":[{"id":26,"version":"5.0","published":"2021-06-29
-        08:34:22 UTC","environment_ids":[6]}],"components":[{"id":21,"name":"cleanup-testcv
-        5.0","content_view_id":9,"version":"5.0","environments":[{"id":6,"name":"Library","label":"Library"}],"content_view":{"id":9,"name":"cleanup-testcv","label":"cleanup-testcv","description":null,"next_version":6,"latest_version":"5.0"},"repositories":[]}],"content_view_components":[{"latest":true,"id":2,"created_at":"2021-06-29
-        08:33:29 UTC","updated_at":"2021-06-29 08:33:29 UTC","composite_content_view":{"id":10,"name":"cleanup-testccv","label":"cleanup-testccv","description":null,"next_version":6,"latest_version":"5.0","version_count":1},"content_view":{"id":9,"name":"cleanup-testcv","label":"cleanup-testcv","description":null,"next_version":6,"latest_version":"5.0","version_count":1},"content_view_version":{"id":21,"name":"cleanup-testcv
-        5.0","content_view_id":9,"version":"5.0","content_view":{"id":9,"name":"cleanup-testcv","label":"cleanup-testcv","description":null},"environments":[{"id":6,"name":"Library","label":"Library"}],"repositories":[]}}],"activation_keys":[],"hosts":[],"next_version":"6.0","last_published":"2021-06-29
-        08:34:22 UTC","permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}},{"composite":false,"component_ids":[],"default":false,"version_count":1,"latest_version":"5.0","latest_version_id":21,"auto_publish":false,"solve_dependencies":false,"import_only":false,"repository_ids":[],"id":9,"name":"cleanup-testcv","label":"cleanup-testcv","description":null,"organization_id":7,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":7},"created_at":"2021-06-29
-        08:33:27 UTC","updated_at":"2021-06-29 08:33:54 UTC","last_task":{"id":"d23c2127-d267-416e-87bd-3d856a80fdd2","result":"successful","last_sync_words":"1
-        minute"},"latest_version_environments":[{"id":6,"name":"Library","label":"Library"}],"environments":[{"id":6,"name":"Library","label":"Library","permissions":{"readable":true}}],"repositories":[],"versions":[{"id":21,"version":"5.0","published":"2021-06-29
-        08:33:54 UTC","environment_ids":[6]}],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"6.0","last_published":"2021-06-29
-        08:33:54 UTC","permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
+      string: '{"total":3,"subtotal":2,"selectable":2,"page":1,"per_page":"4294967296","error":null,"search":"name
+        ~ cleanup","sort":{"by":"name","order":"asc"},"results":[{"composite":true,"component_ids":[46],"duplicate_repositories_to_publish":[],"default":false,"version_count":1,"latest_version":"5.0","latest_version_id":51,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":1,"related_composite_cvs":[],"filtered":false,"repository_ids":[],"id":19,"name":"cleanup-testccv","label":"cleanup-testccv","description":null,"organization_id":26,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":26},"created_at":"2024-07-09
+        14:30:02 UTC","updated_at":"2024-07-09 14:30:58 UTC","last_task":{"id":"aec3029e-8c8f-4ae7-bba9-cb504e1b4d0e","started_at":"2024-07-09
+        14:30:58 UTC","result":"success","last_sync_words":"1 minute"},"latest_version_environments":[{"id":15,"name":"Library","label":"Library"}],"repositories":[],"versions":[{"id":51,"version":"5.0","published":"2024-07-09
+        14:30:58 UTC","description":null,"environment_ids":[15],"filters_applied":false,"published_at_words":"1
+        minute"}],"components":[{"id":46,"name":"cleanup-testcv 5.0","content_view_id":18,"version":"5.0","environments":[{"id":15,"name":"Library","label":"Library"}],"content_view":{"id":18,"name":"cleanup-testcv","label":"cleanup-testcv","description":null,"next_version":6,"latest_version":"5.0"},"repositories":[]}],"content_view_components":[{"latest":true,"id":2,"created_at":"2024-07-09
+        14:30:03 UTC","updated_at":"2024-07-09 14:30:03 UTC","composite_content_view":{"id":19,"name":"cleanup-testccv","label":"cleanup-testccv","description":null,"next_version":6,"latest_version":"5.0","version_count":1},"content_view":{"id":18,"name":"cleanup-testcv","label":"cleanup-testcv","description":null,"next_version":6,"latest_version":"5.0","version_count":1},"content_view_version":{"id":46,"name":"cleanup-testcv
+        5.0","content_view_id":18,"version":"5.0","content_view":{"id":18,"name":"cleanup-testcv","label":"cleanup-testcv","description":null},"environments":[{"id":15,"name":"Library","label":"Library"}],"repositories":[]},"component_content_view_versions":[{"id":46,"version":"5.0","description":null,"published_at_words":"1
+        minute"}]}],"activation_keys":[],"hosts":[],"next_version":"6.0","last_published":"2024-07-09
+        14:30:58 UTC","environments":[{"id":15,"label":"Library","name":"Library","activation_keys":[],"hosts":[],"permissions":{"readable":true}}]},{"composite":false,"component_ids":[],"duplicate_repositories_to_publish":[],"default":false,"version_count":1,"latest_version":"5.0","latest_version_id":46,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":1,"related_composite_cvs":[{"id":19,"name":"cleanup-testccv"}],"filtered":false,"repository_ids":[],"id":18,"name":"cleanup-testcv","label":"cleanup-testcv","description":null,"organization_id":26,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":26},"created_at":"2024-07-09
+        14:30:00 UTC","updated_at":"2024-07-09 14:30:29 UTC","last_task":{"id":"6da31077-1ece-4449-882a-4057308558e4","started_at":"2024-07-09
+        14:30:29 UTC","result":"success","last_sync_words":"1 minute"},"latest_version_environments":[{"id":15,"name":"Library","label":"Library"}],"repositories":[],"versions":[{"id":46,"version":"5.0","published":"2024-07-09
+        14:30:29 UTC","description":null,"environment_ids":[15],"filters_applied":false,"published_at_words":"1
+        minute"}],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"6.0","last_published":"2024-07-09
+        14:30:29 UTC","environments":[{"id":15,"label":"Library","name":"Library","activation_keys":[],"hosts":[],"permissions":{"readable":true}}]}]}
 
         '
     headers:
@@ -153,6 +150,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '3823'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -164,15 +163,13 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 7; Test Organization
+      - 26; Test Organization
       Foreman_version:
-      - 2.5.0
+      - 3.12.0-develop
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -183,8 +180,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '3433'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/content_view_version_cleanup_role-2.yml
+++ b/tests/test_playbooks/fixtures/content_view_version_cleanup_role-2.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"2.5.0","api_version":2}'
+      string: '{"satellite_version":"6.16.0","result":"ok","status":200,"version":"3.12.0-develop","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '100'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.5.0
+      - 3.12.0-develop
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -50,8 +50,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '62'
     status:
       code: 200
       message: OK
@@ -70,17 +68,18 @@ interactions:
     uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
-        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\"\
-        :\"Test_Organization\",\"created_at\":\"2021-06-29 08:33:23 UTC\",\"updated_at\"\
-        :\"2021-06-29 08:33:25 UTC\",\"id\":7,\"name\":\"Test Organization\",\"title\"\
-        :\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+        4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2024-07-09
+        14:29:57 UTC\",\"updated_at\":\"2024-07-09 14:29:59 UTC\",\"id\":26,\"name\":\"Test
+        Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '389'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -94,13 +93,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.5.0
+      - 3.12.0-develop
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -111,8 +108,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '388'
     status:
       code: 200
       message: OK
@@ -128,21 +123,29 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/7/content_views?search=name%3D%22cleanup-testccv%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/26/content_views?search=name%3D%22cleanup-testccv%22&per_page=4294967296
   response:
     body:
-      string: '{"total":3,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"cleanup-testccv\"","sort":{"by":"name","order":"asc"},"results":[{"composite":true,"component_ids":[21],"default":false,"version_count":4,"latest_version":"5.0","latest_version_id":26,"auto_publish":false,"solve_dependencies":false,"import_only":false,"repository_ids":[],"id":10,"name":"cleanup-testccv","label":"cleanup-testccv","description":null,"organization_id":7,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":7},"created_at":"2021-06-29
-        08:33:29 UTC","updated_at":"2021-06-29 08:34:22 UTC","last_task":{"id":"23e7eca9-3adb-48a2-9778-a4f4e6db4435","result":"successful","last_sync_words":"less
-        than a minute"},"latest_version_environments":[{"id":6,"name":"Library","label":"Library"}],"environments":[{"id":6,"name":"Library","label":"Library","permissions":{"readable":true}}],"repositories":[],"versions":[{"id":22,"version":"1.0","published":"2021-06-29
-        08:34:00 UTC","environment_ids":[]},{"id":24,"version":"3.0","published":"2021-06-29
-        08:34:11 UTC","environment_ids":[]},{"id":25,"version":"4.0","published":"2021-06-29
-        08:34:16 UTC","environment_ids":[]},{"id":26,"version":"5.0","published":"2021-06-29
-        08:34:22 UTC","environment_ids":[6]}],"components":[{"id":21,"name":"cleanup-testcv
-        5.0","content_view_id":9,"version":"5.0","environments":[{"id":6,"name":"Library","label":"Library"}],"content_view":{"id":9,"name":"cleanup-testcv","label":"cleanup-testcv","description":null,"next_version":6,"latest_version":"5.0"},"repositories":[]}],"content_view_components":[{"latest":true,"id":2,"created_at":"2021-06-29
-        08:33:29 UTC","updated_at":"2021-06-29 08:33:29 UTC","composite_content_view":{"id":10,"name":"cleanup-testccv","label":"cleanup-testccv","description":null,"next_version":6,"latest_version":"5.0","version_count":4},"content_view":{"id":9,"name":"cleanup-testcv","label":"cleanup-testcv","description":null,"next_version":6,"latest_version":"5.0","version_count":5},"content_view_version":{"id":21,"name":"cleanup-testcv
-        5.0","content_view_id":9,"version":"5.0","content_view":{"id":9,"name":"cleanup-testcv","label":"cleanup-testcv","description":null},"environments":[{"id":6,"name":"Library","label":"Library"}],"repositories":[]}}],"activation_keys":[],"hosts":[],"next_version":"6.0","last_published":"2021-06-29
-        08:34:22 UTC","permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
+      string: '{"total":3,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"cleanup-testccv\"","sort":{"by":"name","order":"asc"},"results":[{"composite":true,"component_ids":[46],"duplicate_repositories_to_publish":[],"default":false,"version_count":4,"latest_version":"5.0","latest_version_id":51,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":1,"related_composite_cvs":[],"filtered":false,"repository_ids":[],"id":19,"name":"cleanup-testccv","label":"cleanup-testccv","description":null,"organization_id":26,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":26},"created_at":"2024-07-09
+        14:30:02 UTC","updated_at":"2024-07-09 14:30:58 UTC","last_task":{"id":"aec3029e-8c8f-4ae7-bba9-cb504e1b4d0e","started_at":"2024-07-09
+        14:30:58 UTC","result":"success","last_sync_words":"less than a minute"},"latest_version_environments":[{"id":15,"name":"Library","label":"Library"}],"repositories":[],"versions":[{"id":51,"version":"5.0","published":"2024-07-09
+        14:30:58 UTC","description":null,"environment_ids":[15],"filters_applied":false,"published_at_words":"less
+        than a minute"},{"id":50,"version":"4.0","published":"2024-07-09 14:30:52
+        UTC","description":null,"environment_ids":[],"filters_applied":false,"published_at_words":"less
+        than a minute"},{"id":49,"version":"3.0","published":"2024-07-09 14:30:47
+        UTC","description":null,"environment_ids":[],"filters_applied":false,"published_at_words":"less
+        than a minute"},{"id":47,"version":"1.0","published":"2024-07-09 14:30:35
+        UTC","description":null,"environment_ids":[],"filters_applied":false,"published_at_words":"1
+        minute"}],"components":[{"id":46,"name":"cleanup-testcv 5.0","content_view_id":18,"version":"5.0","environments":[{"id":15,"name":"Library","label":"Library"}],"content_view":{"id":18,"name":"cleanup-testcv","label":"cleanup-testcv","description":null,"next_version":6,"latest_version":"5.0"},"repositories":[]}],"content_view_components":[{"latest":true,"id":2,"created_at":"2024-07-09
+        14:30:03 UTC","updated_at":"2024-07-09 14:30:03 UTC","composite_content_view":{"id":19,"name":"cleanup-testccv","label":"cleanup-testccv","description":null,"next_version":6,"latest_version":"5.0","version_count":4},"content_view":{"id":18,"name":"cleanup-testcv","label":"cleanup-testcv","description":null,"next_version":6,"latest_version":"5.0","version_count":5},"content_view_version":{"id":46,"name":"cleanup-testcv
+        5.0","content_view_id":18,"version":"5.0","content_view":{"id":18,"name":"cleanup-testcv","label":"cleanup-testcv","description":null},"environments":[{"id":15,"name":"Library","label":"Library"}],"repositories":[]},"component_content_view_versions":[{"id":46,"version":"5.0","description":null,"published_at_words":"1
+        minute"},{"id":45,"version":"4.0","description":null,"published_at_words":"1
+        minute"},{"id":44,"version":"3.0","description":null,"published_at_words":"1
+        minute"},{"id":43,"version":"2.0","description":null,"published_at_words":"1
+        minute"},{"id":42,"version":"1.0","description":null,"published_at_words":"1
+        minute"}]}],"activation_keys":[],"hosts":[],"next_version":"6.0","last_published":"2024-07-09
+        14:30:58 UTC","environments":[{"id":15,"label":"Library","name":"Library","activation_keys":[],"hosts":[],"permissions":{"readable":true}}]}]}
 
         '
     headers:
@@ -150,6 +153,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '3356'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -161,17 +166,13 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 7; Test Organization
+      - 26; Test Organization
       Foreman_version:
-      - 2.5.0
+      - 3.12.0-develop
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -182,8 +183,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '2548'
     status:
       code: 200
       message: OK
@@ -199,21 +198,20 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_view_versions?search=content_view_id%3D10%2Cversion%3D1.0&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_view_versions?search=content_view_id%3D19%2Cversion%3D1.0&per_page=4294967296
   response:
     body:
-      string: '{"total":12,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"content_view_id=10,version=1.0","sort":{"by":"version","order":"desc"},"results":[{"version":"1.0","major":1,"minor":0,"composite_content_view_ids":[],"published_in_composite_content_view_ids":[],"content_view_id":10,"default":false,"description":null,"id":22,"name":"cleanup-testccv
-        1.0","created_at":"2021-06-29 08:34:00 UTC","updated_at":"2021-06-29 08:34:00
-        UTC","content_view":{"id":10,"name":"cleanup-testccv","label":"cleanup-testccv"},"composite_content_views":[],"composite_content_view_versions":[],"published_in_composite_content_views":[],"environments":[],"repositories":[],"last_event":{"user":"admin","status":"successful","description":null,"action":"publish","created_at":"2021-06-29
-        08:34:00 UTC","updated_at":"2021-06-29 08:34:00 UTC","environment":null,"task":{"id":"cbb41869-b49c-4ff6-a744-a32f033b9775","label":"Actions::Katello::ContentView::Publish","pending":false,"action":"Publish
-        content view ''cleanup-testccv''; organization ''Test Organization''","username":"admin","started_at":"2021-06-29
-        08:34:00 UTC","ended_at":"2021-06-29 08:34:00 UTC","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":10,"name":"cleanup-testccv","label":"cleanup-testccv"},"organization":{"id":7,"name":"Test
-        Organization","label":"Test_Organization"},"services_checked":["candlepin","candlepin_auth"],"history_id":21,"content_view_id":10,"auto_publish_composite_ids":[],"content_view_version_name":"cleanup-testccv
-        1.0","content_view_version_id":22,"environment_id":6,"user_id":4,"skip_promotion":null,"current_request_id":"194da2c2-1075-4354-99fe-da28a6ac1a39","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{"content_view_id":10,"content_view_version_id":22,"skip_promotion":null},"humanized":{"action":"Publish","input":[["content_view",{"text":"content
-        view ''cleanup-testccv''","link":"/content_views/10/versions"}],["organization",{"text":"organization
-        ''Test Organization''","link":"/organizations/7/edit"}]],"output":"","errors":[]},"cli_example":null,"start_at":"2021-06-29
-        08:34:00 UTC","available_actions":{"cancellable":false,"resumable":false}},"version":"1.0","publish":true,"version_id":22,"triggered_by":null,"triggered_by_id":null},"active_history":[],"ansible
-        collection_count":0,"deb_count":0,"docker_manifest_count":0,"docker_manifest_list_count":0,"docker_tag_count":0,"file_count":0,"rpm_count":0,"modulemd_count":0,"erratum_count":0,"package_group_count":0,"srpm_count":0,"module_stream_count":0,"package_count":0,"ostree_branch_count":null,"errata_counts":{"security":null,"bugfix":0,"enhancement":0,"total":null},"permissions":{"deletable":true}}]}
+      string: '{"total":11,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"content_view_id=19,version=1.0","sort":{"by":"version","order":"desc"},"results":[{"version":"1.0","major":1,"minor":0,"composite_content_view_ids":[],"published_in_composite_content_view_ids":[],"content_view_id":19,"default":false,"description":null,"id":47,"name":"cleanup-testccv
+        1.0","created_at":"2024-07-09 14:30:35 UTC","updated_at":"2024-07-09 14:30:36
+        UTC","content_view":{"id":19,"name":"cleanup-testccv","label":"cleanup-testccv","generated_for":"none"},"composite_content_views":[],"composite_content_view_versions":[],"published_in_composite_content_views":[],"environments":[],"repositories":[],"last_event":{"user":"admin","status":"successful","description":null,"action":"publish","created_at":"2024-07-09
+        14:30:35 UTC","updated_at":"2024-07-09 14:30:36 UTC","environment":null,"task":{"id":"7a9b2100-7a88-45b0-886e-dd8108e89589","label":"Actions::Katello::ContentView::Publish","pending":false,"action":"Publish
+        content view ''cleanup-testccv''; organization ''Test Organization''","username":"admin","started_at":"2024-07-09
+        14:30:35 UTC","ended_at":"2024-07-09 14:30:36 UTC","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":19,"name":"cleanup-testccv","label":"cleanup-testccv"},"organization":{"id":26,"name":"Test
+        Organization","label":"Test_Organization"},"services_checked":["candlepin","candlepin_auth"],"history_id":71,"content_view_id":19,"auto_publish_composite_ids":[],"content_view_version_name":"cleanup-testccv
+        1.0","content_view_version_id":47,"environment_id":15,"user_id":4,"skip_promotion":null,"current_request_id":"13f27323-0c7d-48c2-9b82-a6033cce0a28","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{"content_view_id":19,"content_view_version_id":47,"skip_promotion":null,"history_id":71},"humanized":{"action":"Publish","input":[["content_view",{"text":"content
+        view ''cleanup-testccv''","link":"/content_views/19/versions"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/26/edit"}]],"output":"","errors":[]},"cli_example":null,"start_at":"2024-07-09
+        14:30:35 UTC","available_actions":{"cancellable":false,"resumable":false}},"version":"1.0","publish":true,"version_id":47,"triggered_by":null,"triggered_by_id":null},"active_history":[],"ansible_collection_count":0,"docker_manifest_count":0,"docker_manifest_list_count":0,"docker_tag_count":0,"file_count":0,"rpm_count":0,"modulemd_count":0,"erratum_count":0,"package_group_count":0,"srpm_count":0,"module_stream_count":0,"package_count":0,"component_view_count":1,"ansible_collection_repository_count":0,"docker_repository_count":0,"file_repository_count":0,"yum_repository_count":0,"errata_counts":{"security":0,"bugfix":0,"enhancement":0,"total":0},"permissions":{"deletable":true},"filters_applied":false}]}
 
         '
     headers:
@@ -221,6 +219,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '2929'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -234,13 +234,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.5.0
+      - 3.12.0-develop
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -251,8 +249,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '2751'
     status:
       code: 200
       message: OK
@@ -270,12 +266,12 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: DELETE
-    uri: https://foreman.example.org/katello/api/content_view_versions/22
+    uri: https://foreman.example.org/katello/api/content_view_versions/47
   response:
     body:
-      string: '  {"id":"ab38d1fd-5723-47fd-939b-e911279b90e3","label":"Actions::Katello::ContentViewVersion::Destroy","pending":true,"action":"Destroy","username":"admin","started_at":"2021-06-29
-        08:34:35 UTC","ended_at":null,"state":"planned","result":"pending","progress":0.0,"input":{"id":22,"current_request_id":"16666074-ce5f-4cb5-8649-0d275a4ed311","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{},"humanized":{"action":"Destroy","input":"","output":"","errors":[]},"cli_example":null,"start_at":"2021-06-29
-        08:34:35 UTC","available_actions":{"cancellable":false,"resumable":false}}
+      string: '  {"id":"697dbb39-07e7-43af-8089-31a3c672366c","label":"Actions::Katello::ContentViewVersion::Destroy","pending":true,"action":"Destroy","username":"admin","started_at":"2024-07-09
+        14:31:11 UTC","ended_at":null,"state":"planned","result":"pending","progress":0.0,"input":{"id":47,"docker_cleanup":false,"current_request_id":"f28ec6ea-7fad-4d6b-aed4-8143077cc38b","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{},"humanized":{"action":"Destroy","input":"","output":"","errors":[]},"cli_example":null,"start_at":"2024-07-09
+        14:31:11 UTC","available_actions":{"cancellable":false,"resumable":false}}
 
         '
     headers:
@@ -296,7 +292,7 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.5.0
+      - 3.12.0-develop
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
@@ -328,17 +324,19 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/foreman_tasks/api/tasks/ab38d1fd-5723-47fd-939b-e911279b90e3
+    uri: https://foreman.example.org/foreman_tasks/api/tasks/697dbb39-07e7-43af-8089-31a3c672366c
   response:
     body:
-      string: '{"id":"ab38d1fd-5723-47fd-939b-e911279b90e3","label":"Actions::Katello::ContentViewVersion::Destroy","pending":false,"action":"Destroy","username":"admin","started_at":"2021-06-29
-        08:34:35 UTC","ended_at":"2021-06-29 08:34:35 UTC","state":"stopped","result":"success","progress":1.0,"input":{"id":22,"current_request_id":"16666074-ce5f-4cb5-8649-0d275a4ed311","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{},"humanized":{"action":"Destroy","input":"","output":"","errors":[]},"cli_example":null,"start_at":"2021-06-29
-        08:34:35 UTC","available_actions":{"cancellable":false,"resumable":false}}'
+      string: '{"id":"697dbb39-07e7-43af-8089-31a3c672366c","label":"Actions::Katello::ContentViewVersion::Destroy","pending":false,"action":"Destroy","username":"admin","started_at":"2024-07-09
+        14:31:11 UTC","ended_at":"2024-07-09 14:31:11 UTC","duration":"0.082938","state":"stopped","result":"success","progress":1.0,"input":{"id":47,"docker_cleanup":false,"current_request_id":"f28ec6ea-7fad-4d6b-aed4-8143077cc38b","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{},"humanized":{"action":"Destroy","input":"","output":"","errors":[]},"cli_example":null,"start_at":"2024-07-09
+        14:31:11 UTC","available_actions":{"cancellable":false,"resumable":false}}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '705'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -352,13 +350,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.5.0
+      - 3.12.0-develop
       Keep-Alive:
       - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -369,8 +365,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '660'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/content_view_version_cleanup_role-3.yml
+++ b/tests/test_playbooks/fixtures/content_view_version_cleanup_role-3.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"2.5.0","api_version":2}'
+      string: '{"satellite_version":"6.16.0","result":"ok","status":200,"version":"3.12.0-develop","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '100'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.5.0
+      - 3.12.0-develop
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -50,8 +50,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '62'
     status:
       code: 200
       message: OK
@@ -70,17 +68,18 @@ interactions:
     uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
-        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\"\
-        :\"Test_Organization\",\"created_at\":\"2021-06-29 08:33:23 UTC\",\"updated_at\"\
-        :\"2021-06-29 08:33:25 UTC\",\"id\":7,\"name\":\"Test Organization\",\"title\"\
-        :\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+        4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2024-07-09
+        14:29:57 UTC\",\"updated_at\":\"2024-07-09 14:29:59 UTC\",\"id\":26,\"name\":\"Test
+        Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '389'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -94,13 +93,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.5.0
+      - 3.12.0-develop
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -111,8 +108,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '388'
     status:
       code: 200
       message: OK
@@ -128,66 +123,61 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/9/content_view_versions?organization_id=7&search=&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_views/18/content_view_versions?organization_id=26&per_page=4294967296
   response:
     body:
-      string: '{"total":5,"subtotal":5,"page":1,"per_page":"4294967296","error":null,"search":"","sort":{"by":"version","order":"desc"},"results":[{"version":"5.0","major":5,"minor":0,"composite_content_view_ids":[],"published_in_composite_content_view_ids":[10,10,10],"content_view_id":9,"default":false,"description":null,"id":21,"name":"cleanup-testcv
-        5.0","created_at":"2021-06-29 08:33:54 UTC","updated_at":"2021-06-29 08:33:54
-        UTC","content_view":{"id":9,"name":"cleanup-testcv","label":"cleanup-testcv"},"composite_content_views":[],"composite_content_view_versions":[{"id":24,"content_view_id":10,"version":"3.0"},{"id":25,"content_view_id":10,"version":"4.0"},{"id":26,"content_view_id":10,"version":"5.0"}],"published_in_composite_content_views":[{"id":10,"name":"cleanup-testccv","label":"cleanup-testccv"},{"id":10,"name":"cleanup-testccv","label":"cleanup-testccv"},{"id":10,"name":"cleanup-testccv","label":"cleanup-testccv"}],"environments":[{"id":6,"name":"Library","label":"Library","publish_date":"1
-        minute","permissions":{"readable":true,"promotable_or_removable":true,"all_hosts_editable":true,"all_keys_editable":true},"host_count":0,"activation_key_count":0}],"repositories":[],"last_event":{"user":"admin","status":"successful","description":null,"action":"publish","created_at":"2021-06-29
-        08:33:54 UTC","updated_at":"2021-06-29 08:33:54 UTC","environment":null,"task":{"id":"d23c2127-d267-416e-87bd-3d856a80fdd2","label":"Actions::Katello::ContentView::Publish","pending":false,"action":"Publish
-        content view ''cleanup-testcv''; organization ''Test Organization''","username":"admin","started_at":"2021-06-29
-        08:33:54 UTC","ended_at":"2021-06-29 08:33:54 UTC","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":9,"name":"cleanup-testcv","label":"cleanup-testcv"},"organization":{"id":7,"name":"Test
-        Organization","label":"Test_Organization"},"services_checked":["candlepin","candlepin_auth"],"history_id":20,"content_view_id":9,"auto_publish_composite_ids":[],"content_view_version_name":"cleanup-testcv
-        5.0","content_view_version_id":21,"environment_id":6,"user_id":4,"skip_promotion":null,"current_request_id":"45b52809-4914-42af-8014-890a6cd395ef","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{"content_view_id":9,"content_view_version_id":21,"skip_promotion":null},"humanized":{"action":"Publish","input":[["content_view",{"text":"content
-        view ''cleanup-testcv''","link":"/content_views/9/versions"}],["organization",{"text":"organization
-        ''Test Organization''","link":"/organizations/7/edit"}]],"output":"","errors":[]},"cli_example":null,"start_at":"2021-06-29
-        08:33:54 UTC","available_actions":{"cancellable":false,"resumable":false}},"version":"5.0","publish":true,"version_id":21,"triggered_by":null,"triggered_by_id":null},"active_history":[],"ansible
-        collection_count":0,"deb_count":0,"docker_manifest_count":0,"docker_manifest_list_count":0,"docker_tag_count":0,"file_count":0,"rpm_count":0,"modulemd_count":0,"erratum_count":0,"package_group_count":0,"srpm_count":0,"module_stream_count":0,"package_count":0,"ostree_branch_count":null,"errata_counts":{"security":null,"bugfix":0,"enhancement":0,"total":null},"permissions":{"deletable":true}},{"version":"4.0","major":4,"minor":0,"composite_content_view_ids":[],"published_in_composite_content_view_ids":[],"content_view_id":9,"default":false,"description":null,"id":20,"name":"cleanup-testcv
-        4.0","created_at":"2021-06-29 08:33:48 UTC","updated_at":"2021-06-29 08:33:49
-        UTC","content_view":{"id":9,"name":"cleanup-testcv","label":"cleanup-testcv"},"composite_content_views":[],"composite_content_view_versions":[],"published_in_composite_content_views":[],"environments":[],"repositories":[],"last_event":{"user":"admin","status":"successful","description":null,"action":"publish","created_at":"2021-06-29
-        08:33:48 UTC","updated_at":"2021-06-29 08:33:49 UTC","environment":null,"task":{"id":"c970bcf1-8d24-4aee-bc57-ac1cd80dd29a","label":"Actions::Katello::ContentView::Publish","pending":false,"action":"Publish
-        content view ''cleanup-testcv''; organization ''Test Organization''","username":"admin","started_at":"2021-06-29
-        08:33:48 UTC","ended_at":"2021-06-29 08:33:49 UTC","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":9,"name":"cleanup-testcv","label":"cleanup-testcv"},"organization":{"id":7,"name":"Test
-        Organization","label":"Test_Organization"},"services_checked":["candlepin","candlepin_auth"],"history_id":19,"content_view_id":9,"auto_publish_composite_ids":[],"content_view_version_name":"cleanup-testcv
-        4.0","content_view_version_id":20,"environment_id":6,"user_id":4,"skip_promotion":null,"current_request_id":"05876deb-2d9f-480c-8c81-9e9cb09c4deb","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{"content_view_id":9,"content_view_version_id":20,"skip_promotion":null},"humanized":{"action":"Publish","input":[["content_view",{"text":"content
-        view ''cleanup-testcv''","link":"/content_views/9/versions"}],["organization",{"text":"organization
-        ''Test Organization''","link":"/organizations/7/edit"}]],"output":"","errors":[]},"cli_example":null,"start_at":"2021-06-29
-        08:33:48 UTC","available_actions":{"cancellable":false,"resumable":false}},"version":"4.0","publish":true,"version_id":20,"triggered_by":null,"triggered_by_id":null},"active_history":[],"ansible
-        collection_count":0,"deb_count":0,"docker_manifest_count":0,"docker_manifest_list_count":0,"docker_tag_count":0,"file_count":0,"rpm_count":0,"modulemd_count":0,"erratum_count":0,"package_group_count":0,"srpm_count":0,"module_stream_count":0,"package_count":0,"ostree_branch_count":null,"errata_counts":{"security":null,"bugfix":0,"enhancement":0,"total":null},"permissions":{"deletable":true}},{"version":"3.0","major":3,"minor":0,"composite_content_view_ids":[],"published_in_composite_content_view_ids":[],"content_view_id":9,"default":false,"description":null,"id":19,"name":"cleanup-testcv
-        3.0","created_at":"2021-06-29 08:33:43 UTC","updated_at":"2021-06-29 08:33:43
-        UTC","content_view":{"id":9,"name":"cleanup-testcv","label":"cleanup-testcv"},"composite_content_views":[],"composite_content_view_versions":[],"published_in_composite_content_views":[],"environments":[],"repositories":[],"last_event":{"user":"admin","status":"successful","description":null,"action":"publish","created_at":"2021-06-29
-        08:33:43 UTC","updated_at":"2021-06-29 08:33:43 UTC","environment":null,"task":{"id":"b7961aca-72f7-4491-a00a-c9e4b56d4ab6","label":"Actions::Katello::ContentView::Publish","pending":false,"action":"Publish
-        content view ''cleanup-testcv''; organization ''Test Organization''","username":"admin","started_at":"2021-06-29
-        08:33:43 UTC","ended_at":"2021-06-29 08:33:43 UTC","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":9,"name":"cleanup-testcv","label":"cleanup-testcv"},"organization":{"id":7,"name":"Test
-        Organization","label":"Test_Organization"},"services_checked":["candlepin","candlepin_auth"],"history_id":18,"content_view_id":9,"auto_publish_composite_ids":[],"content_view_version_name":"cleanup-testcv
-        3.0","content_view_version_id":19,"environment_id":6,"user_id":4,"skip_promotion":null,"current_request_id":"5a0f139b-237f-4ef2-854d-d92e9e1d6a50","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{"content_view_id":9,"content_view_version_id":19,"skip_promotion":null},"humanized":{"action":"Publish","input":[["content_view",{"text":"content
-        view ''cleanup-testcv''","link":"/content_views/9/versions"}],["organization",{"text":"organization
-        ''Test Organization''","link":"/organizations/7/edit"}]],"output":"","errors":[]},"cli_example":null,"start_at":"2021-06-29
-        08:33:43 UTC","available_actions":{"cancellable":false,"resumable":false}},"version":"3.0","publish":true,"version_id":19,"triggered_by":null,"triggered_by_id":null},"active_history":[],"ansible
-        collection_count":0,"deb_count":0,"docker_manifest_count":0,"docker_manifest_list_count":0,"docker_tag_count":0,"file_count":0,"rpm_count":0,"modulemd_count":0,"erratum_count":0,"package_group_count":0,"srpm_count":0,"module_stream_count":0,"package_count":0,"ostree_branch_count":null,"errata_counts":{"security":null,"bugfix":0,"enhancement":0,"total":null},"permissions":{"deletable":true}},{"version":"2.0","major":2,"minor":0,"composite_content_view_ids":[],"published_in_composite_content_view_ids":[],"content_view_id":9,"default":false,"description":null,"id":18,"name":"cleanup-testcv
-        2.0","created_at":"2021-06-29 08:33:37 UTC","updated_at":"2021-06-29 08:33:37
-        UTC","content_view":{"id":9,"name":"cleanup-testcv","label":"cleanup-testcv"},"composite_content_views":[],"composite_content_view_versions":[],"published_in_composite_content_views":[],"environments":[],"repositories":[],"last_event":{"user":"admin","status":"successful","description":null,"action":"publish","created_at":"2021-06-29
-        08:33:37 UTC","updated_at":"2021-06-29 08:33:37 UTC","environment":null,"task":{"id":"e71b9c4c-5c93-48d6-b22f-1e90a256a8f1","label":"Actions::Katello::ContentView::Publish","pending":false,"action":"Publish
-        content view ''cleanup-testcv''; organization ''Test Organization''","username":"admin","started_at":"2021-06-29
-        08:33:37 UTC","ended_at":"2021-06-29 08:33:37 UTC","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":9,"name":"cleanup-testcv","label":"cleanup-testcv"},"organization":{"id":7,"name":"Test
-        Organization","label":"Test_Organization"},"services_checked":["candlepin","candlepin_auth"],"history_id":17,"content_view_id":9,"auto_publish_composite_ids":[],"content_view_version_name":"cleanup-testcv
-        2.0","content_view_version_id":18,"environment_id":6,"user_id":4,"skip_promotion":null,"current_request_id":"052eedfe-ddf1-40bc-98b6-2a47faaa2b8c","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{"content_view_id":9,"content_view_version_id":18,"skip_promotion":null},"humanized":{"action":"Publish","input":[["content_view",{"text":"content
-        view ''cleanup-testcv''","link":"/content_views/9/versions"}],["organization",{"text":"organization
-        ''Test Organization''","link":"/organizations/7/edit"}]],"output":"","errors":[]},"cli_example":null,"start_at":"2021-06-29
-        08:33:37 UTC","available_actions":{"cancellable":false,"resumable":false}},"version":"2.0","publish":true,"version_id":18,"triggered_by":null,"triggered_by_id":null},"active_history":[],"ansible
-        collection_count":0,"deb_count":0,"docker_manifest_count":0,"docker_manifest_list_count":0,"docker_tag_count":0,"file_count":0,"rpm_count":0,"modulemd_count":0,"erratum_count":0,"package_group_count":0,"srpm_count":0,"module_stream_count":0,"package_count":0,"ostree_branch_count":null,"errata_counts":{"security":null,"bugfix":0,"enhancement":0,"total":null},"permissions":{"deletable":true}},{"version":"1.0","major":1,"minor":0,"composite_content_view_ids":[],"published_in_composite_content_view_ids":[],"content_view_id":9,"default":false,"description":null,"id":17,"name":"cleanup-testcv
-        1.0","created_at":"2021-06-29 08:33:31 UTC","updated_at":"2021-06-29 08:33:32
-        UTC","content_view":{"id":9,"name":"cleanup-testcv","label":"cleanup-testcv"},"composite_content_views":[],"composite_content_view_versions":[],"published_in_composite_content_views":[],"environments":[],"repositories":[],"last_event":{"user":"admin","status":"successful","description":null,"action":"publish","created_at":"2021-06-29
-        08:33:31 UTC","updated_at":"2021-06-29 08:33:32 UTC","environment":null,"task":{"id":"733cfc56-ed25-4c92-908a-4da3f2207f77","label":"Actions::Katello::ContentView::Publish","pending":false,"action":"Publish
-        content view ''cleanup-testcv''; organization ''Test Organization''","username":"admin","started_at":"2021-06-29
-        08:33:31 UTC","ended_at":"2021-06-29 08:33:32 UTC","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":9,"name":"cleanup-testcv","label":"cleanup-testcv"},"organization":{"id":7,"name":"Test
-        Organization","label":"Test_Organization"},"services_checked":["candlepin","candlepin_auth"],"history_id":16,"content_view_id":9,"auto_publish_composite_ids":[],"content_view_version_name":"cleanup-testcv
-        1.0","content_view_version_id":17,"environment_id":6,"user_id":4,"skip_promotion":null,"current_request_id":"511dd06b-d232-4ee4-acf0-d8a7ba7159bd","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{"content_view_id":9,"content_view_version_id":17,"skip_promotion":null},"humanized":{"action":"Publish","input":[["content_view",{"text":"content
-        view ''cleanup-testcv''","link":"/content_views/9/versions"}],["organization",{"text":"organization
-        ''Test Organization''","link":"/organizations/7/edit"}]],"output":"","errors":[]},"cli_example":null,"start_at":"2021-06-29
-        08:33:31 UTC","available_actions":{"cancellable":false,"resumable":false}},"version":"1.0","publish":true,"version_id":17,"triggered_by":null,"triggered_by_id":null},"active_history":[],"ansible
-        collection_count":0,"deb_count":0,"docker_manifest_count":0,"docker_manifest_list_count":0,"docker_tag_count":0,"file_count":0,"rpm_count":0,"modulemd_count":0,"erratum_count":0,"package_group_count":0,"srpm_count":0,"module_stream_count":0,"package_count":0,"ostree_branch_count":null,"errata_counts":{"security":null,"bugfix":0,"enhancement":0,"total":null},"permissions":{"deletable":true}}]}
+      string: '{"total":5,"subtotal":5,"selectable":5,"page":1,"per_page":"4294967296","error":null,"search":null,"sort":{"by":"version","order":"desc"},"results":[{"version":"5.0","major":5,"minor":0,"composite_content_view_ids":[],"published_in_composite_content_view_ids":[19,19,19],"content_view_id":18,"default":false,"description":null,"id":46,"name":"cleanup-testcv
+        5.0","created_at":"2024-07-09 14:30:29 UTC","updated_at":"2024-07-09 14:30:30
+        UTC","content_view":{"id":18,"name":"cleanup-testcv","label":"cleanup-testcv","generated_for":"none"},"composite_content_views":[],"composite_content_view_versions":[{"id":49,"content_view_id":19,"version":"3.0"},{"id":50,"content_view_id":19,"version":"4.0"},{"id":51,"content_view_id":19,"version":"5.0"}],"published_in_composite_content_views":[{"id":19,"name":"cleanup-testccv","label":"cleanup-testccv"},{"id":19,"name":"cleanup-testccv","label":"cleanup-testccv"},{"id":19,"name":"cleanup-testccv","label":"cleanup-testccv"}],"environments":[{"id":15,"name":"Library","label":"Library","publish_date":"1
+        minute","permissions":{"readable":true,"promotable_or_removable":true,"all_hosts_editable":true,"all_keys_editable":true},"host_count":0,"activation_key_count":0}],"repositories":[],"last_event":{"user":"admin","status":"successful","description":null,"action":"publish","created_at":"2024-07-09
+        14:30:29 UTC","updated_at":"2024-07-09 14:30:30 UTC","environment":null,"task":{"id":"6da31077-1ece-4449-882a-4057308558e4","label":"Actions::Katello::ContentView::Publish","pending":false,"action":"Publish
+        content view ''cleanup-testcv''; organization ''Test Organization''","username":"admin","started_at":"2024-07-09
+        14:30:29 UTC","ended_at":"2024-07-09 14:30:30 UTC","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":18,"name":"cleanup-testcv","label":"cleanup-testcv"},"organization":{"id":26,"name":"Test
+        Organization","label":"Test_Organization"},"services_checked":["candlepin","candlepin_auth"],"history_id":70,"content_view_id":18,"auto_publish_composite_ids":[],"content_view_version_name":"cleanup-testcv
+        5.0","content_view_version_id":46,"environment_id":15,"user_id":4,"skip_promotion":null,"current_request_id":"184f0380-81b1-439e-8f68-eda7128e7fbf","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{"content_view_id":18,"content_view_version_id":46,"skip_promotion":null,"history_id":70},"humanized":{"action":"Publish","input":[["content_view",{"text":"content
+        view ''cleanup-testcv''","link":"/content_views/18/versions"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/26/edit"}]],"output":"","errors":[]},"cli_example":null,"start_at":"2024-07-09
+        14:30:29 UTC","available_actions":{"cancellable":false,"resumable":false}},"version":"5.0","publish":true,"version_id":46,"triggered_by":null,"triggered_by_id":null},"active_history":[],"ansible_collection_count":0,"docker_manifest_count":0,"docker_manifest_list_count":0,"docker_tag_count":0,"file_count":0,"rpm_count":0,"modulemd_count":0,"erratum_count":0,"package_group_count":0,"srpm_count":0,"module_stream_count":0,"package_count":0,"component_view_count":0,"ansible_collection_repository_count":0,"docker_repository_count":0,"file_repository_count":0,"yum_repository_count":0,"errata_counts":{"security":0,"bugfix":0,"enhancement":0,"total":0},"permissions":{"deletable":true},"filters_applied":false},{"version":"4.0","major":4,"minor":0,"composite_content_view_ids":[],"published_in_composite_content_view_ids":[],"content_view_id":18,"default":false,"description":null,"id":45,"name":"cleanup-testcv
+        4.0","created_at":"2024-07-09 14:30:24 UTC","updated_at":"2024-07-09 14:30:24
+        UTC","content_view":{"id":18,"name":"cleanup-testcv","label":"cleanup-testcv","generated_for":"none"},"composite_content_views":[],"composite_content_view_versions":[],"published_in_composite_content_views":[],"environments":[],"repositories":[],"last_event":{"user":"admin","status":"successful","description":null,"action":"publish","created_at":"2024-07-09
+        14:30:24 UTC","updated_at":"2024-07-09 14:30:24 UTC","environment":null,"task":{"id":"3467c3a4-2d6d-4e03-89cb-d4c671a10bb0","label":"Actions::Katello::ContentView::Publish","pending":false,"action":"Publish
+        content view ''cleanup-testcv''; organization ''Test Organization''","username":"admin","started_at":"2024-07-09
+        14:30:24 UTC","ended_at":"2024-07-09 14:30:24 UTC","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":18,"name":"cleanup-testcv","label":"cleanup-testcv"},"organization":{"id":26,"name":"Test
+        Organization","label":"Test_Organization"},"services_checked":["candlepin","candlepin_auth"],"history_id":69,"content_view_id":18,"auto_publish_composite_ids":[],"content_view_version_name":"cleanup-testcv
+        4.0","content_view_version_id":45,"environment_id":15,"user_id":4,"skip_promotion":null,"current_request_id":"678d454c-a0d7-4e44-95f2-148e0e2fbe20","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{"content_view_id":18,"content_view_version_id":45,"skip_promotion":null,"history_id":69},"humanized":{"action":"Publish","input":[["content_view",{"text":"content
+        view ''cleanup-testcv''","link":"/content_views/18/versions"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/26/edit"}]],"output":"","errors":[]},"cli_example":null,"start_at":"2024-07-09
+        14:30:24 UTC","available_actions":{"cancellable":false,"resumable":false}},"version":"4.0","publish":true,"version_id":45,"triggered_by":null,"triggered_by_id":null},"active_history":[],"ansible_collection_count":0,"docker_manifest_count":0,"docker_manifest_list_count":0,"docker_tag_count":0,"file_count":0,"rpm_count":0,"modulemd_count":0,"erratum_count":0,"package_group_count":0,"srpm_count":0,"module_stream_count":0,"package_count":0,"component_view_count":0,"ansible_collection_repository_count":0,"docker_repository_count":0,"file_repository_count":0,"yum_repository_count":0,"errata_counts":{"security":0,"bugfix":0,"enhancement":0,"total":0},"permissions":{"deletable":true},"filters_applied":false},{"version":"3.0","major":3,"minor":0,"composite_content_view_ids":[],"published_in_composite_content_view_ids":[],"content_view_id":18,"default":false,"description":null,"id":44,"name":"cleanup-testcv
+        3.0","created_at":"2024-07-09 14:30:18 UTC","updated_at":"2024-07-09 14:30:18
+        UTC","content_view":{"id":18,"name":"cleanup-testcv","label":"cleanup-testcv","generated_for":"none"},"composite_content_views":[],"composite_content_view_versions":[],"published_in_composite_content_views":[],"environments":[],"repositories":[],"last_event":{"user":"admin","status":"successful","description":null,"action":"publish","created_at":"2024-07-09
+        14:30:18 UTC","updated_at":"2024-07-09 14:30:18 UTC","environment":null,"task":{"id":"ed9ca23c-1f5e-42b1-9553-b9c729892a63","label":"Actions::Katello::ContentView::Publish","pending":false,"action":"Publish
+        content view ''cleanup-testcv''; organization ''Test Organization''","username":"admin","started_at":"2024-07-09
+        14:30:18 UTC","ended_at":"2024-07-09 14:30:18 UTC","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":18,"name":"cleanup-testcv","label":"cleanup-testcv"},"organization":{"id":26,"name":"Test
+        Organization","label":"Test_Organization"},"services_checked":["candlepin","candlepin_auth"],"history_id":68,"content_view_id":18,"auto_publish_composite_ids":[],"content_view_version_name":"cleanup-testcv
+        3.0","content_view_version_id":44,"environment_id":15,"user_id":4,"skip_promotion":null,"current_request_id":"9220a1fe-1b71-4192-b645-7711e3f1a41b","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{"content_view_id":18,"content_view_version_id":44,"skip_promotion":null,"history_id":68},"humanized":{"action":"Publish","input":[["content_view",{"text":"content
+        view ''cleanup-testcv''","link":"/content_views/18/versions"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/26/edit"}]],"output":"","errors":[]},"cli_example":null,"start_at":"2024-07-09
+        14:30:18 UTC","available_actions":{"cancellable":false,"resumable":false}},"version":"3.0","publish":true,"version_id":44,"triggered_by":null,"triggered_by_id":null},"active_history":[],"ansible_collection_count":0,"docker_manifest_count":0,"docker_manifest_list_count":0,"docker_tag_count":0,"file_count":0,"rpm_count":0,"modulemd_count":0,"erratum_count":0,"package_group_count":0,"srpm_count":0,"module_stream_count":0,"package_count":0,"component_view_count":0,"ansible_collection_repository_count":0,"docker_repository_count":0,"file_repository_count":0,"yum_repository_count":0,"errata_counts":{"security":0,"bugfix":0,"enhancement":0,"total":0},"permissions":{"deletable":true},"filters_applied":false},{"version":"2.0","major":2,"minor":0,"composite_content_view_ids":[],"published_in_composite_content_view_ids":[],"content_view_id":18,"default":false,"description":null,"id":43,"name":"cleanup-testcv
+        2.0","created_at":"2024-07-09 14:30:12 UTC","updated_at":"2024-07-09 14:30:12
+        UTC","content_view":{"id":18,"name":"cleanup-testcv","label":"cleanup-testcv","generated_for":"none"},"composite_content_views":[],"composite_content_view_versions":[],"published_in_composite_content_views":[],"environments":[],"repositories":[],"last_event":{"user":"admin","status":"successful","description":null,"action":"publish","created_at":"2024-07-09
+        14:30:12 UTC","updated_at":"2024-07-09 14:30:12 UTC","environment":null,"task":{"id":"0e6d2fd1-225f-4eb5-aa62-703829022556","label":"Actions::Katello::ContentView::Publish","pending":false,"action":"Publish
+        content view ''cleanup-testcv''; organization ''Test Organization''","username":"admin","started_at":"2024-07-09
+        14:30:12 UTC","ended_at":"2024-07-09 14:30:12 UTC","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":18,"name":"cleanup-testcv","label":"cleanup-testcv"},"organization":{"id":26,"name":"Test
+        Organization","label":"Test_Organization"},"services_checked":["candlepin","candlepin_auth"],"history_id":67,"content_view_id":18,"auto_publish_composite_ids":[],"content_view_version_name":"cleanup-testcv
+        2.0","content_view_version_id":43,"environment_id":15,"user_id":4,"skip_promotion":null,"current_request_id":"fecce2db-22d2-4708-a916-6bb2e2b213ec","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{"content_view_id":18,"content_view_version_id":43,"skip_promotion":null,"history_id":67},"humanized":{"action":"Publish","input":[["content_view",{"text":"content
+        view ''cleanup-testcv''","link":"/content_views/18/versions"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/26/edit"}]],"output":"","errors":[]},"cli_example":null,"start_at":"2024-07-09
+        14:30:12 UTC","available_actions":{"cancellable":false,"resumable":false}},"version":"2.0","publish":true,"version_id":43,"triggered_by":null,"triggered_by_id":null},"active_history":[],"ansible_collection_count":0,"docker_manifest_count":0,"docker_manifest_list_count":0,"docker_tag_count":0,"file_count":0,"rpm_count":0,"modulemd_count":0,"erratum_count":0,"package_group_count":0,"srpm_count":0,"module_stream_count":0,"package_count":0,"component_view_count":0,"ansible_collection_repository_count":0,"docker_repository_count":0,"file_repository_count":0,"yum_repository_count":0,"errata_counts":{"security":0,"bugfix":0,"enhancement":0,"total":0},"permissions":{"deletable":true},"filters_applied":false},{"version":"1.0","major":1,"minor":0,"composite_content_view_ids":[],"published_in_composite_content_view_ids":[],"content_view_id":18,"default":false,"description":null,"id":42,"name":"cleanup-testcv
+        1.0","created_at":"2024-07-09 14:30:06 UTC","updated_at":"2024-07-09 14:30:06
+        UTC","content_view":{"id":18,"name":"cleanup-testcv","label":"cleanup-testcv","generated_for":"none"},"composite_content_views":[],"composite_content_view_versions":[],"published_in_composite_content_views":[],"environments":[],"repositories":[],"last_event":{"user":"admin","status":"successful","description":null,"action":"publish","created_at":"2024-07-09
+        14:30:06 UTC","updated_at":"2024-07-09 14:30:06 UTC","environment":null,"task":{"id":"19cbc6d2-646c-4eea-9bb9-1a23a60e08ff","label":"Actions::Katello::ContentView::Publish","pending":false,"action":"Publish
+        content view ''cleanup-testcv''; organization ''Test Organization''","username":"admin","started_at":"2024-07-09
+        14:30:06 UTC","ended_at":"2024-07-09 14:30:06 UTC","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":18,"name":"cleanup-testcv","label":"cleanup-testcv"},"organization":{"id":26,"name":"Test
+        Organization","label":"Test_Organization"},"services_checked":["candlepin","candlepin_auth"],"history_id":66,"content_view_id":18,"auto_publish_composite_ids":[],"content_view_version_name":"cleanup-testcv
+        1.0","content_view_version_id":42,"environment_id":15,"user_id":4,"skip_promotion":null,"current_request_id":"eb6ab76e-d0b7-49c6-8e59-3f2d25c6e829","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{"content_view_id":18,"content_view_version_id":42,"skip_promotion":null,"history_id":66},"humanized":{"action":"Publish","input":[["content_view",{"text":"content
+        view ''cleanup-testcv''","link":"/content_views/18/versions"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/26/edit"}]],"output":"","errors":[]},"cli_example":null,"start_at":"2024-07-09
+        14:30:06 UTC","available_actions":{"cancellable":false,"resumable":false}},"version":"1.0","publish":true,"version_id":42,"triggered_by":null,"triggered_by_id":null},"active_history":[],"ansible_collection_count":0,"docker_manifest_count":0,"docker_manifest_list_count":0,"docker_tag_count":0,"file_count":0,"rpm_count":0,"modulemd_count":0,"erratum_count":0,"package_group_count":0,"srpm_count":0,"module_stream_count":0,"package_count":0,"component_view_count":0,"ansible_collection_repository_count":0,"docker_repository_count":0,"file_repository_count":0,"yum_repository_count":0,"errata_counts":{"security":0,"bugfix":0,"enhancement":0,"total":0},"permissions":{"deletable":true},"filters_applied":false}]}
 
         '
     headers:
@@ -195,6 +185,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '14410'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -206,15 +198,13 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 7; Test Organization
+      - 26; Test Organization
       Foreman_version:
-      - 2.5.0
+      - 3.12.0-develop
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -225,8 +215,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '13547'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/content_view_version_cleanup_role-4.yml
+++ b/tests/test_playbooks/fixtures/content_view_version_cleanup_role-4.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"2.5.0","api_version":2}'
+      string: '{"satellite_version":"6.16.0","result":"ok","status":200,"version":"3.12.0-develop","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '100'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.5.0
+      - 3.12.0-develop
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -50,8 +50,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '62'
     status:
       code: 200
       message: OK
@@ -70,17 +68,18 @@ interactions:
     uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
-        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\"\
-        :\"Test_Organization\",\"created_at\":\"2021-06-29 08:33:23 UTC\",\"updated_at\"\
-        :\"2021-06-29 08:33:25 UTC\",\"id\":7,\"name\":\"Test Organization\",\"title\"\
-        :\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+        4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2024-07-09
+        14:29:57 UTC\",\"updated_at\":\"2024-07-09 14:29:59 UTC\",\"id\":26,\"name\":\"Test
+        Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '389'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -94,13 +93,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.5.0
+      - 3.12.0-develop
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -111,8 +108,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '388'
     status:
       code: 200
       message: OK
@@ -128,19 +123,20 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/7/content_views?search=name%3D%22cleanup-testcv%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/26/content_views?search=name%3D%22cleanup-testcv%22&per_page=4294967296
   response:
     body:
-      string: '{"total":3,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"cleanup-testcv\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":5,"latest_version":"5.0","latest_version_id":21,"auto_publish":false,"solve_dependencies":false,"import_only":false,"repository_ids":[],"id":9,"name":"cleanup-testcv","label":"cleanup-testcv","description":null,"organization_id":7,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":7},"created_at":"2021-06-29
-        08:33:27 UTC","updated_at":"2021-06-29 08:33:54 UTC","last_task":{"id":"d23c2127-d267-416e-87bd-3d856a80fdd2","result":"successful","last_sync_words":"1
-        minute"},"latest_version_environments":[{"id":6,"name":"Library","label":"Library"}],"environments":[{"id":6,"name":"Library","label":"Library","permissions":{"readable":true}}],"repositories":[],"versions":[{"id":17,"version":"1.0","published":"2021-06-29
-        08:33:31 UTC","environment_ids":[]},{"id":18,"version":"2.0","published":"2021-06-29
-        08:33:37 UTC","environment_ids":[]},{"id":19,"version":"3.0","published":"2021-06-29
-        08:33:43 UTC","environment_ids":[]},{"id":20,"version":"4.0","published":"2021-06-29
-        08:33:48 UTC","environment_ids":[]},{"id":21,"version":"5.0","published":"2021-06-29
-        08:33:54 UTC","environment_ids":[6]}],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"6.0","last_published":"2021-06-29
-        08:33:54 UTC","permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
+      string: '{"total":3,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"cleanup-testcv\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"duplicate_repositories_to_publish":[],"default":false,"version_count":5,"latest_version":"5.0","latest_version_id":46,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":1,"related_composite_cvs":[{"id":19,"name":"cleanup-testccv"}],"filtered":false,"repository_ids":[],"id":18,"name":"cleanup-testcv","label":"cleanup-testcv","description":null,"organization_id":26,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":26},"created_at":"2024-07-09
+        14:30:00 UTC","updated_at":"2024-07-09 14:30:29 UTC","last_task":{"id":"6da31077-1ece-4449-882a-4057308558e4","started_at":"2024-07-09
+        14:30:29 UTC","result":"success","last_sync_words":"1 minute"},"latest_version_environments":[{"id":15,"name":"Library","label":"Library"}],"repositories":[],"versions":[{"id":46,"version":"5.0","published":"2024-07-09
+        14:30:29 UTC","description":null,"environment_ids":[15],"filters_applied":false,"published_at_words":"1
+        minute"},{"id":45,"version":"4.0","published":"2024-07-09 14:30:24 UTC","description":null,"environment_ids":[],"filters_applied":false,"published_at_words":"1
+        minute"},{"id":44,"version":"3.0","published":"2024-07-09 14:30:18 UTC","description":null,"environment_ids":[],"filters_applied":false,"published_at_words":"1
+        minute"},{"id":43,"version":"2.0","published":"2024-07-09 14:30:12 UTC","description":null,"environment_ids":[],"filters_applied":false,"published_at_words":"1
+        minute"},{"id":42,"version":"1.0","published":"2024-07-09 14:30:06 UTC","description":null,"environment_ids":[],"filters_applied":false,"published_at_words":"1
+        minute"}],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"6.0","last_published":"2024-07-09
+        14:30:29 UTC","environments":[{"id":15,"label":"Library","name":"Library","activation_keys":[],"hosts":[],"permissions":{"readable":true}}]}]}
 
         '
     headers:
@@ -148,6 +144,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '2113'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -159,15 +157,13 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 7; Test Organization
+      - 26; Test Organization
       Foreman_version:
-      - 2.5.0
+      - 3.12.0-develop
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -178,8 +174,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '1653'
     status:
       code: 200
       message: OK
@@ -195,21 +189,20 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_view_versions?search=content_view_id%3D9%2Cversion%3D2.0&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_view_versions?search=content_view_id%3D18%2Cversion%3D2.0&per_page=4294967296
   response:
     body:
-      string: '{"total":11,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"content_view_id=9,version=2.0","sort":{"by":"version","order":"desc"},"results":[{"version":"2.0","major":2,"minor":0,"composite_content_view_ids":[],"published_in_composite_content_view_ids":[],"content_view_id":9,"default":false,"description":null,"id":18,"name":"cleanup-testcv
-        2.0","created_at":"2021-06-29 08:33:37 UTC","updated_at":"2021-06-29 08:33:37
-        UTC","content_view":{"id":9,"name":"cleanup-testcv","label":"cleanup-testcv"},"composite_content_views":[],"composite_content_view_versions":[],"published_in_composite_content_views":[],"environments":[],"repositories":[],"last_event":{"user":"admin","status":"successful","description":null,"action":"publish","created_at":"2021-06-29
-        08:33:37 UTC","updated_at":"2021-06-29 08:33:37 UTC","environment":null,"task":{"id":"e71b9c4c-5c93-48d6-b22f-1e90a256a8f1","label":"Actions::Katello::ContentView::Publish","pending":false,"action":"Publish
-        content view ''cleanup-testcv''; organization ''Test Organization''","username":"admin","started_at":"2021-06-29
-        08:33:37 UTC","ended_at":"2021-06-29 08:33:37 UTC","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":9,"name":"cleanup-testcv","label":"cleanup-testcv"},"organization":{"id":7,"name":"Test
-        Organization","label":"Test_Organization"},"services_checked":["candlepin","candlepin_auth"],"history_id":17,"content_view_id":9,"auto_publish_composite_ids":[],"content_view_version_name":"cleanup-testcv
-        2.0","content_view_version_id":18,"environment_id":6,"user_id":4,"skip_promotion":null,"current_request_id":"052eedfe-ddf1-40bc-98b6-2a47faaa2b8c","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{"content_view_id":9,"content_view_version_id":18,"skip_promotion":null},"humanized":{"action":"Publish","input":[["content_view",{"text":"content
-        view ''cleanup-testcv''","link":"/content_views/9/versions"}],["organization",{"text":"organization
-        ''Test Organization''","link":"/organizations/7/edit"}]],"output":"","errors":[]},"cli_example":null,"start_at":"2021-06-29
-        08:33:37 UTC","available_actions":{"cancellable":false,"resumable":false}},"version":"2.0","publish":true,"version_id":18,"triggered_by":null,"triggered_by_id":null},"active_history":[],"ansible
-        collection_count":0,"deb_count":0,"docker_manifest_count":0,"docker_manifest_list_count":0,"docker_tag_count":0,"file_count":0,"rpm_count":0,"modulemd_count":0,"erratum_count":0,"package_group_count":0,"srpm_count":0,"module_stream_count":0,"package_count":0,"ostree_branch_count":null,"errata_counts":{"security":null,"bugfix":0,"enhancement":0,"total":null},"permissions":{"deletable":true}}]}
+      string: '{"total":10,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"content_view_id=18,version=2.0","sort":{"by":"version","order":"desc"},"results":[{"version":"2.0","major":2,"minor":0,"composite_content_view_ids":[],"published_in_composite_content_view_ids":[],"content_view_id":18,"default":false,"description":null,"id":43,"name":"cleanup-testcv
+        2.0","created_at":"2024-07-09 14:30:12 UTC","updated_at":"2024-07-09 14:30:12
+        UTC","content_view":{"id":18,"name":"cleanup-testcv","label":"cleanup-testcv","generated_for":"none"},"composite_content_views":[],"composite_content_view_versions":[],"published_in_composite_content_views":[],"environments":[],"repositories":[],"last_event":{"user":"admin","status":"successful","description":null,"action":"publish","created_at":"2024-07-09
+        14:30:12 UTC","updated_at":"2024-07-09 14:30:12 UTC","environment":null,"task":{"id":"0e6d2fd1-225f-4eb5-aa62-703829022556","label":"Actions::Katello::ContentView::Publish","pending":false,"action":"Publish
+        content view ''cleanup-testcv''; organization ''Test Organization''","username":"admin","started_at":"2024-07-09
+        14:30:12 UTC","ended_at":"2024-07-09 14:30:12 UTC","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":18,"name":"cleanup-testcv","label":"cleanup-testcv"},"organization":{"id":26,"name":"Test
+        Organization","label":"Test_Organization"},"services_checked":["candlepin","candlepin_auth"],"history_id":67,"content_view_id":18,"auto_publish_composite_ids":[],"content_view_version_name":"cleanup-testcv
+        2.0","content_view_version_id":43,"environment_id":15,"user_id":4,"skip_promotion":null,"current_request_id":"fecce2db-22d2-4708-a916-6bb2e2b213ec","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{"content_view_id":18,"content_view_version_id":43,"skip_promotion":null,"history_id":67},"humanized":{"action":"Publish","input":[["content_view",{"text":"content
+        view ''cleanup-testcv''","link":"/content_views/18/versions"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/26/edit"}]],"output":"","errors":[]},"cli_example":null,"start_at":"2024-07-09
+        14:30:12 UTC","available_actions":{"cancellable":false,"resumable":false}},"version":"2.0","publish":true,"version_id":43,"triggered_by":null,"triggered_by_id":null},"active_history":[],"ansible_collection_count":0,"docker_manifest_count":0,"docker_manifest_list_count":0,"docker_tag_count":0,"file_count":0,"rpm_count":0,"modulemd_count":0,"erratum_count":0,"package_group_count":0,"srpm_count":0,"module_stream_count":0,"package_count":0,"component_view_count":0,"ansible_collection_repository_count":0,"docker_repository_count":0,"file_repository_count":0,"yum_repository_count":0,"errata_counts":{"security":0,"bugfix":0,"enhancement":0,"total":0},"permissions":{"deletable":true},"filters_applied":false}]}
 
         '
     headers:
@@ -217,6 +210,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '2921'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -230,13 +225,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.5.0
+      - 3.12.0-develop
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -247,8 +240,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '2736'
     status:
       code: 200
       message: OK
@@ -266,12 +257,12 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: DELETE
-    uri: https://foreman.example.org/katello/api/content_view_versions/18
+    uri: https://foreman.example.org/katello/api/content_view_versions/43
   response:
     body:
-      string: '  {"id":"da7f5b4a-4dcb-4eca-8409-31566153e029","label":"Actions::Katello::ContentViewVersion::Destroy","pending":true,"action":"Destroy","username":"admin","started_at":"2021-06-29
-        08:34:41 UTC","ended_at":null,"state":"planned","result":"pending","progress":0.0,"input":{"id":18,"current_request_id":"6db7f3ee-36ec-4e8c-9797-247661990f45","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{},"humanized":{"action":"Destroy","input":"","output":"","errors":[]},"cli_example":null,"start_at":"2021-06-29
-        08:34:41 UTC","available_actions":{"cancellable":false,"resumable":false}}
+      string: '  {"id":"03f17f29-3cb0-415c-aa48-f29f1c102c15","label":"Actions::Katello::ContentViewVersion::Destroy","pending":true,"action":"Destroy","username":"admin","started_at":"2024-07-09
+        14:31:18 UTC","ended_at":null,"state":"planned","result":"pending","progress":0.0,"input":{"id":43,"docker_cleanup":false,"current_request_id":"d5e2414b-59d4-4395-86bb-669a2b0ae8d5","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{},"humanized":{"action":"Destroy","input":"","output":"","errors":[]},"cli_example":null,"start_at":"2024-07-09
+        14:31:18 UTC","available_actions":{"cancellable":false,"resumable":false}}
 
         '
     headers:
@@ -292,7 +283,7 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.5.0
+      - 3.12.0-develop
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
@@ -324,17 +315,19 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/foreman_tasks/api/tasks/da7f5b4a-4dcb-4eca-8409-31566153e029
+    uri: https://foreman.example.org/foreman_tasks/api/tasks/03f17f29-3cb0-415c-aa48-f29f1c102c15
   response:
     body:
-      string: '{"id":"da7f5b4a-4dcb-4eca-8409-31566153e029","label":"Actions::Katello::ContentViewVersion::Destroy","pending":false,"action":"Destroy","username":"admin","started_at":"2021-06-29
-        08:34:41 UTC","ended_at":"2021-06-29 08:34:41 UTC","state":"stopped","result":"success","progress":1.0,"input":{"id":18,"current_request_id":"6db7f3ee-36ec-4e8c-9797-247661990f45","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{},"humanized":{"action":"Destroy","input":"","output":"","errors":[]},"cli_example":null,"start_at":"2021-06-29
-        08:34:41 UTC","available_actions":{"cancellable":false,"resumable":false}}'
+      string: '{"id":"03f17f29-3cb0-415c-aa48-f29f1c102c15","label":"Actions::Katello::ContentViewVersion::Destroy","pending":false,"action":"Destroy","username":"admin","started_at":"2024-07-09
+        14:31:18 UTC","ended_at":"2024-07-09 14:31:18 UTC","duration":"0.086911","state":"stopped","result":"success","progress":1.0,"input":{"id":43,"docker_cleanup":false,"current_request_id":"d5e2414b-59d4-4395-86bb-669a2b0ae8d5","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{},"humanized":{"action":"Destroy","input":"","output":"","errors":[]},"cli_example":null,"start_at":"2024-07-09
+        14:31:18 UTC","available_actions":{"cancellable":false,"resumable":false}}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '705'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -348,13 +341,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.5.0
+      - 3.12.0-develop
       Keep-Alive:
       - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -365,8 +356,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '660'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/content_view_version_cleanup_role-5.yml
+++ b/tests/test_playbooks/fixtures/content_view_version_cleanup_role-5.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"2.5.0","api_version":2}'
+      string: '{"satellite_version":"6.16.0","result":"ok","status":200,"version":"3.12.0-develop","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '100'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.5.0
+      - 3.12.0-develop
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -50,8 +50,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '62'
     status:
       code: 200
       message: OK
@@ -70,17 +68,18 @@ interactions:
     uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
-        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\"\
-        :\"Test_Organization\",\"created_at\":\"2021-06-29 08:33:23 UTC\",\"updated_at\"\
-        :\"2021-06-29 08:33:25 UTC\",\"id\":7,\"name\":\"Test Organization\",\"title\"\
-        :\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+        4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2024-07-09
+        14:29:57 UTC\",\"updated_at\":\"2024-07-09 14:29:59 UTC\",\"id\":26,\"name\":\"Test
+        Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '389'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -94,13 +93,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.5.0
+      - 3.12.0-develop
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -111,8 +108,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '388'
     status:
       code: 200
       message: OK
@@ -128,18 +123,19 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/7/content_views?search=name%3D%22cleanup-testcv%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/26/content_views?search=name%3D%22cleanup-testcv%22&per_page=4294967296
   response:
     body:
-      string: '{"total":3,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"cleanup-testcv\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":4,"latest_version":"5.0","latest_version_id":21,"auto_publish":false,"solve_dependencies":false,"import_only":false,"repository_ids":[],"id":9,"name":"cleanup-testcv","label":"cleanup-testcv","description":null,"organization_id":7,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":7},"created_at":"2021-06-29
-        08:33:27 UTC","updated_at":"2021-06-29 08:33:54 UTC","last_task":{"id":"d23c2127-d267-416e-87bd-3d856a80fdd2","result":"successful","last_sync_words":"1
-        minute"},"latest_version_environments":[{"id":6,"name":"Library","label":"Library"}],"environments":[{"id":6,"name":"Library","label":"Library","permissions":{"readable":true}}],"repositories":[],"versions":[{"id":17,"version":"1.0","published":"2021-06-29
-        08:33:31 UTC","environment_ids":[]},{"id":19,"version":"3.0","published":"2021-06-29
-        08:33:43 UTC","environment_ids":[]},{"id":20,"version":"4.0","published":"2021-06-29
-        08:33:48 UTC","environment_ids":[]},{"id":21,"version":"5.0","published":"2021-06-29
-        08:33:54 UTC","environment_ids":[6]}],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"6.0","last_published":"2021-06-29
-        08:33:54 UTC","permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
+      string: '{"total":3,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"cleanup-testcv\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"duplicate_repositories_to_publish":[],"default":false,"version_count":4,"latest_version":"5.0","latest_version_id":46,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":1,"related_composite_cvs":[{"id":19,"name":"cleanup-testccv"}],"filtered":false,"repository_ids":[],"id":18,"name":"cleanup-testcv","label":"cleanup-testcv","description":null,"organization_id":26,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":26},"created_at":"2024-07-09
+        14:30:00 UTC","updated_at":"2024-07-09 14:30:29 UTC","last_task":{"id":"6da31077-1ece-4449-882a-4057308558e4","started_at":"2024-07-09
+        14:30:29 UTC","result":"success","last_sync_words":"1 minute"},"latest_version_environments":[{"id":15,"name":"Library","label":"Library"}],"repositories":[],"versions":[{"id":46,"version":"5.0","published":"2024-07-09
+        14:30:29 UTC","description":null,"environment_ids":[15],"filters_applied":false,"published_at_words":"1
+        minute"},{"id":45,"version":"4.0","published":"2024-07-09 14:30:24 UTC","description":null,"environment_ids":[],"filters_applied":false,"published_at_words":"1
+        minute"},{"id":44,"version":"3.0","published":"2024-07-09 14:30:18 UTC","description":null,"environment_ids":[],"filters_applied":false,"published_at_words":"1
+        minute"},{"id":42,"version":"1.0","published":"2024-07-09 14:30:06 UTC","description":null,"environment_ids":[],"filters_applied":false,"published_at_words":"1
+        minute"}],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"6.0","last_published":"2024-07-09
+        14:30:29 UTC","environments":[{"id":15,"label":"Library","name":"Library","activation_keys":[],"hosts":[],"permissions":{"readable":true}}]}]}
 
         '
     headers:
@@ -147,6 +143,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '1953'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -158,15 +156,13 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 7; Test Organization
+      - 26; Test Organization
       Foreman_version:
-      - 2.5.0
+      - 3.12.0-develop
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -177,8 +173,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '1568'
     status:
       code: 200
       message: OK
@@ -194,21 +188,20 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_view_versions?search=content_view_id%3D9%2Cversion%3D1.0&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_view_versions?search=content_view_id%3D18%2Cversion%3D1.0&per_page=4294967296
   response:
     body:
-      string: '{"total":10,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"content_view_id=9,version=1.0","sort":{"by":"version","order":"desc"},"results":[{"version":"1.0","major":1,"minor":0,"composite_content_view_ids":[],"published_in_composite_content_view_ids":[],"content_view_id":9,"default":false,"description":null,"id":17,"name":"cleanup-testcv
-        1.0","created_at":"2021-06-29 08:33:31 UTC","updated_at":"2021-06-29 08:33:32
-        UTC","content_view":{"id":9,"name":"cleanup-testcv","label":"cleanup-testcv"},"composite_content_views":[],"composite_content_view_versions":[],"published_in_composite_content_views":[],"environments":[],"repositories":[],"last_event":{"user":"admin","status":"successful","description":null,"action":"publish","created_at":"2021-06-29
-        08:33:31 UTC","updated_at":"2021-06-29 08:33:32 UTC","environment":null,"task":{"id":"733cfc56-ed25-4c92-908a-4da3f2207f77","label":"Actions::Katello::ContentView::Publish","pending":false,"action":"Publish
-        content view ''cleanup-testcv''; organization ''Test Organization''","username":"admin","started_at":"2021-06-29
-        08:33:31 UTC","ended_at":"2021-06-29 08:33:32 UTC","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":9,"name":"cleanup-testcv","label":"cleanup-testcv"},"organization":{"id":7,"name":"Test
-        Organization","label":"Test_Organization"},"services_checked":["candlepin","candlepin_auth"],"history_id":16,"content_view_id":9,"auto_publish_composite_ids":[],"content_view_version_name":"cleanup-testcv
-        1.0","content_view_version_id":17,"environment_id":6,"user_id":4,"skip_promotion":null,"current_request_id":"511dd06b-d232-4ee4-acf0-d8a7ba7159bd","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{"content_view_id":9,"content_view_version_id":17,"skip_promotion":null},"humanized":{"action":"Publish","input":[["content_view",{"text":"content
-        view ''cleanup-testcv''","link":"/content_views/9/versions"}],["organization",{"text":"organization
-        ''Test Organization''","link":"/organizations/7/edit"}]],"output":"","errors":[]},"cli_example":null,"start_at":"2021-06-29
-        08:33:31 UTC","available_actions":{"cancellable":false,"resumable":false}},"version":"1.0","publish":true,"version_id":17,"triggered_by":null,"triggered_by_id":null},"active_history":[],"ansible
-        collection_count":0,"deb_count":0,"docker_manifest_count":0,"docker_manifest_list_count":0,"docker_tag_count":0,"file_count":0,"rpm_count":0,"modulemd_count":0,"erratum_count":0,"package_group_count":0,"srpm_count":0,"module_stream_count":0,"package_count":0,"ostree_branch_count":null,"errata_counts":{"security":null,"bugfix":0,"enhancement":0,"total":null},"permissions":{"deletable":true}}]}
+      string: '{"total":9,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"content_view_id=18,version=1.0","sort":{"by":"version","order":"desc"},"results":[{"version":"1.0","major":1,"minor":0,"composite_content_view_ids":[],"published_in_composite_content_view_ids":[],"content_view_id":18,"default":false,"description":null,"id":42,"name":"cleanup-testcv
+        1.0","created_at":"2024-07-09 14:30:06 UTC","updated_at":"2024-07-09 14:30:06
+        UTC","content_view":{"id":18,"name":"cleanup-testcv","label":"cleanup-testcv","generated_for":"none"},"composite_content_views":[],"composite_content_view_versions":[],"published_in_composite_content_views":[],"environments":[],"repositories":[],"last_event":{"user":"admin","status":"successful","description":null,"action":"publish","created_at":"2024-07-09
+        14:30:06 UTC","updated_at":"2024-07-09 14:30:06 UTC","environment":null,"task":{"id":"19cbc6d2-646c-4eea-9bb9-1a23a60e08ff","label":"Actions::Katello::ContentView::Publish","pending":false,"action":"Publish
+        content view ''cleanup-testcv''; organization ''Test Organization''","username":"admin","started_at":"2024-07-09
+        14:30:06 UTC","ended_at":"2024-07-09 14:30:06 UTC","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":18,"name":"cleanup-testcv","label":"cleanup-testcv"},"organization":{"id":26,"name":"Test
+        Organization","label":"Test_Organization"},"services_checked":["candlepin","candlepin_auth"],"history_id":66,"content_view_id":18,"auto_publish_composite_ids":[],"content_view_version_name":"cleanup-testcv
+        1.0","content_view_version_id":42,"environment_id":15,"user_id":4,"skip_promotion":null,"current_request_id":"eb6ab76e-d0b7-49c6-8e59-3f2d25c6e829","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{"content_view_id":18,"content_view_version_id":42,"skip_promotion":null,"history_id":66},"humanized":{"action":"Publish","input":[["content_view",{"text":"content
+        view ''cleanup-testcv''","link":"/content_views/18/versions"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/26/edit"}]],"output":"","errors":[]},"cli_example":null,"start_at":"2024-07-09
+        14:30:06 UTC","available_actions":{"cancellable":false,"resumable":false}},"version":"1.0","publish":true,"version_id":42,"triggered_by":null,"triggered_by_id":null},"active_history":[],"ansible_collection_count":0,"docker_manifest_count":0,"docker_manifest_list_count":0,"docker_tag_count":0,"file_count":0,"rpm_count":0,"modulemd_count":0,"erratum_count":0,"package_group_count":0,"srpm_count":0,"module_stream_count":0,"package_count":0,"component_view_count":0,"ansible_collection_repository_count":0,"docker_repository_count":0,"file_repository_count":0,"yum_repository_count":0,"errata_counts":{"security":0,"bugfix":0,"enhancement":0,"total":0},"permissions":{"deletable":true},"filters_applied":false}]}
 
         '
     headers:
@@ -216,6 +209,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '2920'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -229,13 +224,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.5.0
+      - 3.12.0-develop
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -246,8 +239,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '2736'
     status:
       code: 200
       message: OK
@@ -265,12 +256,12 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: DELETE
-    uri: https://foreman.example.org/katello/api/content_view_versions/17
+    uri: https://foreman.example.org/katello/api/content_view_versions/42
   response:
     body:
-      string: '  {"id":"86fda755-d5ec-4064-afc2-d443b59f876c","label":"Actions::Katello::ContentViewVersion::Destroy","pending":true,"action":"Destroy","username":"admin","started_at":"2021-06-29
-        08:34:46 UTC","ended_at":null,"state":"planned","result":"pending","progress":0.0,"input":{"id":17,"current_request_id":"aacd69f0-b72c-4f5c-af66-5b95a825169b","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{},"humanized":{"action":"Destroy","input":"","output":"","errors":[]},"cli_example":null,"start_at":"2021-06-29
-        08:34:46 UTC","available_actions":{"cancellable":false,"resumable":false}}
+      string: '  {"id":"ee46c944-7b24-4175-883b-0d3df8389ed2","label":"Actions::Katello::ContentViewVersion::Destroy","pending":true,"action":"Destroy","username":"admin","started_at":"2024-07-09
+        14:31:24 UTC","ended_at":null,"state":"planned","result":"pending","progress":0.0,"input":{"id":42,"docker_cleanup":false,"current_request_id":"47cf8a3d-e4c9-42fd-b231-99f794944bda","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{},"humanized":{"action":"Destroy","input":"","output":"","errors":[]},"cli_example":null,"start_at":"2024-07-09
+        14:31:24 UTC","available_actions":{"cancellable":false,"resumable":false}}
 
         '
     headers:
@@ -291,7 +282,7 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.5.0
+      - 3.12.0-develop
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
@@ -323,17 +314,19 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/foreman_tasks/api/tasks/86fda755-d5ec-4064-afc2-d443b59f876c
+    uri: https://foreman.example.org/foreman_tasks/api/tasks/ee46c944-7b24-4175-883b-0d3df8389ed2
   response:
     body:
-      string: '{"id":"86fda755-d5ec-4064-afc2-d443b59f876c","label":"Actions::Katello::ContentViewVersion::Destroy","pending":false,"action":"Destroy","username":"admin","started_at":"2021-06-29
-        08:34:46 UTC","ended_at":"2021-06-29 08:34:46 UTC","state":"stopped","result":"success","progress":1.0,"input":{"id":17,"current_request_id":"aacd69f0-b72c-4f5c-af66-5b95a825169b","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{},"humanized":{"action":"Destroy","input":"","output":"","errors":[]},"cli_example":null,"start_at":"2021-06-29
-        08:34:46 UTC","available_actions":{"cancellable":false,"resumable":false}}'
+      string: '{"id":"ee46c944-7b24-4175-883b-0d3df8389ed2","label":"Actions::Katello::ContentViewVersion::Destroy","pending":false,"action":"Destroy","username":"admin","started_at":"2024-07-09
+        14:31:24 UTC","ended_at":"2024-07-09 14:31:24 UTC","duration":"0.073975","state":"stopped","result":"success","progress":1.0,"input":{"id":42,"docker_cleanup":false,"current_request_id":"47cf8a3d-e4c9-42fd-b231-99f794944bda","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{},"humanized":{"action":"Destroy","input":"","output":"","errors":[]},"cli_example":null,"start_at":"2024-07-09
+        14:31:24 UTC","available_actions":{"cancellable":false,"resumable":false}}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '705'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -347,13 +340,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.5.0
+      - 3.12.0-develop
       Keep-Alive:
       - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -364,8 +355,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '660'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/content_view_version_cleanup_role-6.yml
+++ b/tests/test_playbooks/fixtures/content_view_version_cleanup_role-6.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"2.5.0","api_version":2}'
+      string: '{"satellite_version":"6.16.0","result":"ok","status":200,"version":"3.12.0-develop","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '100'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.5.0
+      - 3.12.0-develop
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -50,8 +50,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '62'
     status:
       code: 200
       message: OK
@@ -70,17 +68,18 @@ interactions:
     uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
-        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\"\
-        :\"Test_Organization\",\"created_at\":\"2021-06-29 08:33:23 UTC\",\"updated_at\"\
-        :\"2021-06-29 08:33:25 UTC\",\"id\":7,\"name\":\"Test Organization\",\"title\"\
-        :\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+        4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2024-07-09
+        14:29:57 UTC\",\"updated_at\":\"2024-07-09 14:29:59 UTC\",\"id\":26,\"name\":\"Test
+        Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '389'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -94,13 +93,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.5.0
+      - 3.12.0-develop
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -111,8 +108,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '388'
     status:
       code: 200
       message: OK
@@ -128,28 +123,32 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/7/content_views?search=name+~+cleanup&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/26/content_views?search=name+~+cleanup&per_page=4294967296
   response:
     body:
-      string: '{"total":3,"subtotal":2,"page":1,"per_page":"4294967296","error":null,"search":"name
-        ~ cleanup","sort":{"by":"name","order":"asc"},"results":[{"composite":true,"component_ids":[21],"default":false,"version_count":3,"latest_version":"5.0","latest_version_id":26,"auto_publish":false,"solve_dependencies":false,"import_only":false,"repository_ids":[],"id":10,"name":"cleanup-testccv","label":"cleanup-testccv","description":null,"organization_id":7,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":7},"created_at":"2021-06-29
-        08:33:29 UTC","updated_at":"2021-06-29 08:34:22 UTC","last_task":{"id":"23e7eca9-3adb-48a2-9778-a4f4e6db4435","result":"successful","last_sync_words":"1
-        minute"},"latest_version_environments":[{"id":6,"name":"Library","label":"Library"}],"environments":[{"id":6,"name":"Library","label":"Library","permissions":{"readable":true}}],"repositories":[],"versions":[{"id":24,"version":"3.0","published":"2021-06-29
-        08:34:11 UTC","environment_ids":[]},{"id":25,"version":"4.0","published":"2021-06-29
-        08:34:16 UTC","environment_ids":[]},{"id":26,"version":"5.0","published":"2021-06-29
-        08:34:22 UTC","environment_ids":[6]}],"components":[{"id":21,"name":"cleanup-testcv
-        5.0","content_view_id":9,"version":"5.0","environments":[{"id":6,"name":"Library","label":"Library"}],"content_view":{"id":9,"name":"cleanup-testcv","label":"cleanup-testcv","description":null,"next_version":6,"latest_version":"5.0"},"repositories":[]}],"content_view_components":[{"latest":true,"id":2,"created_at":"2021-06-29
-        08:33:29 UTC","updated_at":"2021-06-29 08:33:29 UTC","composite_content_view":{"id":10,"name":"cleanup-testccv","label":"cleanup-testccv","description":null,"next_version":6,"latest_version":"5.0","version_count":3},"content_view":{"id":9,"name":"cleanup-testcv","label":"cleanup-testcv","description":null,"next_version":6,"latest_version":"5.0","version_count":3},"content_view_version":{"id":21,"name":"cleanup-testcv
-        5.0","content_view_id":9,"version":"5.0","content_view":{"id":9,"name":"cleanup-testcv","label":"cleanup-testcv","description":null},"environments":[{"id":6,"name":"Library","label":"Library"}],"repositories":[]}}],"activation_keys":[],"hosts":[],"next_version":"6.0","last_published":"2021-06-29
-        08:34:22 UTC","permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}},{"composite":false,"component_ids":[],"default":false,"version_count":3,"latest_version":"5.0","latest_version_id":21,"auto_publish":false,"solve_dependencies":false,"import_only":false,"repository_ids":[],"id":9,"name":"cleanup-testcv","label":"cleanup-testcv","description":null,"organization_id":7,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":7},"created_at":"2021-06-29
-        08:33:27 UTC","updated_at":"2021-06-29 08:33:54 UTC","last_task":{"id":"d23c2127-d267-416e-87bd-3d856a80fdd2","result":"successful","last_sync_words":"1
-        minute"},"latest_version_environments":[{"id":6,"name":"Library","label":"Library"}],"environments":[{"id":6,"name":"Library","label":"Library","permissions":{"readable":true}}],"repositories":[],"versions":[{"id":19,"version":"3.0","published":"2021-06-29
-        08:33:43 UTC","environment_ids":[]},{"id":20,"version":"4.0","published":"2021-06-29
-        08:33:48 UTC","environment_ids":[]},{"id":21,"version":"5.0","published":"2021-06-29
-        08:33:54 UTC","environment_ids":[6]}],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"6.0","last_published":"2021-06-29
-        08:33:54 UTC","permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
+      string: '{"total":3,"subtotal":2,"selectable":2,"page":1,"per_page":"4294967296","error":null,"search":"name
+        ~ cleanup","sort":{"by":"name","order":"asc"},"results":[{"composite":true,"component_ids":[46],"duplicate_repositories_to_publish":[],"default":false,"version_count":3,"latest_version":"5.0","latest_version_id":51,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":1,"related_composite_cvs":[],"filtered":false,"repository_ids":[],"id":19,"name":"cleanup-testccv","label":"cleanup-testccv","description":null,"organization_id":26,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":26},"created_at":"2024-07-09
+        14:30:02 UTC","updated_at":"2024-07-09 14:30:58 UTC","last_task":{"id":"aec3029e-8c8f-4ae7-bba9-cb504e1b4d0e","started_at":"2024-07-09
+        14:30:58 UTC","result":"success","last_sync_words":"1 minute"},"latest_version_environments":[{"id":15,"name":"Library","label":"Library"}],"repositories":[],"versions":[{"id":51,"version":"5.0","published":"2024-07-09
+        14:30:58 UTC","description":null,"environment_ids":[15],"filters_applied":false,"published_at_words":"1
+        minute"},{"id":50,"version":"4.0","published":"2024-07-09 14:30:52 UTC","description":null,"environment_ids":[],"filters_applied":false,"published_at_words":"1
+        minute"},{"id":49,"version":"3.0","published":"2024-07-09 14:30:47 UTC","description":null,"environment_ids":[],"filters_applied":false,"published_at_words":"1
+        minute"}],"components":[{"id":46,"name":"cleanup-testcv 5.0","content_view_id":18,"version":"5.0","environments":[{"id":15,"name":"Library","label":"Library"}],"content_view":{"id":18,"name":"cleanup-testcv","label":"cleanup-testcv","description":null,"next_version":6,"latest_version":"5.0"},"repositories":[]}],"content_view_components":[{"latest":true,"id":2,"created_at":"2024-07-09
+        14:30:03 UTC","updated_at":"2024-07-09 14:30:03 UTC","composite_content_view":{"id":19,"name":"cleanup-testccv","label":"cleanup-testccv","description":null,"next_version":6,"latest_version":"5.0","version_count":3},"content_view":{"id":18,"name":"cleanup-testcv","label":"cleanup-testcv","description":null,"next_version":6,"latest_version":"5.0","version_count":3},"content_view_version":{"id":46,"name":"cleanup-testcv
+        5.0","content_view_id":18,"version":"5.0","content_view":{"id":18,"name":"cleanup-testcv","label":"cleanup-testcv","description":null},"environments":[{"id":15,"name":"Library","label":"Library"}],"repositories":[]},"component_content_view_versions":[{"id":46,"version":"5.0","description":null,"published_at_words":"1
+        minute"},{"id":45,"version":"4.0","description":null,"published_at_words":"1
+        minute"},{"id":44,"version":"3.0","description":null,"published_at_words":"1
+        minute"}]}],"activation_keys":[],"hosts":[],"next_version":"6.0","last_published":"2024-07-09
+        14:30:58 UTC","environments":[{"id":15,"label":"Library","name":"Library","activation_keys":[],"hosts":[],"permissions":{"readable":true}}]},{"composite":false,"component_ids":[],"duplicate_repositories_to_publish":[],"default":false,"version_count":3,"latest_version":"5.0","latest_version_id":46,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":1,"related_composite_cvs":[{"id":19,"name":"cleanup-testccv"}],"filtered":false,"repository_ids":[],"id":18,"name":"cleanup-testcv","label":"cleanup-testcv","description":null,"organization_id":26,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":26},"created_at":"2024-07-09
+        14:30:00 UTC","updated_at":"2024-07-09 14:30:29 UTC","last_task":{"id":"6da31077-1ece-4449-882a-4057308558e4","started_at":"2024-07-09
+        14:30:29 UTC","result":"success","last_sync_words":"1 minute"},"latest_version_environments":[{"id":15,"name":"Library","label":"Library"}],"repositories":[],"versions":[{"id":46,"version":"5.0","published":"2024-07-09
+        14:30:29 UTC","description":null,"environment_ids":[15],"filters_applied":false,"published_at_words":"1
+        minute"},{"id":45,"version":"4.0","published":"2024-07-09 14:30:24 UTC","description":null,"environment_ids":[],"filters_applied":false,"published_at_words":"1
+        minute"},{"id":44,"version":"3.0","published":"2024-07-09 14:30:18 UTC","description":null,"environment_ids":[],"filters_applied":false,"published_at_words":"1
+        minute"}],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"6.0","last_published":"2024-07-09
+        14:30:29 UTC","environments":[{"id":15,"label":"Library","name":"Library","activation_keys":[],"hosts":[],"permissions":{"readable":true}}]}]}
 
         '
     headers:
@@ -157,6 +156,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '4617'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -168,15 +169,13 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 7; Test Organization
+      - 26; Test Organization
       Foreman_version:
-      - 2.5.0
+      - 3.12.0-develop
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -187,8 +186,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '3773'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/content_view_version_cleanup_role-7.yml
+++ b/tests/test_playbooks/fixtures/content_view_version_cleanup_role-7.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"2.5.0","api_version":2}'
+      string: '{"satellite_version":"6.16.0","result":"ok","status":200,"version":"3.12.0-develop","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '100'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.5.0
+      - 3.12.0-develop
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -50,8 +50,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '62'
     status:
       code: 200
       message: OK
@@ -70,17 +68,18 @@ interactions:
     uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
-        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\"\
-        :\"Test_Organization\",\"created_at\":\"2021-06-29 08:33:23 UTC\",\"updated_at\"\
-        :\"2021-06-29 08:33:25 UTC\",\"id\":7,\"name\":\"Test Organization\",\"title\"\
-        :\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+        4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2024-07-09
+        14:29:57 UTC\",\"updated_at\":\"2024-07-09 14:29:59 UTC\",\"id\":26,\"name\":\"Test
+        Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '389'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -94,13 +93,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.5.0
+      - 3.12.0-develop
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -111,8 +108,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '388'
     status:
       code: 200
       message: OK
@@ -128,28 +123,32 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/7/content_views?search=name+~+cleanup&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/26/content_views?search=name+~+cleanup&per_page=4294967296
   response:
     body:
-      string: '{"total":3,"subtotal":2,"page":1,"per_page":"4294967296","error":null,"search":"name
-        ~ cleanup","sort":{"by":"name","order":"asc"},"results":[{"composite":true,"component_ids":[21],"default":false,"version_count":3,"latest_version":"5.0","latest_version_id":26,"auto_publish":false,"solve_dependencies":false,"import_only":false,"repository_ids":[],"id":10,"name":"cleanup-testccv","label":"cleanup-testccv","description":null,"organization_id":7,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":7},"created_at":"2021-06-29
-        08:33:29 UTC","updated_at":"2021-06-29 08:34:22 UTC","last_task":{"id":"23e7eca9-3adb-48a2-9778-a4f4e6db4435","result":"successful","last_sync_words":"1
-        minute"},"latest_version_environments":[{"id":6,"name":"Library","label":"Library"}],"environments":[{"id":6,"name":"Library","label":"Library","permissions":{"readable":true}}],"repositories":[],"versions":[{"id":24,"version":"3.0","published":"2021-06-29
-        08:34:11 UTC","environment_ids":[]},{"id":25,"version":"4.0","published":"2021-06-29
-        08:34:16 UTC","environment_ids":[]},{"id":26,"version":"5.0","published":"2021-06-29
-        08:34:22 UTC","environment_ids":[6]}],"components":[{"id":21,"name":"cleanup-testcv
-        5.0","content_view_id":9,"version":"5.0","environments":[{"id":6,"name":"Library","label":"Library"}],"content_view":{"id":9,"name":"cleanup-testcv","label":"cleanup-testcv","description":null,"next_version":6,"latest_version":"5.0"},"repositories":[]}],"content_view_components":[{"latest":true,"id":2,"created_at":"2021-06-29
-        08:33:29 UTC","updated_at":"2021-06-29 08:33:29 UTC","composite_content_view":{"id":10,"name":"cleanup-testccv","label":"cleanup-testccv","description":null,"next_version":6,"latest_version":"5.0","version_count":3},"content_view":{"id":9,"name":"cleanup-testcv","label":"cleanup-testcv","description":null,"next_version":6,"latest_version":"5.0","version_count":3},"content_view_version":{"id":21,"name":"cleanup-testcv
-        5.0","content_view_id":9,"version":"5.0","content_view":{"id":9,"name":"cleanup-testcv","label":"cleanup-testcv","description":null},"environments":[{"id":6,"name":"Library","label":"Library"}],"repositories":[]}}],"activation_keys":[],"hosts":[],"next_version":"6.0","last_published":"2021-06-29
-        08:34:22 UTC","permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}},{"composite":false,"component_ids":[],"default":false,"version_count":3,"latest_version":"5.0","latest_version_id":21,"auto_publish":false,"solve_dependencies":false,"import_only":false,"repository_ids":[],"id":9,"name":"cleanup-testcv","label":"cleanup-testcv","description":null,"organization_id":7,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":7},"created_at":"2021-06-29
-        08:33:27 UTC","updated_at":"2021-06-29 08:33:54 UTC","last_task":{"id":"d23c2127-d267-416e-87bd-3d856a80fdd2","result":"successful","last_sync_words":"1
-        minute"},"latest_version_environments":[{"id":6,"name":"Library","label":"Library"}],"environments":[{"id":6,"name":"Library","label":"Library","permissions":{"readable":true}}],"repositories":[],"versions":[{"id":19,"version":"3.0","published":"2021-06-29
-        08:33:43 UTC","environment_ids":[]},{"id":20,"version":"4.0","published":"2021-06-29
-        08:33:48 UTC","environment_ids":[]},{"id":21,"version":"5.0","published":"2021-06-29
-        08:33:54 UTC","environment_ids":[6]}],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"6.0","last_published":"2021-06-29
-        08:33:54 UTC","permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
+      string: '{"total":3,"subtotal":2,"selectable":2,"page":1,"per_page":"4294967296","error":null,"search":"name
+        ~ cleanup","sort":{"by":"name","order":"asc"},"results":[{"composite":true,"component_ids":[46],"duplicate_repositories_to_publish":[],"default":false,"version_count":3,"latest_version":"5.0","latest_version_id":51,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":1,"related_composite_cvs":[],"filtered":false,"repository_ids":[],"id":19,"name":"cleanup-testccv","label":"cleanup-testccv","description":null,"organization_id":26,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":26},"created_at":"2024-07-09
+        14:30:02 UTC","updated_at":"2024-07-09 14:30:58 UTC","last_task":{"id":"aec3029e-8c8f-4ae7-bba9-cb504e1b4d0e","started_at":"2024-07-09
+        14:30:58 UTC","result":"success","last_sync_words":"1 minute"},"latest_version_environments":[{"id":15,"name":"Library","label":"Library"}],"repositories":[],"versions":[{"id":51,"version":"5.0","published":"2024-07-09
+        14:30:58 UTC","description":null,"environment_ids":[15],"filters_applied":false,"published_at_words":"1
+        minute"},{"id":50,"version":"4.0","published":"2024-07-09 14:30:52 UTC","description":null,"environment_ids":[],"filters_applied":false,"published_at_words":"1
+        minute"},{"id":49,"version":"3.0","published":"2024-07-09 14:30:47 UTC","description":null,"environment_ids":[],"filters_applied":false,"published_at_words":"1
+        minute"}],"components":[{"id":46,"name":"cleanup-testcv 5.0","content_view_id":18,"version":"5.0","environments":[{"id":15,"name":"Library","label":"Library"}],"content_view":{"id":18,"name":"cleanup-testcv","label":"cleanup-testcv","description":null,"next_version":6,"latest_version":"5.0"},"repositories":[]}],"content_view_components":[{"latest":true,"id":2,"created_at":"2024-07-09
+        14:30:03 UTC","updated_at":"2024-07-09 14:30:03 UTC","composite_content_view":{"id":19,"name":"cleanup-testccv","label":"cleanup-testccv","description":null,"next_version":6,"latest_version":"5.0","version_count":3},"content_view":{"id":18,"name":"cleanup-testcv","label":"cleanup-testcv","description":null,"next_version":6,"latest_version":"5.0","version_count":3},"content_view_version":{"id":46,"name":"cleanup-testcv
+        5.0","content_view_id":18,"version":"5.0","content_view":{"id":18,"name":"cleanup-testcv","label":"cleanup-testcv","description":null},"environments":[{"id":15,"name":"Library","label":"Library"}],"repositories":[]},"component_content_view_versions":[{"id":46,"version":"5.0","description":null,"published_at_words":"1
+        minute"},{"id":45,"version":"4.0","description":null,"published_at_words":"1
+        minute"},{"id":44,"version":"3.0","description":null,"published_at_words":"1
+        minute"}]}],"activation_keys":[],"hosts":[],"next_version":"6.0","last_published":"2024-07-09
+        14:30:58 UTC","environments":[{"id":15,"label":"Library","name":"Library","activation_keys":[],"hosts":[],"permissions":{"readable":true}}]},{"composite":false,"component_ids":[],"duplicate_repositories_to_publish":[],"default":false,"version_count":3,"latest_version":"5.0","latest_version_id":46,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":1,"related_composite_cvs":[{"id":19,"name":"cleanup-testccv"}],"filtered":false,"repository_ids":[],"id":18,"name":"cleanup-testcv","label":"cleanup-testcv","description":null,"organization_id":26,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":26},"created_at":"2024-07-09
+        14:30:00 UTC","updated_at":"2024-07-09 14:30:29 UTC","last_task":{"id":"6da31077-1ece-4449-882a-4057308558e4","started_at":"2024-07-09
+        14:30:29 UTC","result":"success","last_sync_words":"1 minute"},"latest_version_environments":[{"id":15,"name":"Library","label":"Library"}],"repositories":[],"versions":[{"id":46,"version":"5.0","published":"2024-07-09
+        14:30:29 UTC","description":null,"environment_ids":[15],"filters_applied":false,"published_at_words":"1
+        minute"},{"id":45,"version":"4.0","published":"2024-07-09 14:30:24 UTC","description":null,"environment_ids":[],"filters_applied":false,"published_at_words":"1
+        minute"},{"id":44,"version":"3.0","published":"2024-07-09 14:30:18 UTC","description":null,"environment_ids":[],"filters_applied":false,"published_at_words":"1
+        minute"}],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"6.0","last_published":"2024-07-09
+        14:30:29 UTC","environments":[{"id":15,"label":"Library","name":"Library","activation_keys":[],"hosts":[],"permissions":{"readable":true}}]}]}
 
         '
     headers:
@@ -157,6 +156,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '4617'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -168,15 +169,13 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 7; Test Organization
+      - 26; Test Organization
       Foreman_version:
-      - 2.5.0
+      - 3.12.0-develop
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -187,8 +186,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '3773'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/content_view_version_cleanup_role-8.yml
+++ b/tests/test_playbooks/fixtures/content_view_version_cleanup_role-8.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"2.5.0","api_version":2}'
+      string: '{"satellite_version":"6.16.0","result":"ok","status":200,"version":"3.12.0-develop","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '100'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.5.0
+      - 3.12.0-develop
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -50,8 +50,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '62'
     status:
       code: 200
       message: OK
@@ -70,17 +68,18 @@ interactions:
     uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
-        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\"\
-        :\"Test_Organization\",\"created_at\":\"2021-06-29 08:33:23 UTC\",\"updated_at\"\
-        :\"2021-06-29 08:33:25 UTC\",\"id\":7,\"name\":\"Test Organization\",\"title\"\
-        :\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+        4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2024-07-09
+        14:29:57 UTC\",\"updated_at\":\"2024-07-09 14:29:59 UTC\",\"id\":26,\"name\":\"Test
+        Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '389'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -94,13 +93,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.5.0
+      - 3.12.0-develop
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -111,8 +108,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '388'
     status:
       code: 200
       message: OK
@@ -128,20 +123,23 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/7/content_views?search=name%3D%22cleanup-testccv%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/26/content_views?search=name%3D%22cleanup-testccv%22&per_page=4294967296
   response:
     body:
-      string: '{"total":3,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"cleanup-testccv\"","sort":{"by":"name","order":"asc"},"results":[{"composite":true,"component_ids":[21],"default":false,"version_count":3,"latest_version":"5.0","latest_version_id":26,"auto_publish":false,"solve_dependencies":false,"import_only":false,"repository_ids":[],"id":10,"name":"cleanup-testccv","label":"cleanup-testccv","description":null,"organization_id":7,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":7},"created_at":"2021-06-29
-        08:33:29 UTC","updated_at":"2021-06-29 08:34:22 UTC","last_task":{"id":"23e7eca9-3adb-48a2-9778-a4f4e6db4435","result":"successful","last_sync_words":"1
-        minute"},"latest_version_environments":[{"id":6,"name":"Library","label":"Library"}],"environments":[{"id":6,"name":"Library","label":"Library","permissions":{"readable":true}}],"repositories":[],"versions":[{"id":24,"version":"3.0","published":"2021-06-29
-        08:34:11 UTC","environment_ids":[]},{"id":25,"version":"4.0","published":"2021-06-29
-        08:34:16 UTC","environment_ids":[]},{"id":26,"version":"5.0","published":"2021-06-29
-        08:34:22 UTC","environment_ids":[6]}],"components":[{"id":21,"name":"cleanup-testcv
-        5.0","content_view_id":9,"version":"5.0","environments":[{"id":6,"name":"Library","label":"Library"}],"content_view":{"id":9,"name":"cleanup-testcv","label":"cleanup-testcv","description":null,"next_version":6,"latest_version":"5.0"},"repositories":[]}],"content_view_components":[{"latest":true,"id":2,"created_at":"2021-06-29
-        08:33:29 UTC","updated_at":"2021-06-29 08:33:29 UTC","composite_content_view":{"id":10,"name":"cleanup-testccv","label":"cleanup-testccv","description":null,"next_version":6,"latest_version":"5.0","version_count":3},"content_view":{"id":9,"name":"cleanup-testcv","label":"cleanup-testcv","description":null,"next_version":6,"latest_version":"5.0","version_count":3},"content_view_version":{"id":21,"name":"cleanup-testcv
-        5.0","content_view_id":9,"version":"5.0","content_view":{"id":9,"name":"cleanup-testcv","label":"cleanup-testcv","description":null},"environments":[{"id":6,"name":"Library","label":"Library"}],"repositories":[]}}],"activation_keys":[],"hosts":[],"next_version":"6.0","last_published":"2021-06-29
-        08:34:22 UTC","permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
+      string: '{"total":3,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"cleanup-testccv\"","sort":{"by":"name","order":"asc"},"results":[{"composite":true,"component_ids":[46],"duplicate_repositories_to_publish":[],"default":false,"version_count":3,"latest_version":"5.0","latest_version_id":51,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":1,"related_composite_cvs":[],"filtered":false,"repository_ids":[],"id":19,"name":"cleanup-testccv","label":"cleanup-testccv","description":null,"organization_id":26,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":26},"created_at":"2024-07-09
+        14:30:02 UTC","updated_at":"2024-07-09 14:30:58 UTC","last_task":{"id":"aec3029e-8c8f-4ae7-bba9-cb504e1b4d0e","started_at":"2024-07-09
+        14:30:58 UTC","result":"success","last_sync_words":"1 minute"},"latest_version_environments":[{"id":15,"name":"Library","label":"Library"}],"repositories":[],"versions":[{"id":51,"version":"5.0","published":"2024-07-09
+        14:30:58 UTC","description":null,"environment_ids":[15],"filters_applied":false,"published_at_words":"1
+        minute"},{"id":50,"version":"4.0","published":"2024-07-09 14:30:52 UTC","description":null,"environment_ids":[],"filters_applied":false,"published_at_words":"1
+        minute"},{"id":49,"version":"3.0","published":"2024-07-09 14:30:47 UTC","description":null,"environment_ids":[],"filters_applied":false,"published_at_words":"1
+        minute"}],"components":[{"id":46,"name":"cleanup-testcv 5.0","content_view_id":18,"version":"5.0","environments":[{"id":15,"name":"Library","label":"Library"}],"content_view":{"id":18,"name":"cleanup-testcv","label":"cleanup-testcv","description":null,"next_version":6,"latest_version":"5.0"},"repositories":[]}],"content_view_components":[{"latest":true,"id":2,"created_at":"2024-07-09
+        14:30:03 UTC","updated_at":"2024-07-09 14:30:03 UTC","composite_content_view":{"id":19,"name":"cleanup-testccv","label":"cleanup-testccv","description":null,"next_version":6,"latest_version":"5.0","version_count":3},"content_view":{"id":18,"name":"cleanup-testcv","label":"cleanup-testcv","description":null,"next_version":6,"latest_version":"5.0","version_count":3},"content_view_version":{"id":46,"name":"cleanup-testcv
+        5.0","content_view_id":18,"version":"5.0","content_view":{"id":18,"name":"cleanup-testcv","label":"cleanup-testcv","description":null},"environments":[{"id":15,"name":"Library","label":"Library"}],"repositories":[]},"component_content_view_versions":[{"id":46,"version":"5.0","description":null,"published_at_words":"1
+        minute"},{"id":45,"version":"4.0","description":null,"published_at_words":"1
+        minute"},{"id":44,"version":"3.0","description":null,"published_at_words":"1
+        minute"}]}],"activation_keys":[],"hosts":[],"next_version":"6.0","last_published":"2024-07-09
+        14:30:58 UTC","environments":[{"id":15,"label":"Library","name":"Library","activation_keys":[],"hosts":[],"permissions":{"readable":true}}]}]}
 
         '
     headers:
@@ -149,6 +147,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '3002'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -160,15 +160,13 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 7; Test Organization
+      - 26; Test Organization
       Foreman_version:
-      - 2.5.0
+      - 3.12.0-develop
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -179,8 +177,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '2453'
     status:
       code: 200
       message: OK
@@ -196,21 +192,20 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_view_versions?search=content_view_id%3D10%2Cversion%3D4.0&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_view_versions?search=content_view_id%3D19%2Cversion%3D4.0&per_page=4294967296
   response:
     body:
-      string: '{"total":9,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"content_view_id=10,version=4.0","sort":{"by":"version","order":"desc"},"results":[{"version":"4.0","major":4,"minor":0,"composite_content_view_ids":[],"published_in_composite_content_view_ids":[],"content_view_id":10,"default":false,"description":null,"id":25,"name":"cleanup-testccv
-        4.0","created_at":"2021-06-29 08:34:16 UTC","updated_at":"2021-06-29 08:34:17
-        UTC","content_view":{"id":10,"name":"cleanup-testccv","label":"cleanup-testccv"},"composite_content_views":[],"composite_content_view_versions":[],"published_in_composite_content_views":[],"environments":[],"repositories":[],"last_event":{"user":"admin","status":"successful","description":null,"action":"publish","created_at":"2021-06-29
-        08:34:16 UTC","updated_at":"2021-06-29 08:34:17 UTC","environment":null,"task":{"id":"c8357e30-f9da-411d-bf0a-1d1859a9f0c0","label":"Actions::Katello::ContentView::Publish","pending":false,"action":"Publish
-        content view ''cleanup-testccv''; organization ''Test Organization''","username":"admin","started_at":"2021-06-29
-        08:34:16 UTC","ended_at":"2021-06-29 08:34:17 UTC","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":10,"name":"cleanup-testccv","label":"cleanup-testccv"},"organization":{"id":7,"name":"Test
-        Organization","label":"Test_Organization"},"services_checked":["candlepin","candlepin_auth"],"history_id":24,"content_view_id":10,"auto_publish_composite_ids":[],"content_view_version_name":"cleanup-testccv
-        4.0","content_view_version_id":25,"environment_id":6,"user_id":4,"skip_promotion":null,"current_request_id":"aae78cbc-0474-4aff-b7b9-d78ccad67877","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{"content_view_id":10,"content_view_version_id":25,"skip_promotion":null},"humanized":{"action":"Publish","input":[["content_view",{"text":"content
-        view ''cleanup-testccv''","link":"/content_views/10/versions"}],["organization",{"text":"organization
-        ''Test Organization''","link":"/organizations/7/edit"}]],"output":"","errors":[]},"cli_example":null,"start_at":"2021-06-29
-        08:34:16 UTC","available_actions":{"cancellable":false,"resumable":false}},"version":"4.0","publish":true,"version_id":25,"triggered_by":null,"triggered_by_id":null},"active_history":[],"ansible
-        collection_count":0,"deb_count":0,"docker_manifest_count":0,"docker_manifest_list_count":0,"docker_tag_count":0,"file_count":0,"rpm_count":0,"modulemd_count":0,"erratum_count":0,"package_group_count":0,"srpm_count":0,"module_stream_count":0,"package_count":0,"ostree_branch_count":null,"errata_counts":{"security":null,"bugfix":0,"enhancement":0,"total":null},"permissions":{"deletable":true}}]}
+      string: '{"total":8,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"content_view_id=19,version=4.0","sort":{"by":"version","order":"desc"},"results":[{"version":"4.0","major":4,"minor":0,"composite_content_view_ids":[],"published_in_composite_content_view_ids":[],"content_view_id":19,"default":false,"description":null,"id":50,"name":"cleanup-testccv
+        4.0","created_at":"2024-07-09 14:30:52 UTC","updated_at":"2024-07-09 14:30:53
+        UTC","content_view":{"id":19,"name":"cleanup-testccv","label":"cleanup-testccv","generated_for":"none"},"composite_content_views":[],"composite_content_view_versions":[],"published_in_composite_content_views":[],"environments":[],"repositories":[],"last_event":{"user":"admin","status":"successful","description":null,"action":"publish","created_at":"2024-07-09
+        14:30:52 UTC","updated_at":"2024-07-09 14:30:53 UTC","environment":null,"task":{"id":"2c367519-3227-440c-a930-be9d588d36d9","label":"Actions::Katello::ContentView::Publish","pending":false,"action":"Publish
+        content view ''cleanup-testccv''; organization ''Test Organization''","username":"admin","started_at":"2024-07-09
+        14:30:52 UTC","ended_at":"2024-07-09 14:30:53 UTC","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":19,"name":"cleanup-testccv","label":"cleanup-testccv"},"organization":{"id":26,"name":"Test
+        Organization","label":"Test_Organization"},"services_checked":["candlepin","candlepin_auth"],"history_id":74,"content_view_id":19,"auto_publish_composite_ids":[],"content_view_version_name":"cleanup-testccv
+        4.0","content_view_version_id":50,"environment_id":15,"user_id":4,"skip_promotion":null,"current_request_id":"d25b6e86-2942-49bf-99f2-f99aa1fc5ec5","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{"content_view_id":19,"content_view_version_id":50,"skip_promotion":null,"history_id":74},"humanized":{"action":"Publish","input":[["content_view",{"text":"content
+        view ''cleanup-testccv''","link":"/content_views/19/versions"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/26/edit"}]],"output":"","errors":[]},"cli_example":null,"start_at":"2024-07-09
+        14:30:52 UTC","available_actions":{"cancellable":false,"resumable":false}},"version":"4.0","publish":true,"version_id":50,"triggered_by":null,"triggered_by_id":null},"active_history":[],"ansible_collection_count":0,"docker_manifest_count":0,"docker_manifest_list_count":0,"docker_tag_count":0,"file_count":0,"rpm_count":0,"modulemd_count":0,"erratum_count":0,"package_group_count":0,"srpm_count":0,"module_stream_count":0,"package_count":0,"component_view_count":1,"ansible_collection_repository_count":0,"docker_repository_count":0,"file_repository_count":0,"yum_repository_count":0,"errata_counts":{"security":0,"bugfix":0,"enhancement":0,"total":0},"permissions":{"deletable":true},"filters_applied":false}]}
 
         '
     headers:
@@ -218,6 +213,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '2928'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -231,13 +228,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.5.0
+      - 3.12.0-develop
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -248,8 +243,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '2750'
     status:
       code: 200
       message: OK
@@ -267,12 +260,12 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: DELETE
-    uri: https://foreman.example.org/katello/api/content_view_versions/25
+    uri: https://foreman.example.org/katello/api/content_view_versions/50
   response:
     body:
-      string: '  {"id":"beee2d59-7eca-487d-9a4f-3253eda55627","label":"Actions::Katello::ContentViewVersion::Destroy","pending":true,"action":"Destroy","username":"admin","started_at":"2021-06-29
-        08:34:55 UTC","ended_at":null,"state":"planned","result":"pending","progress":0.0,"input":{"id":25,"current_request_id":"035fb465-04e7-463d-8ac2-bd6d5bf93d4b","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{},"humanized":{"action":"Destroy","input":"","output":"","errors":[]},"cli_example":null,"start_at":"2021-06-29
-        08:34:55 UTC","available_actions":{"cancellable":false,"resumable":false}}
+      string: '  {"id":"2781ee3d-4b8e-4c51-97f2-b75627426387","label":"Actions::Katello::ContentViewVersion::Destroy","pending":true,"action":"Destroy","username":"admin","started_at":"2024-07-09
+        14:31:32 UTC","ended_at":null,"state":"planned","result":"pending","progress":0.0,"input":{"id":50,"docker_cleanup":false,"current_request_id":"40daf60e-b9d5-42aa-bb9e-d6375347591e","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{},"humanized":{"action":"Destroy","input":"","output":"","errors":[]},"cli_example":null,"start_at":"2024-07-09
+        14:31:32 UTC","available_actions":{"cancellable":false,"resumable":false}}
 
         '
     headers:
@@ -293,7 +286,7 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.5.0
+      - 3.12.0-develop
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
@@ -325,17 +318,19 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/foreman_tasks/api/tasks/beee2d59-7eca-487d-9a4f-3253eda55627
+    uri: https://foreman.example.org/foreman_tasks/api/tasks/2781ee3d-4b8e-4c51-97f2-b75627426387
   response:
     body:
-      string: '{"id":"beee2d59-7eca-487d-9a4f-3253eda55627","label":"Actions::Katello::ContentViewVersion::Destroy","pending":false,"action":"Destroy","username":"admin","started_at":"2021-06-29
-        08:34:55 UTC","ended_at":"2021-06-29 08:34:55 UTC","state":"stopped","result":"success","progress":1.0,"input":{"id":25,"current_request_id":"035fb465-04e7-463d-8ac2-bd6d5bf93d4b","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{},"humanized":{"action":"Destroy","input":"","output":"","errors":[]},"cli_example":null,"start_at":"2021-06-29
-        08:34:55 UTC","available_actions":{"cancellable":false,"resumable":false}}'
+      string: '{"id":"2781ee3d-4b8e-4c51-97f2-b75627426387","label":"Actions::Katello::ContentViewVersion::Destroy","pending":false,"action":"Destroy","username":"admin","started_at":"2024-07-09
+        14:31:32 UTC","ended_at":"2024-07-09 14:31:32 UTC","duration":"0.084371","state":"stopped","result":"success","progress":1.0,"input":{"id":50,"docker_cleanup":false,"current_request_id":"40daf60e-b9d5-42aa-bb9e-d6375347591e","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{},"humanized":{"action":"Destroy","input":"","output":"","errors":[]},"cli_example":null,"start_at":"2024-07-09
+        14:31:32 UTC","available_actions":{"cancellable":false,"resumable":false}}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '705'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -349,13 +344,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.5.0
+      - 3.12.0-develop
       Keep-Alive:
       - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -366,8 +359,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '660'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/content_view_version_cleanup_role-9.yml
+++ b/tests/test_playbooks/fixtures/content_view_version_cleanup_role-9.yml
@@ -14,12 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"2.5.0","api_version":2}'
+      string: '{"satellite_version":"6.16.0","result":"ok","status":200,"version":"3.12.0-develop","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '100'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -33,13 +35,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.5.0
+      - 3.12.0-develop
       Keep-Alive:
       - timeout=15, max=100
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -50,8 +50,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '62'
     status:
       code: 200
       message: OK
@@ -70,17 +68,18 @@ interactions:
     uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
-        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\"\
-        :\"Test_Organization\",\"created_at\":\"2021-06-29 08:33:23 UTC\",\"updated_at\"\
-        :\"2021-06-29 08:33:25 UTC\",\"id\":7,\"name\":\"Test Organization\",\"title\"\
-        :\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+        4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2024-07-09
+        14:29:57 UTC\",\"updated_at\":\"2024-07-09 14:29:59 UTC\",\"id\":26,\"name\":\"Test
+        Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '389'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -94,13 +93,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.5.0
+      - 3.12.0-develop
       Keep-Alive:
       - timeout=15, max=99
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -111,8 +108,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '388'
     status:
       code: 200
       message: OK
@@ -128,19 +123,22 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/7/content_views?search=name%3D%22cleanup-testccv%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/26/content_views?search=name%3D%22cleanup-testccv%22&per_page=4294967296
   response:
     body:
-      string: '{"total":3,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"cleanup-testccv\"","sort":{"by":"name","order":"asc"},"results":[{"composite":true,"component_ids":[21],"default":false,"version_count":2,"latest_version":"5.0","latest_version_id":26,"auto_publish":false,"solve_dependencies":false,"import_only":false,"repository_ids":[],"id":10,"name":"cleanup-testccv","label":"cleanup-testccv","description":null,"organization_id":7,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":7},"created_at":"2021-06-29
-        08:33:29 UTC","updated_at":"2021-06-29 08:34:22 UTC","last_task":{"id":"23e7eca9-3adb-48a2-9778-a4f4e6db4435","result":"successful","last_sync_words":"1
-        minute"},"latest_version_environments":[{"id":6,"name":"Library","label":"Library"}],"environments":[{"id":6,"name":"Library","label":"Library","permissions":{"readable":true}}],"repositories":[],"versions":[{"id":24,"version":"3.0","published":"2021-06-29
-        08:34:11 UTC","environment_ids":[]},{"id":26,"version":"5.0","published":"2021-06-29
-        08:34:22 UTC","environment_ids":[6]}],"components":[{"id":21,"name":"cleanup-testcv
-        5.0","content_view_id":9,"version":"5.0","environments":[{"id":6,"name":"Library","label":"Library"}],"content_view":{"id":9,"name":"cleanup-testcv","label":"cleanup-testcv","description":null,"next_version":6,"latest_version":"5.0"},"repositories":[]}],"content_view_components":[{"latest":true,"id":2,"created_at":"2021-06-29
-        08:33:29 UTC","updated_at":"2021-06-29 08:33:29 UTC","composite_content_view":{"id":10,"name":"cleanup-testccv","label":"cleanup-testccv","description":null,"next_version":6,"latest_version":"5.0","version_count":2},"content_view":{"id":9,"name":"cleanup-testcv","label":"cleanup-testcv","description":null,"next_version":6,"latest_version":"5.0","version_count":3},"content_view_version":{"id":21,"name":"cleanup-testcv
-        5.0","content_view_id":9,"version":"5.0","content_view":{"id":9,"name":"cleanup-testcv","label":"cleanup-testcv","description":null},"environments":[{"id":6,"name":"Library","label":"Library"}],"repositories":[]}}],"activation_keys":[],"hosts":[],"next_version":"6.0","last_published":"2021-06-29
-        08:34:22 UTC","permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
+      string: '{"total":3,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"cleanup-testccv\"","sort":{"by":"name","order":"asc"},"results":[{"composite":true,"component_ids":[46],"duplicate_repositories_to_publish":[],"default":false,"version_count":2,"latest_version":"5.0","latest_version_id":51,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":1,"related_composite_cvs":[],"filtered":false,"repository_ids":[],"id":19,"name":"cleanup-testccv","label":"cleanup-testccv","description":null,"organization_id":26,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":26},"created_at":"2024-07-09
+        14:30:02 UTC","updated_at":"2024-07-09 14:30:58 UTC","last_task":{"id":"aec3029e-8c8f-4ae7-bba9-cb504e1b4d0e","started_at":"2024-07-09
+        14:30:58 UTC","result":"success","last_sync_words":"1 minute"},"latest_version_environments":[{"id":15,"name":"Library","label":"Library"}],"repositories":[],"versions":[{"id":51,"version":"5.0","published":"2024-07-09
+        14:30:58 UTC","description":null,"environment_ids":[15],"filters_applied":false,"published_at_words":"1
+        minute"},{"id":49,"version":"3.0","published":"2024-07-09 14:30:47 UTC","description":null,"environment_ids":[],"filters_applied":false,"published_at_words":"1
+        minute"}],"components":[{"id":46,"name":"cleanup-testcv 5.0","content_view_id":18,"version":"5.0","environments":[{"id":15,"name":"Library","label":"Library"}],"content_view":{"id":18,"name":"cleanup-testcv","label":"cleanup-testcv","description":null,"next_version":6,"latest_version":"5.0"},"repositories":[]}],"content_view_components":[{"latest":true,"id":2,"created_at":"2024-07-09
+        14:30:03 UTC","updated_at":"2024-07-09 14:30:03 UTC","composite_content_view":{"id":19,"name":"cleanup-testccv","label":"cleanup-testccv","description":null,"next_version":6,"latest_version":"5.0","version_count":2},"content_view":{"id":18,"name":"cleanup-testcv","label":"cleanup-testcv","description":null,"next_version":6,"latest_version":"5.0","version_count":3},"content_view_version":{"id":46,"name":"cleanup-testcv
+        5.0","content_view_id":18,"version":"5.0","content_view":{"id":18,"name":"cleanup-testcv","label":"cleanup-testcv","description":null},"environments":[{"id":15,"name":"Library","label":"Library"}],"repositories":[]},"component_content_view_versions":[{"id":46,"version":"5.0","description":null,"published_at_words":"1
+        minute"},{"id":45,"version":"4.0","description":null,"published_at_words":"1
+        minute"},{"id":44,"version":"3.0","description":null,"published_at_words":"1
+        minute"}]}],"activation_keys":[],"hosts":[],"next_version":"6.0","last_published":"2024-07-09
+        14:30:58 UTC","environments":[{"id":15,"label":"Library","name":"Library","activation_keys":[],"hosts":[],"permissions":{"readable":true}}]}]}
 
         '
     headers:
@@ -148,6 +146,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '2842'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -159,15 +159,13 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 7; Test Organization
+      - 26; Test Organization
       Foreman_version:
-      - 2.5.0
+      - 3.12.0-develop
       Keep-Alive:
       - timeout=15, max=98
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -178,8 +176,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '2368'
     status:
       code: 200
       message: OK
@@ -195,21 +191,20 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_view_versions?search=content_view_id%3D10%2Cversion%3D3.0&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_view_versions?search=content_view_id%3D19%2Cversion%3D3.0&per_page=4294967296
   response:
     body:
-      string: '{"total":8,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"content_view_id=10,version=3.0","sort":{"by":"version","order":"desc"},"results":[{"version":"3.0","major":3,"minor":0,"composite_content_view_ids":[],"published_in_composite_content_view_ids":[],"content_view_id":10,"default":false,"description":null,"id":24,"name":"cleanup-testccv
-        3.0","created_at":"2021-06-29 08:34:11 UTC","updated_at":"2021-06-29 08:34:11
-        UTC","content_view":{"id":10,"name":"cleanup-testccv","label":"cleanup-testccv"},"composite_content_views":[],"composite_content_view_versions":[],"published_in_composite_content_views":[],"environments":[],"repositories":[],"last_event":{"user":"admin","status":"successful","description":null,"action":"publish","created_at":"2021-06-29
-        08:34:11 UTC","updated_at":"2021-06-29 08:34:11 UTC","environment":null,"task":{"id":"a3b6422a-290e-4c79-971a-37dc112e5d4f","label":"Actions::Katello::ContentView::Publish","pending":false,"action":"Publish
-        content view ''cleanup-testccv''; organization ''Test Organization''","username":"admin","started_at":"2021-06-29
-        08:34:11 UTC","ended_at":"2021-06-29 08:34:11 UTC","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":10,"name":"cleanup-testccv","label":"cleanup-testccv"},"organization":{"id":7,"name":"Test
-        Organization","label":"Test_Organization"},"services_checked":["candlepin","candlepin_auth"],"history_id":23,"content_view_id":10,"auto_publish_composite_ids":[],"content_view_version_name":"cleanup-testccv
-        3.0","content_view_version_id":24,"environment_id":6,"user_id":4,"skip_promotion":null,"current_request_id":"3de49503-9c5b-429a-9a63-ef02685bc57e","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{"content_view_id":10,"content_view_version_id":24,"skip_promotion":null},"humanized":{"action":"Publish","input":[["content_view",{"text":"content
-        view ''cleanup-testccv''","link":"/content_views/10/versions"}],["organization",{"text":"organization
-        ''Test Organization''","link":"/organizations/7/edit"}]],"output":"","errors":[]},"cli_example":null,"start_at":"2021-06-29
-        08:34:11 UTC","available_actions":{"cancellable":false,"resumable":false}},"version":"3.0","publish":true,"version_id":24,"triggered_by":null,"triggered_by_id":null},"active_history":[],"ansible
-        collection_count":0,"deb_count":0,"docker_manifest_count":0,"docker_manifest_list_count":0,"docker_tag_count":0,"file_count":0,"rpm_count":0,"modulemd_count":0,"erratum_count":0,"package_group_count":0,"srpm_count":0,"module_stream_count":0,"package_count":0,"ostree_branch_count":null,"errata_counts":{"security":null,"bugfix":0,"enhancement":0,"total":null},"permissions":{"deletable":true}}]}
+      string: '{"total":7,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"content_view_id=19,version=3.0","sort":{"by":"version","order":"desc"},"results":[{"version":"3.0","major":3,"minor":0,"composite_content_view_ids":[],"published_in_composite_content_view_ids":[],"content_view_id":19,"default":false,"description":null,"id":49,"name":"cleanup-testccv
+        3.0","created_at":"2024-07-09 14:30:47 UTC","updated_at":"2024-07-09 14:30:47
+        UTC","content_view":{"id":19,"name":"cleanup-testccv","label":"cleanup-testccv","generated_for":"none"},"composite_content_views":[],"composite_content_view_versions":[],"published_in_composite_content_views":[],"environments":[],"repositories":[],"last_event":{"user":"admin","status":"successful","description":null,"action":"publish","created_at":"2024-07-09
+        14:30:47 UTC","updated_at":"2024-07-09 14:30:47 UTC","environment":null,"task":{"id":"e91ace72-655d-412c-b3ee-03526865df90","label":"Actions::Katello::ContentView::Publish","pending":false,"action":"Publish
+        content view ''cleanup-testccv''; organization ''Test Organization''","username":"admin","started_at":"2024-07-09
+        14:30:47 UTC","ended_at":"2024-07-09 14:30:47 UTC","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":19,"name":"cleanup-testccv","label":"cleanup-testccv"},"organization":{"id":26,"name":"Test
+        Organization","label":"Test_Organization"},"services_checked":["candlepin","candlepin_auth"],"history_id":73,"content_view_id":19,"auto_publish_composite_ids":[],"content_view_version_name":"cleanup-testccv
+        3.0","content_view_version_id":49,"environment_id":15,"user_id":4,"skip_promotion":null,"current_request_id":"9c140475-bd69-45ea-9b91-78e20126cb74","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{"content_view_id":19,"content_view_version_id":49,"skip_promotion":null,"history_id":73},"humanized":{"action":"Publish","input":[["content_view",{"text":"content
+        view ''cleanup-testccv''","link":"/content_views/19/versions"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/26/edit"}]],"output":"","errors":[]},"cli_example":null,"start_at":"2024-07-09
+        14:30:47 UTC","available_actions":{"cancellable":false,"resumable":false}},"version":"3.0","publish":true,"version_id":49,"triggered_by":null,"triggered_by_id":null},"active_history":[],"ansible_collection_count":0,"docker_manifest_count":0,"docker_manifest_list_count":0,"docker_tag_count":0,"file_count":0,"rpm_count":0,"modulemd_count":0,"erratum_count":0,"package_group_count":0,"srpm_count":0,"module_stream_count":0,"package_count":0,"component_view_count":1,"ansible_collection_repository_count":0,"docker_repository_count":0,"file_repository_count":0,"yum_repository_count":0,"errata_counts":{"security":0,"bugfix":0,"enhancement":0,"total":0},"permissions":{"deletable":true},"filters_applied":false}]}
 
         '
     headers:
@@ -217,6 +212,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '2928'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -230,13 +227,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.5.0
+      - 3.12.0-develop
       Keep-Alive:
       - timeout=15, max=97
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -247,8 +242,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '2750'
     status:
       code: 200
       message: OK
@@ -266,12 +259,12 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: DELETE
-    uri: https://foreman.example.org/katello/api/content_view_versions/24
+    uri: https://foreman.example.org/katello/api/content_view_versions/49
   response:
     body:
-      string: '  {"id":"d0fefbea-cf06-4105-8770-0c86bfed4b97","label":"Actions::Katello::ContentViewVersion::Destroy","pending":true,"action":"Destroy","username":"admin","started_at":"2021-06-29
-        08:35:00 UTC","ended_at":null,"state":"planned","result":"pending","progress":0.0,"input":{"id":24,"current_request_id":"01d73bf6-81aa-4701-b064-677926c78a29","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{},"humanized":{"action":"Destroy","input":"","output":"","errors":[]},"cli_example":null,"start_at":"2021-06-29
-        08:35:00 UTC","available_actions":{"cancellable":false,"resumable":false}}
+      string: '  {"id":"f2de7806-8afa-4faa-abd8-83b9e0c15266","label":"Actions::Katello::ContentViewVersion::Destroy","pending":true,"action":"Destroy","username":"admin","started_at":"2024-07-09
+        14:31:37 UTC","ended_at":null,"state":"planned","result":"pending","progress":0.0,"input":{"id":49,"docker_cleanup":false,"current_request_id":"5bffd708-7811-42b0-bd59-bde69c93d42e","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{},"humanized":{"action":"Destroy","input":"","output":"","errors":[]},"cli_example":null,"start_at":"2024-07-09
+        14:31:37 UTC","available_actions":{"cancellable":false,"resumable":false}}
 
         '
     headers:
@@ -292,7 +285,7 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.5.0
+      - 3.12.0-develop
       Keep-Alive:
       - timeout=15, max=96
       Strict-Transport-Security:
@@ -324,17 +317,19 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/foreman_tasks/api/tasks/d0fefbea-cf06-4105-8770-0c86bfed4b97
+    uri: https://foreman.example.org/foreman_tasks/api/tasks/f2de7806-8afa-4faa-abd8-83b9e0c15266
   response:
     body:
-      string: '{"id":"d0fefbea-cf06-4105-8770-0c86bfed4b97","label":"Actions::Katello::ContentViewVersion::Destroy","pending":false,"action":"Destroy","username":"admin","started_at":"2021-06-29
-        08:35:00 UTC","ended_at":"2021-06-29 08:35:00 UTC","state":"stopped","result":"success","progress":1.0,"input":{"id":24,"current_request_id":"01d73bf6-81aa-4701-b064-677926c78a29","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{},"humanized":{"action":"Destroy","input":"","output":"","errors":[]},"cli_example":null,"start_at":"2021-06-29
-        08:35:00 UTC","available_actions":{"cancellable":false,"resumable":false}}'
+      string: '{"id":"f2de7806-8afa-4faa-abd8-83b9e0c15266","label":"Actions::Katello::ContentViewVersion::Destroy","pending":false,"action":"Destroy","username":"admin","started_at":"2024-07-09
+        14:31:37 UTC","ended_at":"2024-07-09 14:31:38 UTC","duration":"0.08398","state":"stopped","result":"success","progress":1.0,"input":{"id":49,"docker_cleanup":false,"current_request_id":"5bffd708-7811-42b0-bd59-bde69c93d42e","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{},"humanized":{"action":"Destroy","input":"","output":"","errors":[]},"cli_example":null,"start_at":"2024-07-09
+        14:31:37 UTC","available_actions":{"cancellable":false,"resumable":false}}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
+      Content-Length:
+      - '704'
       Content-Security-Policy:
       - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
         img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
@@ -348,13 +343,11 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.5.0
+      - 3.12.0-develop
       Keep-Alive:
       - timeout=15, max=95
       Strict-Transport-Security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -365,8 +358,6 @@ interactions:
       - none
       X-XSS-Protection:
       - 1; mode=block
-      content-length:
-      - '660'
     status:
       code: 200
       message: OK


### PR DESCRIPTION
`remaining_cvs.resources[1].versions|map(attribute='version')|list` was returning `['5.0', '4.0', '3.0']` which is != to `['3.0', '4.0', '5.0']`. Let's use `difference()` and compare them like we would with a set.