### PR TITLE
Make smart_proxy testing work on a live host

### DIFF
--- a/tests/test_playbooks/domain.yml
+++ b/tests/test_playbooks/domain.yml
@@ -47,13 +47,13 @@
       include_tasks: tasks/domain.yml
       vars:
         domain_state: "present"
-        domain_dns_proxy: "{{ foreman_proxy }}"
+        domain_dns_proxy: "{{ foreman_host }}"
         expected_change: true
     - name: assign dns_proxy again, no change
       include_tasks: tasks/domain.yml
       vars:
         domain_state: "present"
-        domain_dns_proxy: "{{ foreman_proxy }}"
+        domain_dns_proxy: "{{ foreman_host }}"
         expected_change: false
     - name: unset dns_proxy
       include_tasks: tasks/domain.yml

--- a/tests/test_playbooks/fixtures/katello_smart_proxy-0.yml
+++ b/tests/test_playbooks/fixtures/katello_smart_proxy-0.yml
@@ -2,213 +2,292 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: [application/json;version=2]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: ['apypie (https://github.com/Apipie/apypie)']
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
     uri: https://foreman.example.org/api/status
   response:
-    body: {string: !!python/unicode '{"result":"ok","status":200,"version":"2.2.0-rc3","api_version":2}'}
+    body:
+      string: '{"satellite_version":"6.16.0","result":"ok","status":200,"version":"3.12.0-develop","api_version":2}'
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      connection: [Keep-Alive]
-      content-length: ['66']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline''
-          ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      foreman_api_version: ['2']
-      foreman_current_location: [; ANY]
-      foreman_current_organization: [; ANY]
-      foreman_version: [2.2.0-rc3]
-      keep-alive: ['timeout=15, max=100']
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Length:
+      - '100'
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.12.0-develop
+      Keep-Alive:
+      - timeout=15, max=100
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json;version=2]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: ['apypie (https://github.com/Apipie/apypie)']
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/environments?per_page=4294967296&search=name%3D%22Dev%22
+    uri: https://foreman.example.org/katello/api/environments?search=name%3D%22Dev%22&per_page=4294967296
   response:
-    body: {string: !!python/unicode '{"total":4,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Dev\"","sort":{"by":"name","order":"asc"},"results":[{"library":false,"registry_name_pattern":null,"registry_unauthenticated_pull":false,"id":3,"name":"Dev","label":"dev","description":null,"organization_id":4,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":4},"created_at":"2020-10-20
-        15:09:27 UTC","updated_at":"2020-10-20 15:09:27 UTC","prior":{"name":"Library","id":2},"successor":{"name":"Test","id":4},"counts":{"content_hosts":0,"content_views":0},"permissions":{"create_lifecycle_environments":true,"view_lifecycle_environments":true,"edit_lifecycle_environments":true,"destroy_lifecycle_environments":true,"promote_or_remove_content_views_to_environments":true}}]}
+    body:
+      string: '{"total":4,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Dev\"","sort":{"by":"name","order":"asc"},"results":[{"library":false,"registry_name_pattern":null,"registry_unauthenticated_pull":false,"id":6,"name":"Dev","label":"dev","description":null,"organization_id":6,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":6},"created_at":"2024-07-10
+        14:13:10 UTC","updated_at":"2024-07-10 14:13:10 UTC","prior":{"name":"Library","id":5},"successor":{"name":"Test","id":7},"counts":{"content_hosts":0,"content_views":0},"permissions":{"create_lifecycle_environments":true,"view_lifecycle_environments":true,"edit_lifecycle_environments":true,"destroy_lifecycle_environments":true,"promote_or_remove_content_views_to_environments":true},"content_views":[]}]}
 
-'}
+        '
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      connection: [Keep-Alive]
-      content-length: ['789']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline''
-          ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      foreman_api_version: ['2']
-      foreman_current_location: [; ANY]
-      foreman_current_organization: [; ANY]
-      foreman_version: [2.2.0-rc3]
-      keep-alive: ['timeout=15, max=99']
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Length:
+      - '823'
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.12.0-develop
+      Keep-Alive:
+      - timeout=15, max=99
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json;version=2]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: ['apypie (https://github.com/Apipie/apypie)']
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/smart_proxies?per_page=4294967296&search=name%3D%22Smart+Proxy%22
+    uri: https://foreman.example.org/api/smart_proxies?search=name%3D%22Smart+Proxy%22&per_page=4294967296
   response:
-    body: {string: !!python/unicode "{\n  \"total\": 2,\n  \"subtotal\": 0,\n  \"page\":
-        1,\n  \"per_page\": 4294967296,\n  \"search\": \"name=\\\"Smart Proxy\\\"\",\n
-        \ \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
-        []\n}\n"}
+    body:
+      string: "{\n  \"total\": 1,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\":
+        4294967296,\n  \"search\": \"name=\\\"Smart Proxy\\\"\",\n  \"sort\": {\n
+        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": []\n}\n"
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      connection: [Keep-Alive]
-      content-length: ['177']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline''
-          ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      foreman_api_version: ['2']
-      foreman_current_location: [; ANY]
-      foreman_current_organization: [; ANY]
-      foreman_version: [2.2.0-rc3]
-      keep-alive: ['timeout=15, max=98']
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Length:
+      - '177'
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.12.0-develop
+      Keep-Alive:
+      - timeout=15, max=98
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
-    body: !!python/unicode '{"smart_proxy": {"url": "http://foreman-proxy.example.com:8000",
-      "name": "Smart Proxy"}}'
+    body: '{"smart_proxy": {"name": "Smart Proxy", "url": "https://foreman-proxy.example.com:9090"}}'
     headers:
-      Accept: [application/json;version=2]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['88']
-      Content-Type: [application/json]
-      User-Agent: ['apypie (https://github.com/Apipie/apypie)']
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '111'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: POST
     uri: https://foreman.example.org/api/smart_proxies
   response:
-    body: {string: !!python/unicode '{"created_at":"2020-10-21 09:15:38 UTC","updated_at":"2020-10-21
-        09:15:38 UTC","name":"Smart Proxy","id":15,"url":"http://foreman-proxy.example.com:8000","remote_execution_pubkey":null,"download_policy":"on_demand","supported_pulp_types":{"pulp2":{"supported_types":["deb","docker","file","puppet","yum"]},"pulp3":{"supported_types":[],"overriden_to_pulp2":[]}},"features":[{"capabilities":[],"name":"Pulp
-        Node","id":3},{"capabilities":[],"name":"Templates","id":1},{"capabilities":[],"name":"Puppet
-        CA","id":9},{"capabilities":[],"name":"Puppet","id":8},{"capabilities":[],"name":"Logs","id":13}],"locations":[],"organizations":[]}'}
+    body:
+      string: '{"created_at":"2024-07-10 14:13:12 UTC","updated_at":"2024-07-10 14:13:12
+        UTC","hosts_count":0,"name":"Smart Proxy","id":12,"url":"https://foreman-proxy.example.com:9090","remote_execution_pubkey":"ssh-rsa
+        AAAAB3NzaC1yc2EAAAADAQABAAABgQCkn5pNuZ47pHDMpL1or9cDtaDJaJXn2EdrmcQBiXQOhoWjSn3R2da7ThZkjXGTirQrMeU8FeDpZUso368rUGU4PFg8JHCwuNF7X+mcOeodK3EJyGHIfsj172xF8wAHUc4tK2MSIKDfVd8MvX4M3qPN80290wmhCh4YrKFA30az96eSP4RDt19m3/qxTXpcmSRyuw1NKr0DUs4lCG08uV4hMpheypT21HM8eb3NSic73fY0nTLOerTwo9BUdQugjdiBNjlA9o9MzSZ6acCiOqAxqYEnVlWKqfgsy/55uBCAi4rO78sIKptvb+g1i1l86HNj/6xtwlrsXNft1p6MwcGDb66naRDARhzNLWUlrM6yqXpOkHEK1w76zaNw0RfwsxFSbZx5TueQQ1QI/DIxcIX0bIBSiVsp39TneEwFQqXu0a7dvst4LAKIOii6GtEc6FIcuCX49x6qe0VsJvHBS3LgKBcfTUUvWkm67qNX3Xaik1MKjvredkcH+7byxL+TiDE=
+        foreman-proxy@foreman-proxy.example.com","download_policy":"on_demand","supported_pulp_types":["ansible_collection","docker","file","yum"],"lifecycle_environments":[],"features":[{"capabilities":[],"name":"Container_Gateway","id":4},{"capabilities":["single","ssh"],"name":"Dynflow","id":17},{"capabilities":["cockpit"],"name":"Script","id":19},{"capabilities":["ansible","certguard","container","core","file","rpm"],"name":"Pulpcore","id":3},{"capabilities":[],"name":"Templates","id":5},{"capabilities":[],"name":"Logs","id":13},{"capabilities":[],"name":"Registration","id":16},{"capabilities":[],"name":"Container_Gateway","id":4},{"capabilities":["single","ssh"],"name":"Dynflow","id":17},{"capabilities":["cockpit"],"name":"Script","id":19},{"capabilities":["ansible","certguard","container","core","file","rpm"],"name":"Pulpcore","id":3},{"capabilities":[],"name":"Templates","id":5},{"capabilities":[],"name":"Logs","id":13},{"capabilities":[],"name":"Registration","id":16}],"locations":[],"organizations":[]}'
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      connection: [Keep-Alive]
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline''
-          ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      foreman_api_version: ['2']
-      foreman_current_location: [; ANY]
-      foreman_current_organization: [; ANY]
-      foreman_version: [2.2.0-rc3]
-      keep-alive: ['timeout=15, max=97']
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      transfer-encoding: [chunked]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-xss-protection: [1; mode=block]
-    status: {code: 201, message: Created}
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Length:
+      - '1813'
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.12.0-develop
+      Keep-Alive:
+      - timeout=15, max=97
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
 - request:
-    body: null
+    body: '{"environment_id": 6}'
     headers:
-      Accept: [application/json;version=2]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: ['apypie (https://github.com/Apipie/apypie)']
-    method: GET
-    uri: https://foreman.example.org/katello/api/capsules/15/content/lifecycle_environments
-  response:
-    body: {string: !!python/unicode '{"total":0,"subtotal":0,"page":null,"per_page":null,"error":null,"search":null,"sort":{"by":null,"order":null},"results":[]}
-
-'}
-    headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      connection: [Keep-Alive]
-      content-length: ['125']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline''
-          ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      foreman_api_version: ['2']
-      foreman_current_location: [; ANY]
-      foreman_current_organization: [; ANY]
-      foreman_version: [2.2.0-rc3]
-      keep-alive: ['timeout=15, max=96']
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
-- request:
-    body: !!python/unicode '{"environment_id": 3}'
-    headers:
-      Accept: [application/json;version=2]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['21']
-      Content-Type: [application/json]
-      User-Agent: ['apypie (https://github.com/Apipie/apypie)']
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '21'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: POST
-    uri: https://foreman.example.org/katello/api/capsules/15/content/lifecycle_environments
+    uri: https://foreman.example.org/katello/api/capsules/12/content/lifecycle_environments
   response:
-    body: {string: !!python/unicode '{"total":1,"subtotal":1,"page":null,"per_page":null,"error":null,"search":null,"sort":{"by":null,"order":null},"results":[{"library":false,"registry_name_pattern":null,"registry_unauthenticated_pull":false,"id":3,"name":"Dev","label":"dev","description":null,"organization_id":4,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":4},"created_at":"2020-10-20
-        15:09:27 UTC","updated_at":"2020-10-20 15:09:27 UTC","prior":{"name":"Library","id":2},"successor":{"name":"Test","id":4},"counts":{"content_hosts":0,"content_views":0},"permissions":{"create_lifecycle_environments":true,"view_lifecycle_environments":true,"edit_lifecycle_environments":true,"destroy_lifecycle_environments":true,"promote_or_remove_content_views_to_environments":true}}]}
+    body:
+      string: '{"total":1,"subtotal":1,"selectable":1,"page":null,"per_page":null,"error":null,"search":null,"sort":{"by":null,"order":null},"results":[{"library":false,"registry_name_pattern":null,"registry_unauthenticated_pull":false,"id":6,"name":"Dev","label":"dev","description":null,"organization_id":6,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":6},"created_at":"2024-07-10
+        14:13:10 UTC","updated_at":"2024-07-10 14:13:10 UTC","prior":{"name":"Library","id":5},"successor":{"name":"Test","id":7},"counts":{"content_hosts":0,"content_views":0},"permissions":{"create_lifecycle_environments":true,"view_lifecycle_environments":true,"edit_lifecycle_environments":true,"destroy_lifecycle_environments":true,"promote_or_remove_content_views_to_environments":true},"content_views":[]}]}
 
-'}
+        '
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      connection: [Keep-Alive]
-      content-length: ['771']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline''
-          ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      foreman_api_version: ['2']
-      foreman_current_location: [; ANY]
-      foreman_current_organization: [; ANY]
-      foreman_version: [2.2.0-rc3]
-      keep-alive: ['timeout=15, max=95']
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Length:
+      - '805'
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.12.0-develop
+      Keep-Alive:
+      - timeout=15, max=96
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/test_playbooks/fixtures/katello_smart_proxy-1.yml
+++ b/tests/test_playbooks/fixtures/katello_smart_proxy-1.yml
@@ -2,178 +2,292 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: [application/json;version=2]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: ['apypie (https://github.com/Apipie/apypie)']
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
     uri: https://foreman.example.org/api/status
   response:
-    body: {string: !!python/unicode '{"result":"ok","status":200,"version":"2.2.0-rc3","api_version":2}'}
+    body:
+      string: '{"satellite_version":"6.16.0","result":"ok","status":200,"version":"3.12.0-develop","api_version":2}'
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      connection: [Keep-Alive]
-      content-length: ['66']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline''
-          ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      foreman_api_version: ['2']
-      foreman_current_location: [; ANY]
-      foreman_current_organization: [; ANY]
-      foreman_version: [2.2.0-rc3]
-      keep-alive: ['timeout=15, max=100']
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Length:
+      - '100'
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.12.0-develop
+      Keep-Alive:
+      - timeout=15, max=100
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json;version=2]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: ['apypie (https://github.com/Apipie/apypie)']
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/environments?per_page=4294967296&search=name%3D%22Dev%22
+    uri: https://foreman.example.org/katello/api/environments?search=name%3D%22Dev%22&per_page=4294967296
   response:
-    body: {string: !!python/unicode '{"total":4,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Dev\"","sort":{"by":"name","order":"asc"},"results":[{"library":false,"registry_name_pattern":null,"registry_unauthenticated_pull":false,"id":3,"name":"Dev","label":"dev","description":null,"organization_id":4,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":4},"created_at":"2020-10-20
-        15:09:27 UTC","updated_at":"2020-10-20 15:09:27 UTC","prior":{"name":"Library","id":2},"successor":{"name":"Test","id":4},"counts":{"content_hosts":0,"content_views":0},"permissions":{"create_lifecycle_environments":true,"view_lifecycle_environments":true,"edit_lifecycle_environments":true,"destroy_lifecycle_environments":true,"promote_or_remove_content_views_to_environments":true}}]}
+    body:
+      string: '{"total":4,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Dev\"","sort":{"by":"name","order":"asc"},"results":[{"library":false,"registry_name_pattern":null,"registry_unauthenticated_pull":false,"id":6,"name":"Dev","label":"dev","description":null,"organization_id":6,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":6},"created_at":"2024-07-10
+        14:13:10 UTC","updated_at":"2024-07-10 14:13:10 UTC","prior":{"name":"Library","id":5},"successor":{"name":"Test","id":7},"counts":{"content_hosts":0,"content_views":0},"permissions":{"create_lifecycle_environments":true,"view_lifecycle_environments":true,"edit_lifecycle_environments":true,"destroy_lifecycle_environments":true,"promote_or_remove_content_views_to_environments":true},"content_views":[]}]}
 
-'}
+        '
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      connection: [Keep-Alive]
-      content-length: ['789']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline''
-          ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      foreman_api_version: ['2']
-      foreman_current_location: [; ANY]
-      foreman_current_organization: [; ANY]
-      foreman_version: [2.2.0-rc3]
-      keep-alive: ['timeout=15, max=99']
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Length:
+      - '823'
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.12.0-develop
+      Keep-Alive:
+      - timeout=15, max=99
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json;version=2]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: ['apypie (https://github.com/Apipie/apypie)']
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/smart_proxies?per_page=4294967296&search=name%3D%22Smart+Proxy%22
+    uri: https://foreman.example.org/api/smart_proxies?search=name%3D%22Smart+Proxy%22&per_page=4294967296
   response:
-    body: {string: !!python/unicode "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\":
-        1,\n  \"per_page\": 4294967296,\n  \"search\": \"name=\\\"Smart Proxy\\\"\",\n
-        \ \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
-        [{\"created_at\":\"2020-10-21 09:15:38 UTC\",\"updated_at\":\"2020-10-21 09:15:38
-        UTC\",\"name\":\"Smart Proxy\",\"id\":15,\"url\":\"http://foreman-proxy.example.com:8000\",\"remote_execution_pubkey\":null,\"download_policy\":\"on_demand\",\"supported_pulp_types\":{\"pulp2\":{\"supported_types\":[\"deb\",\"docker\",\"file\",\"puppet\",\"yum\"]},\"pulp3\":{\"supported_types\":[],\"overriden_to_pulp2\":[]}},\"features\":[{\"capabilities\":[],\"name\":\"Pulp
-        Node\",\"id\":3},{\"capabilities\":[],\"name\":\"Templates\",\"id\":1},{\"capabilities\":[],\"name\":\"Puppet
-        CA\",\"id\":9},{\"capabilities\":[],\"name\":\"Puppet\",\"id\":8},{\"capabilities\":[],\"name\":\"Logs\",\"id\":13}]}]\n}\n"}
+    body:
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+        4294967296,\n  \"search\": \"name=\\\"Smart Proxy\\\"\",\n  \"sort\": {\n
+        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\":\"2024-07-10
+        14:13:12 UTC\",\"updated_at\":\"2024-07-10 14:13:12 UTC\",\"hosts_count\":0,\"name\":\"Smart
+        Proxy\",\"id\":12,\"url\":\"https://foreman-proxy.example.com:9090\",\"remote_execution_pubkey\":\"ssh-rsa
+        AAAAB3NzaC1yc2EAAAADAQABAAABgQCkn5pNuZ47pHDMpL1or9cDtaDJaJXn2EdrmcQBiXQOhoWjSn3R2da7ThZkjXGTirQrMeU8FeDpZUso368rUGU4PFg8JHCwuNF7X+mcOeodK3EJyGHIfsj172xF8wAHUc4tK2MSIKDfVd8MvX4M3qPN80290wmhCh4YrKFA30az96eSP4RDt19m3/qxTXpcmSRyuw1NKr0DUs4lCG08uV4hMpheypT21HM8eb3NSic73fY0nTLOerTwo9BUdQugjdiBNjlA9o9MzSZ6acCiOqAxqYEnVlWKqfgsy/55uBCAi4rO78sIKptvb+g1i1l86HNj/6xtwlrsXNft1p6MwcGDb66naRDARhzNLWUlrM6yqXpOkHEK1w76zaNw0RfwsxFSbZx5TueQQ1QI/DIxcIX0bIBSiVsp39TneEwFQqXu0a7dvst4LAKIOii6GtEc6FIcuCX49x6qe0VsJvHBS3LgKBcfTUUvWkm67qNX3Xaik1MKjvredkcH+7byxL+TiDE=
+        foreman-proxy@foreman-proxy.example.com\",\"download_policy\":\"on_demand\",\"supported_pulp_types\":[\"ansible_collection\",\"docker\",\"file\",\"yum\"],\"lifecycle_environments\":[{\"id\":6,\"name\":\"Dev\",\"description\":null,\"library\":false,\"organization_id\":6,\"created_at\":\"2024-07-10
+        14:13:10 UTC\",\"updated_at\":\"2024-07-10 14:13:10 UTC\",\"label\":\"dev\",\"registry_name_pattern\":null,\"registry_unauthenticated_pull\":false,\"prior\":\"Library\",\"prior_id\":5,\"organization\":\"Test
+        Organization\"}],\"features\":[{\"capabilities\":[],\"name\":\"Container_Gateway\",\"id\":4},{\"capabilities\":[\"single\",\"ssh\"],\"name\":\"Dynflow\",\"id\":17},{\"capabilities\":[\"cockpit\"],\"name\":\"Script\",\"id\":19},{\"capabilities\":[\"ansible\",\"certguard\",\"container\",\"core\",\"file\",\"rpm\"],\"name\":\"Pulpcore\",\"id\":3},{\"capabilities\":[],\"name\":\"Templates\",\"id\":5},{\"capabilities\":[],\"name\":\"Logs\",\"id\":13},{\"capabilities\":[],\"name\":\"Registration\",\"id\":16}]}]\n}\n"
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      connection: [Keep-Alive]
-      content-length: ['775']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline''
-          ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      foreman_api_version: ['2']
-      foreman_current_location: [; ANY]
-      foreman_current_organization: [; ANY]
-      foreman_version: [2.2.0-rc3]
-      keep-alive: ['timeout=15, max=98']
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Length:
+      - '1855'
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.12.0-develop
+      Keep-Alive:
+      - timeout=15, max=98
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json;version=2]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: ['apypie (https://github.com/Apipie/apypie)']
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/smart_proxies/15
+    uri: https://foreman.example.org/api/smart_proxies/12
   response:
-    body: {string: !!python/unicode '{"created_at":"2020-10-21 09:15:38 UTC","updated_at":"2020-10-21
-        09:15:38 UTC","name":"Smart Proxy","id":15,"url":"http://foreman-proxy.example.com:8000","remote_execution_pubkey":null,"download_policy":"on_demand","supported_pulp_types":{"pulp2":{"supported_types":["deb","docker","file","puppet","yum"]},"pulp3":{"supported_types":[],"overriden_to_pulp2":[]}},"features":[{"capabilities":[],"name":"Pulp
-        Node","id":3},{"capabilities":[],"name":"Templates","id":1},{"capabilities":[],"name":"Puppet
-        CA","id":9},{"capabilities":[],"name":"Puppet","id":8},{"capabilities":[],"name":"Logs","id":13}],"locations":[],"organizations":[]}'}
+    body:
+      string: '{"created_at":"2024-07-10 14:13:12 UTC","updated_at":"2024-07-10 14:13:12
+        UTC","hosts_count":0,"name":"Smart Proxy","id":12,"url":"https://foreman-proxy.example.com:9090","remote_execution_pubkey":"ssh-rsa
+        AAAAB3NzaC1yc2EAAAADAQABAAABgQCkn5pNuZ47pHDMpL1or9cDtaDJaJXn2EdrmcQBiXQOhoWjSn3R2da7ThZkjXGTirQrMeU8FeDpZUso368rUGU4PFg8JHCwuNF7X+mcOeodK3EJyGHIfsj172xF8wAHUc4tK2MSIKDfVd8MvX4M3qPN80290wmhCh4YrKFA30az96eSP4RDt19m3/qxTXpcmSRyuw1NKr0DUs4lCG08uV4hMpheypT21HM8eb3NSic73fY0nTLOerTwo9BUdQugjdiBNjlA9o9MzSZ6acCiOqAxqYEnVlWKqfgsy/55uBCAi4rO78sIKptvb+g1i1l86HNj/6xtwlrsXNft1p6MwcGDb66naRDARhzNLWUlrM6yqXpOkHEK1w76zaNw0RfwsxFSbZx5TueQQ1QI/DIxcIX0bIBSiVsp39TneEwFQqXu0a7dvst4LAKIOii6GtEc6FIcuCX49x6qe0VsJvHBS3LgKBcfTUUvWkm67qNX3Xaik1MKjvredkcH+7byxL+TiDE=
+        foreman-proxy@foreman-proxy.example.com","download_policy":"on_demand","supported_pulp_types":["ansible_collection","docker","file","yum"],"lifecycle_environments":[{"id":6,"name":"Dev","description":null,"library":false,"organization_id":6,"created_at":"2024-07-10
+        14:13:10 UTC","updated_at":"2024-07-10 14:13:10 UTC","label":"dev","registry_name_pattern":null,"registry_unauthenticated_pull":false,"prior":"Library","prior_id":5,"organization":"Test
+        Organization"}],"features":[{"capabilities":[],"name":"Container_Gateway","id":4},{"capabilities":["single","ssh"],"name":"Dynflow","id":17},{"capabilities":["cockpit"],"name":"Script","id":19},{"capabilities":["ansible","certguard","container","core","file","rpm"],"name":"Pulpcore","id":3},{"capabilities":[],"name":"Templates","id":5},{"capabilities":[],"name":"Logs","id":13},{"capabilities":[],"name":"Registration","id":16}],"locations":[],"organizations":[]}'
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      connection: [Keep-Alive]
-      content-length: ['632']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline''
-          ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      foreman_api_version: ['2']
-      foreman_current_location: [; ANY]
-      foreman_current_organization: [; ANY]
-      foreman_version: [2.2.0-rc3]
-      keep-alive: ['timeout=15, max=97']
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Length:
+      - '1712'
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.12.0-develop
+      Keep-Alive:
+      - timeout=15, max=97
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json;version=2]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: ['apypie (https://github.com/Apipie/apypie)']
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/capsules/15/content/lifecycle_environments
+    uri: https://foreman.example.org/katello/api/capsules/12/content/lifecycle_environments
   response:
-    body: {string: !!python/unicode '{"total":1,"subtotal":1,"page":null,"per_page":null,"error":null,"search":null,"sort":{"by":null,"order":null},"results":[{"library":false,"registry_name_pattern":null,"registry_unauthenticated_pull":false,"id":3,"name":"Dev","label":"dev","description":null,"organization_id":4,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":4},"created_at":"2020-10-20
-        15:09:27 UTC","updated_at":"2020-10-20 15:09:27 UTC","prior":{"name":"Library","id":2},"successor":{"name":"Test","id":4},"counts":{"content_hosts":0,"content_views":0},"permissions":{"create_lifecycle_environments":true,"view_lifecycle_environments":true,"edit_lifecycle_environments":true,"destroy_lifecycle_environments":true,"promote_or_remove_content_views_to_environments":true}}]}
+    body:
+      string: '{"total":1,"subtotal":1,"selectable":1,"page":null,"per_page":null,"error":null,"search":null,"sort":{"by":null,"order":null},"results":[{"library":false,"registry_name_pattern":null,"registry_unauthenticated_pull":false,"id":6,"name":"Dev","label":"dev","description":null,"organization_id":6,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":6},"created_at":"2024-07-10
+        14:13:10 UTC","updated_at":"2024-07-10 14:13:10 UTC","prior":{"name":"Library","id":5},"successor":{"name":"Test","id":7},"counts":{"content_hosts":0,"content_views":0},"permissions":{"create_lifecycle_environments":true,"view_lifecycle_environments":true,"edit_lifecycle_environments":true,"destroy_lifecycle_environments":true,"promote_or_remove_content_views_to_environments":true},"content_views":[]}]}
 
-'}
+        '
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      connection: [Keep-Alive]
-      content-length: ['771']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline''
-          ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      foreman_api_version: ['2']
-      foreman_current_location: [; ANY]
-      foreman_current_organization: [; ANY]
-      foreman_version: [2.2.0-rc3]
-      keep-alive: ['timeout=15, max=96']
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Length:
+      - '805'
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.12.0-develop
+      Keep-Alive:
+      - timeout=15, max=96
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/test_playbooks/fixtures/katello_smart_proxy-2.yml
+++ b/tests/test_playbooks/fixtures/katello_smart_proxy-2.yml
@@ -2,255 +2,416 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: [application/json;version=2]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: ['apypie (https://github.com/Apipie/apypie)']
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
     uri: https://foreman.example.org/api/status
   response:
-    body: {string: !!python/unicode '{"result":"ok","status":200,"version":"2.2.0-rc3","api_version":2}'}
+    body:
+      string: '{"satellite_version":"6.16.0","result":"ok","status":200,"version":"3.12.0-develop","api_version":2}'
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      connection: [Keep-Alive]
-      content-length: ['66']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline''
-          ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      foreman_api_version: ['2']
-      foreman_current_location: [; ANY]
-      foreman_current_organization: [; ANY]
-      foreman_version: [2.2.0-rc3]
-      keep-alive: ['timeout=15, max=100']
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Length:
+      - '100'
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.12.0-develop
+      Keep-Alive:
+      - timeout=15, max=100
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json;version=2]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: ['apypie (https://github.com/Apipie/apypie)']
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/environments?per_page=4294967296&search=name%3D%22Test%22
+    uri: https://foreman.example.org/katello/api/environments?search=name%3D%22Test%22&per_page=4294967296
   response:
-    body: {string: !!python/unicode '{"total":4,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test\"","sort":{"by":"name","order":"asc"},"results":[{"library":false,"registry_name_pattern":null,"registry_unauthenticated_pull":false,"id":4,"name":"Test","label":"test","description":null,"organization_id":4,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":4},"created_at":"2020-10-20
-        15:09:31 UTC","updated_at":"2020-10-20 15:09:31 UTC","prior":{"name":"Dev","id":3},"successor":null,"counts":{"content_hosts":0,"content_views":0},"permissions":{"create_lifecycle_environments":true,"view_lifecycle_environments":true,"edit_lifecycle_environments":true,"destroy_lifecycle_environments":true,"promote_or_remove_content_views_to_environments":true}}]}
+    body:
+      string: '{"total":4,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test\"","sort":{"by":"name","order":"asc"},"results":[{"library":false,"registry_name_pattern":null,"registry_unauthenticated_pull":false,"id":7,"name":"Test","label":"test","description":null,"organization_id":6,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":6},"created_at":"2024-07-10
+        14:13:11 UTC","updated_at":"2024-07-10 14:13:11 UTC","prior":{"name":"Dev","id":6},"successor":null,"counts":{"content_hosts":0,"content_views":0},"permissions":{"create_lifecycle_environments":true,"view_lifecycle_environments":true,"edit_lifecycle_environments":true,"destroy_lifecycle_environments":true,"promote_or_remove_content_views_to_environments":true},"content_views":[]}]}
 
-'}
+        '
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      connection: [Keep-Alive]
-      content-length: ['770']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline''
-          ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      foreman_api_version: ['2']
-      foreman_current_location: [; ANY]
-      foreman_current_organization: [; ANY]
-      foreman_version: [2.2.0-rc3]
-      keep-alive: ['timeout=15, max=99']
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Length:
+      - '804'
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.12.0-develop
+      Keep-Alive:
+      - timeout=15, max=99
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json;version=2]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: ['apypie (https://github.com/Apipie/apypie)']
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/smart_proxies?per_page=4294967296&search=name%3D%22Smart+Proxy%22
+    uri: https://foreman.example.org/api/smart_proxies?search=name%3D%22Smart+Proxy%22&per_page=4294967296
   response:
-    body: {string: !!python/unicode "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\":
-        1,\n  \"per_page\": 4294967296,\n  \"search\": \"name=\\\"Smart Proxy\\\"\",\n
-        \ \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
-        [{\"created_at\":\"2020-10-21 09:15:38 UTC\",\"updated_at\":\"2020-10-21 09:15:38
-        UTC\",\"name\":\"Smart Proxy\",\"id\":15,\"url\":\"http://foreman-proxy.example.com:8000\",\"remote_execution_pubkey\":null,\"download_policy\":\"on_demand\",\"supported_pulp_types\":{\"pulp2\":{\"supported_types\":[\"deb\",\"docker\",\"file\",\"puppet\",\"yum\"]},\"pulp3\":{\"supported_types\":[],\"overriden_to_pulp2\":[]}},\"features\":[{\"capabilities\":[],\"name\":\"Pulp
-        Node\",\"id\":3},{\"capabilities\":[],\"name\":\"Templates\",\"id\":1},{\"capabilities\":[],\"name\":\"Puppet
-        CA\",\"id\":9},{\"capabilities\":[],\"name\":\"Puppet\",\"id\":8},{\"capabilities\":[],\"name\":\"Logs\",\"id\":13}]}]\n}\n"}
+    body:
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+        4294967296,\n  \"search\": \"name=\\\"Smart Proxy\\\"\",\n  \"sort\": {\n
+        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\":\"2024-07-10
+        14:13:12 UTC\",\"updated_at\":\"2024-07-10 14:13:12 UTC\",\"hosts_count\":0,\"name\":\"Smart
+        Proxy\",\"id\":12,\"url\":\"https://foreman-proxy.example.com:9090\",\"remote_execution_pubkey\":\"ssh-rsa
+        AAAAB3NzaC1yc2EAAAADAQABAAABgQCkn5pNuZ47pHDMpL1or9cDtaDJaJXn2EdrmcQBiXQOhoWjSn3R2da7ThZkjXGTirQrMeU8FeDpZUso368rUGU4PFg8JHCwuNF7X+mcOeodK3EJyGHIfsj172xF8wAHUc4tK2MSIKDfVd8MvX4M3qPN80290wmhCh4YrKFA30az96eSP4RDt19m3/qxTXpcmSRyuw1NKr0DUs4lCG08uV4hMpheypT21HM8eb3NSic73fY0nTLOerTwo9BUdQugjdiBNjlA9o9MzSZ6acCiOqAxqYEnVlWKqfgsy/55uBCAi4rO78sIKptvb+g1i1l86HNj/6xtwlrsXNft1p6MwcGDb66naRDARhzNLWUlrM6yqXpOkHEK1w76zaNw0RfwsxFSbZx5TueQQ1QI/DIxcIX0bIBSiVsp39TneEwFQqXu0a7dvst4LAKIOii6GtEc6FIcuCX49x6qe0VsJvHBS3LgKBcfTUUvWkm67qNX3Xaik1MKjvredkcH+7byxL+TiDE=
+        foreman-proxy@foreman-proxy.example.com\",\"download_policy\":\"on_demand\",\"supported_pulp_types\":[\"ansible_collection\",\"docker\",\"file\",\"yum\"],\"lifecycle_environments\":[{\"id\":6,\"name\":\"Dev\",\"description\":null,\"library\":false,\"organization_id\":6,\"created_at\":\"2024-07-10
+        14:13:10 UTC\",\"updated_at\":\"2024-07-10 14:13:10 UTC\",\"label\":\"dev\",\"registry_name_pattern\":null,\"registry_unauthenticated_pull\":false,\"prior\":\"Library\",\"prior_id\":5,\"organization\":\"Test
+        Organization\"}],\"features\":[{\"capabilities\":[],\"name\":\"Container_Gateway\",\"id\":4},{\"capabilities\":[\"single\",\"ssh\"],\"name\":\"Dynflow\",\"id\":17},{\"capabilities\":[\"cockpit\"],\"name\":\"Script\",\"id\":19},{\"capabilities\":[\"ansible\",\"certguard\",\"container\",\"core\",\"file\",\"rpm\"],\"name\":\"Pulpcore\",\"id\":3},{\"capabilities\":[],\"name\":\"Templates\",\"id\":5},{\"capabilities\":[],\"name\":\"Logs\",\"id\":13},{\"capabilities\":[],\"name\":\"Registration\",\"id\":16}]}]\n}\n"
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      connection: [Keep-Alive]
-      content-length: ['775']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline''
-          ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      foreman_api_version: ['2']
-      foreman_current_location: [; ANY]
-      foreman_current_organization: [; ANY]
-      foreman_version: [2.2.0-rc3]
-      keep-alive: ['timeout=15, max=98']
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Length:
+      - '1855'
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.12.0-develop
+      Keep-Alive:
+      - timeout=15, max=98
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json;version=2]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: ['apypie (https://github.com/Apipie/apypie)']
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/smart_proxies/15
+    uri: https://foreman.example.org/api/smart_proxies/12
   response:
-    body: {string: !!python/unicode '{"created_at":"2020-10-21 09:15:38 UTC","updated_at":"2020-10-21
-        09:15:38 UTC","name":"Smart Proxy","id":15,"url":"http://foreman-proxy.example.com:8000","remote_execution_pubkey":null,"download_policy":"on_demand","supported_pulp_types":{"pulp2":{"supported_types":["deb","docker","file","puppet","yum"]},"pulp3":{"supported_types":[],"overriden_to_pulp2":[]}},"features":[{"capabilities":[],"name":"Pulp
-        Node","id":3},{"capabilities":[],"name":"Templates","id":1},{"capabilities":[],"name":"Puppet
-        CA","id":9},{"capabilities":[],"name":"Puppet","id":8},{"capabilities":[],"name":"Logs","id":13}],"locations":[],"organizations":[]}'}
+    body:
+      string: '{"created_at":"2024-07-10 14:13:12 UTC","updated_at":"2024-07-10 14:13:12
+        UTC","hosts_count":0,"name":"Smart Proxy","id":12,"url":"https://foreman-proxy.example.com:9090","remote_execution_pubkey":"ssh-rsa
+        AAAAB3NzaC1yc2EAAAADAQABAAABgQCkn5pNuZ47pHDMpL1or9cDtaDJaJXn2EdrmcQBiXQOhoWjSn3R2da7ThZkjXGTirQrMeU8FeDpZUso368rUGU4PFg8JHCwuNF7X+mcOeodK3EJyGHIfsj172xF8wAHUc4tK2MSIKDfVd8MvX4M3qPN80290wmhCh4YrKFA30az96eSP4RDt19m3/qxTXpcmSRyuw1NKr0DUs4lCG08uV4hMpheypT21HM8eb3NSic73fY0nTLOerTwo9BUdQugjdiBNjlA9o9MzSZ6acCiOqAxqYEnVlWKqfgsy/55uBCAi4rO78sIKptvb+g1i1l86HNj/6xtwlrsXNft1p6MwcGDb66naRDARhzNLWUlrM6yqXpOkHEK1w76zaNw0RfwsxFSbZx5TueQQ1QI/DIxcIX0bIBSiVsp39TneEwFQqXu0a7dvst4LAKIOii6GtEc6FIcuCX49x6qe0VsJvHBS3LgKBcfTUUvWkm67qNX3Xaik1MKjvredkcH+7byxL+TiDE=
+        foreman-proxy@foreman-proxy.example.com","download_policy":"on_demand","supported_pulp_types":["ansible_collection","docker","file","yum"],"lifecycle_environments":[{"id":6,"name":"Dev","description":null,"library":false,"organization_id":6,"created_at":"2024-07-10
+        14:13:10 UTC","updated_at":"2024-07-10 14:13:10 UTC","label":"dev","registry_name_pattern":null,"registry_unauthenticated_pull":false,"prior":"Library","prior_id":5,"organization":"Test
+        Organization"}],"features":[{"capabilities":[],"name":"Container_Gateway","id":4},{"capabilities":["single","ssh"],"name":"Dynflow","id":17},{"capabilities":["cockpit"],"name":"Script","id":19},{"capabilities":["ansible","certguard","container","core","file","rpm"],"name":"Pulpcore","id":3},{"capabilities":[],"name":"Templates","id":5},{"capabilities":[],"name":"Logs","id":13},{"capabilities":[],"name":"Registration","id":16}],"locations":[],"organizations":[]}'
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      connection: [Keep-Alive]
-      content-length: ['632']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline''
-          ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      foreman_api_version: ['2']
-      foreman_current_location: [; ANY]
-      foreman_current_organization: [; ANY]
-      foreman_version: [2.2.0-rc3]
-      keep-alive: ['timeout=15, max=97']
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Length:
+      - '1712'
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.12.0-develop
+      Keep-Alive:
+      - timeout=15, max=97
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json;version=2]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: ['apypie (https://github.com/Apipie/apypie)']
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/capsules/15/content/lifecycle_environments
+    uri: https://foreman.example.org/katello/api/capsules/12/content/lifecycle_environments
   response:
-    body: {string: !!python/unicode '{"total":1,"subtotal":1,"page":null,"per_page":null,"error":null,"search":null,"sort":{"by":null,"order":null},"results":[{"library":false,"registry_name_pattern":null,"registry_unauthenticated_pull":false,"id":3,"name":"Dev","label":"dev","description":null,"organization_id":4,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":4},"created_at":"2020-10-20
-        15:09:27 UTC","updated_at":"2020-10-20 15:09:27 UTC","prior":{"name":"Library","id":2},"successor":{"name":"Test","id":4},"counts":{"content_hosts":0,"content_views":0},"permissions":{"create_lifecycle_environments":true,"view_lifecycle_environments":true,"edit_lifecycle_environments":true,"destroy_lifecycle_environments":true,"promote_or_remove_content_views_to_environments":true}}]}
+    body:
+      string: '{"total":1,"subtotal":1,"selectable":1,"page":null,"per_page":null,"error":null,"search":null,"sort":{"by":null,"order":null},"results":[{"library":false,"registry_name_pattern":null,"registry_unauthenticated_pull":false,"id":6,"name":"Dev","label":"dev","description":null,"organization_id":6,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":6},"created_at":"2024-07-10
+        14:13:10 UTC","updated_at":"2024-07-10 14:13:10 UTC","prior":{"name":"Library","id":5},"successor":{"name":"Test","id":7},"counts":{"content_hosts":0,"content_views":0},"permissions":{"create_lifecycle_environments":true,"view_lifecycle_environments":true,"edit_lifecycle_environments":true,"destroy_lifecycle_environments":true,"promote_or_remove_content_views_to_environments":true},"content_views":[]}]}
 
-'}
+        '
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      connection: [Keep-Alive]
-      content-length: ['771']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline''
-          ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      foreman_api_version: ['2']
-      foreman_current_location: [; ANY]
-      foreman_current_organization: [; ANY]
-      foreman_version: [2.2.0-rc3]
-      keep-alive: ['timeout=15, max=96']
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Length:
+      - '805'
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.12.0-develop
+      Keep-Alive:
+      - timeout=15, max=96
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
-    body: !!python/unicode '{"environment_id": 4}'
+    body: '{"environment_id": 7}'
     headers:
-      Accept: [application/json;version=2]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['21']
-      Content-Type: [application/json]
-      User-Agent: ['apypie (https://github.com/Apipie/apypie)']
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '21'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: POST
-    uri: https://foreman.example.org/katello/api/capsules/15/content/lifecycle_environments
+    uri: https://foreman.example.org/katello/api/capsules/12/content/lifecycle_environments
   response:
-    body: {string: !!python/unicode '{"total":2,"subtotal":2,"page":null,"per_page":null,"error":null,"search":null,"sort":{"by":null,"order":null},"results":[{"library":false,"registry_name_pattern":null,"registry_unauthenticated_pull":false,"id":3,"name":"Dev","label":"dev","description":null,"organization_id":4,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":4},"created_at":"2020-10-20
-        15:09:27 UTC","updated_at":"2020-10-20 15:09:27 UTC","prior":{"name":"Library","id":2},"successor":{"name":"Test","id":4},"counts":{"content_hosts":0,"content_views":0},"permissions":{"create_lifecycle_environments":true,"view_lifecycle_environments":true,"edit_lifecycle_environments":true,"destroy_lifecycle_environments":true,"promote_or_remove_content_views_to_environments":true}},{"library":false,"registry_name_pattern":null,"registry_unauthenticated_pull":false,"id":4,"name":"Test","label":"test","description":null,"organization_id":4,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":4},"created_at":"2020-10-20
-        15:09:31 UTC","updated_at":"2020-10-20 15:09:31 UTC","prior":{"name":"Dev","id":3},"successor":null,"counts":{"content_hosts":0,"content_views":0},"permissions":{"create_lifecycle_environments":true,"view_lifecycle_environments":true,"edit_lifecycle_environments":true,"destroy_lifecycle_environments":true,"promote_or_remove_content_views_to_environments":true}}]}
+    body:
+      string: '{"total":2,"subtotal":2,"selectable":2,"page":null,"per_page":null,"error":null,"search":null,"sort":{"by":null,"order":null},"results":[{"library":false,"registry_name_pattern":null,"registry_unauthenticated_pull":false,"id":6,"name":"Dev","label":"dev","description":null,"organization_id":6,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":6},"created_at":"2024-07-10
+        14:13:10 UTC","updated_at":"2024-07-10 14:13:10 UTC","prior":{"name":"Library","id":5},"successor":{"name":"Test","id":7},"counts":{"content_hosts":0,"content_views":0},"permissions":{"create_lifecycle_environments":true,"view_lifecycle_environments":true,"edit_lifecycle_environments":true,"destroy_lifecycle_environments":true,"promote_or_remove_content_views_to_environments":true},"content_views":[]},{"library":false,"registry_name_pattern":null,"registry_unauthenticated_pull":false,"id":7,"name":"Test","label":"test","description":null,"organization_id":6,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":6},"created_at":"2024-07-10
+        14:13:11 UTC","updated_at":"2024-07-10 14:13:11 UTC","prior":{"name":"Dev","id":6},"successor":null,"counts":{"content_hosts":0,"content_views":0},"permissions":{"create_lifecycle_environments":true,"view_lifecycle_environments":true,"edit_lifecycle_environments":true,"destroy_lifecycle_environments":true,"promote_or_remove_content_views_to_environments":true},"content_views":[]}]}
 
-'}
+        '
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      connection: [Keep-Alive]
-      content-length: ['1398']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline''
-          ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      foreman_api_version: ['2']
-      foreman_current_location: [; ANY]
-      foreman_current_organization: [; ANY]
-      foreman_version: [2.2.0-rc3]
-      keep-alive: ['timeout=15, max=95']
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Length:
+      - '1451'
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.12.0-develop
+      Keep-Alive:
+      - timeout=15, max=95
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json;version=2]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: ['apypie (https://github.com/Apipie/apypie)']
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: DELETE
-    uri: https://foreman.example.org/katello/api/capsules/15/content/lifecycle_environments/3
+    uri: https://foreman.example.org/katello/api/capsules/12/content/lifecycle_environments/6
   response:
-    body: {string: !!python/unicode '{"total":1,"subtotal":1,"page":null,"per_page":null,"error":null,"search":null,"sort":{"by":null,"order":null},"results":[{"library":false,"registry_name_pattern":null,"registry_unauthenticated_pull":false,"id":4,"name":"Test","label":"test","description":null,"organization_id":4,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":4},"created_at":"2020-10-20
-        15:09:31 UTC","updated_at":"2020-10-20 15:09:31 UTC","prior":{"name":"Dev","id":3},"successor":null,"counts":{"content_hosts":0,"content_views":0},"permissions":{"create_lifecycle_environments":true,"view_lifecycle_environments":true,"edit_lifecycle_environments":true,"destroy_lifecycle_environments":true,"promote_or_remove_content_views_to_environments":true}}]}
+    body:
+      string: '{"total":1,"subtotal":1,"selectable":1,"page":null,"per_page":null,"error":null,"search":null,"sort":{"by":null,"order":null},"results":[{"library":false,"registry_name_pattern":null,"registry_unauthenticated_pull":false,"id":7,"name":"Test","label":"test","description":null,"organization_id":6,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":6},"created_at":"2024-07-10
+        14:13:11 UTC","updated_at":"2024-07-10 14:13:11 UTC","prior":{"name":"Dev","id":6},"successor":null,"counts":{"content_hosts":0,"content_views":0},"permissions":{"create_lifecycle_environments":true,"view_lifecycle_environments":true,"edit_lifecycle_environments":true,"destroy_lifecycle_environments":true,"promote_or_remove_content_views_to_environments":true},"content_views":[]}]}
 
-'}
+        '
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      connection: [Keep-Alive]
-      content-length: ['751']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline''
-          ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      foreman_api_version: ['2']
-      foreman_current_location: [; ANY]
-      foreman_current_organization: [; ANY]
-      foreman_version: [2.2.0-rc3]
-      keep-alive: ['timeout=15, max=94']
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Length:
+      - '785'
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.12.0-develop
+      Keep-Alive:
+      - timeout=15, max=94
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/test_playbooks/fixtures/katello_smart_proxy-3.yml
+++ b/tests/test_playbooks/fixtures/katello_smart_proxy-3.yml
@@ -2,178 +2,292 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: [application/json;version=2]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: ['apypie (https://github.com/Apipie/apypie)']
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
     uri: https://foreman.example.org/api/status
   response:
-    body: {string: !!python/unicode '{"result":"ok","status":200,"version":"2.2.0-rc3","api_version":2}'}
+    body:
+      string: '{"satellite_version":"6.16.0","result":"ok","status":200,"version":"3.12.0-develop","api_version":2}'
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      connection: [Keep-Alive]
-      content-length: ['66']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline''
-          ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      foreman_api_version: ['2']
-      foreman_current_location: [; ANY]
-      foreman_current_organization: [; ANY]
-      foreman_version: [2.2.0-rc3]
-      keep-alive: ['timeout=15, max=100']
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Length:
+      - '100'
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.12.0-develop
+      Keep-Alive:
+      - timeout=15, max=100
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json;version=2]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: ['apypie (https://github.com/Apipie/apypie)']
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/environments?per_page=4294967296&search=name%3D%22Test%22
+    uri: https://foreman.example.org/katello/api/environments?search=name%3D%22Test%22&per_page=4294967296
   response:
-    body: {string: !!python/unicode '{"total":4,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test\"","sort":{"by":"name","order":"asc"},"results":[{"library":false,"registry_name_pattern":null,"registry_unauthenticated_pull":false,"id":4,"name":"Test","label":"test","description":null,"organization_id":4,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":4},"created_at":"2020-10-20
-        15:09:31 UTC","updated_at":"2020-10-20 15:09:31 UTC","prior":{"name":"Dev","id":3},"successor":null,"counts":{"content_hosts":0,"content_views":0},"permissions":{"create_lifecycle_environments":true,"view_lifecycle_environments":true,"edit_lifecycle_environments":true,"destroy_lifecycle_environments":true,"promote_or_remove_content_views_to_environments":true}}]}
+    body:
+      string: '{"total":4,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test\"","sort":{"by":"name","order":"asc"},"results":[{"library":false,"registry_name_pattern":null,"registry_unauthenticated_pull":false,"id":7,"name":"Test","label":"test","description":null,"organization_id":6,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":6},"created_at":"2024-07-10
+        14:13:11 UTC","updated_at":"2024-07-10 14:13:11 UTC","prior":{"name":"Dev","id":6},"successor":null,"counts":{"content_hosts":0,"content_views":0},"permissions":{"create_lifecycle_environments":true,"view_lifecycle_environments":true,"edit_lifecycle_environments":true,"destroy_lifecycle_environments":true,"promote_or_remove_content_views_to_environments":true},"content_views":[]}]}
 
-'}
+        '
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      connection: [Keep-Alive]
-      content-length: ['770']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline''
-          ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      foreman_api_version: ['2']
-      foreman_current_location: [; ANY]
-      foreman_current_organization: [; ANY]
-      foreman_version: [2.2.0-rc3]
-      keep-alive: ['timeout=15, max=99']
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Length:
+      - '804'
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.12.0-develop
+      Keep-Alive:
+      - timeout=15, max=99
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json;version=2]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: ['apypie (https://github.com/Apipie/apypie)']
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/smart_proxies?per_page=4294967296&search=name%3D%22Smart+Proxy%22
+    uri: https://foreman.example.org/api/smart_proxies?search=name%3D%22Smart+Proxy%22&per_page=4294967296
   response:
-    body: {string: !!python/unicode "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\":
-        1,\n  \"per_page\": 4294967296,\n  \"search\": \"name=\\\"Smart Proxy\\\"\",\n
-        \ \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
-        [{\"created_at\":\"2020-10-21 09:15:38 UTC\",\"updated_at\":\"2020-10-21 09:15:38
-        UTC\",\"name\":\"Smart Proxy\",\"id\":15,\"url\":\"http://foreman-proxy.example.com:8000\",\"remote_execution_pubkey\":null,\"download_policy\":\"on_demand\",\"supported_pulp_types\":{\"pulp2\":{\"supported_types\":[\"deb\",\"docker\",\"file\",\"puppet\",\"yum\"]},\"pulp3\":{\"supported_types\":[],\"overriden_to_pulp2\":[]}},\"features\":[{\"capabilities\":[],\"name\":\"Pulp
-        Node\",\"id\":3},{\"capabilities\":[],\"name\":\"Templates\",\"id\":1},{\"capabilities\":[],\"name\":\"Puppet
-        CA\",\"id\":9},{\"capabilities\":[],\"name\":\"Puppet\",\"id\":8},{\"capabilities\":[],\"name\":\"Logs\",\"id\":13}]}]\n}\n"}
+    body:
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+        4294967296,\n  \"search\": \"name=\\\"Smart Proxy\\\"\",\n  \"sort\": {\n
+        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\":\"2024-07-10
+        14:13:12 UTC\",\"updated_at\":\"2024-07-10 14:13:12 UTC\",\"hosts_count\":0,\"name\":\"Smart
+        Proxy\",\"id\":12,\"url\":\"https://foreman-proxy.example.com:9090\",\"remote_execution_pubkey\":\"ssh-rsa
+        AAAAB3NzaC1yc2EAAAADAQABAAABgQCkn5pNuZ47pHDMpL1or9cDtaDJaJXn2EdrmcQBiXQOhoWjSn3R2da7ThZkjXGTirQrMeU8FeDpZUso368rUGU4PFg8JHCwuNF7X+mcOeodK3EJyGHIfsj172xF8wAHUc4tK2MSIKDfVd8MvX4M3qPN80290wmhCh4YrKFA30az96eSP4RDt19m3/qxTXpcmSRyuw1NKr0DUs4lCG08uV4hMpheypT21HM8eb3NSic73fY0nTLOerTwo9BUdQugjdiBNjlA9o9MzSZ6acCiOqAxqYEnVlWKqfgsy/55uBCAi4rO78sIKptvb+g1i1l86HNj/6xtwlrsXNft1p6MwcGDb66naRDARhzNLWUlrM6yqXpOkHEK1w76zaNw0RfwsxFSbZx5TueQQ1QI/DIxcIX0bIBSiVsp39TneEwFQqXu0a7dvst4LAKIOii6GtEc6FIcuCX49x6qe0VsJvHBS3LgKBcfTUUvWkm67qNX3Xaik1MKjvredkcH+7byxL+TiDE=
+        foreman-proxy@foreman-proxy.example.com\",\"download_policy\":\"on_demand\",\"supported_pulp_types\":[\"ansible_collection\",\"docker\",\"file\",\"yum\"],\"lifecycle_environments\":[{\"id\":7,\"name\":\"Test\",\"description\":null,\"library\":false,\"organization_id\":6,\"created_at\":\"2024-07-10
+        14:13:11 UTC\",\"updated_at\":\"2024-07-10 14:13:11 UTC\",\"label\":\"test\",\"registry_name_pattern\":null,\"registry_unauthenticated_pull\":false,\"prior\":\"Dev\",\"prior_id\":6,\"organization\":\"Test
+        Organization\"}],\"features\":[{\"capabilities\":[],\"name\":\"Container_Gateway\",\"id\":4},{\"capabilities\":[\"single\",\"ssh\"],\"name\":\"Dynflow\",\"id\":17},{\"capabilities\":[\"cockpit\"],\"name\":\"Script\",\"id\":19},{\"capabilities\":[\"ansible\",\"certguard\",\"container\",\"core\",\"file\",\"rpm\"],\"name\":\"Pulpcore\",\"id\":3},{\"capabilities\":[],\"name\":\"Templates\",\"id\":5},{\"capabilities\":[],\"name\":\"Logs\",\"id\":13},{\"capabilities\":[],\"name\":\"Registration\",\"id\":16}]}]\n}\n"
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      connection: [Keep-Alive]
-      content-length: ['775']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline''
-          ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      foreman_api_version: ['2']
-      foreman_current_location: [; ANY]
-      foreman_current_organization: [; ANY]
-      foreman_version: [2.2.0-rc3]
-      keep-alive: ['timeout=15, max=98']
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Length:
+      - '1853'
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.12.0-develop
+      Keep-Alive:
+      - timeout=15, max=98
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json;version=2]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: ['apypie (https://github.com/Apipie/apypie)']
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/smart_proxies/15
+    uri: https://foreman.example.org/api/smart_proxies/12
   response:
-    body: {string: !!python/unicode '{"created_at":"2020-10-21 09:15:38 UTC","updated_at":"2020-10-21
-        09:15:38 UTC","name":"Smart Proxy","id":15,"url":"http://foreman-proxy.example.com:8000","remote_execution_pubkey":null,"download_policy":"on_demand","supported_pulp_types":{"pulp2":{"supported_types":["deb","docker","file","puppet","yum"]},"pulp3":{"supported_types":[],"overriden_to_pulp2":[]}},"features":[{"capabilities":[],"name":"Pulp
-        Node","id":3},{"capabilities":[],"name":"Templates","id":1},{"capabilities":[],"name":"Puppet
-        CA","id":9},{"capabilities":[],"name":"Puppet","id":8},{"capabilities":[],"name":"Logs","id":13}],"locations":[],"organizations":[]}'}
+    body:
+      string: '{"created_at":"2024-07-10 14:13:12 UTC","updated_at":"2024-07-10 14:13:12
+        UTC","hosts_count":0,"name":"Smart Proxy","id":12,"url":"https://foreman-proxy.example.com:9090","remote_execution_pubkey":"ssh-rsa
+        AAAAB3NzaC1yc2EAAAADAQABAAABgQCkn5pNuZ47pHDMpL1or9cDtaDJaJXn2EdrmcQBiXQOhoWjSn3R2da7ThZkjXGTirQrMeU8FeDpZUso368rUGU4PFg8JHCwuNF7X+mcOeodK3EJyGHIfsj172xF8wAHUc4tK2MSIKDfVd8MvX4M3qPN80290wmhCh4YrKFA30az96eSP4RDt19m3/qxTXpcmSRyuw1NKr0DUs4lCG08uV4hMpheypT21HM8eb3NSic73fY0nTLOerTwo9BUdQugjdiBNjlA9o9MzSZ6acCiOqAxqYEnVlWKqfgsy/55uBCAi4rO78sIKptvb+g1i1l86HNj/6xtwlrsXNft1p6MwcGDb66naRDARhzNLWUlrM6yqXpOkHEK1w76zaNw0RfwsxFSbZx5TueQQ1QI/DIxcIX0bIBSiVsp39TneEwFQqXu0a7dvst4LAKIOii6GtEc6FIcuCX49x6qe0VsJvHBS3LgKBcfTUUvWkm67qNX3Xaik1MKjvredkcH+7byxL+TiDE=
+        foreman-proxy@foreman-proxy.example.com","download_policy":"on_demand","supported_pulp_types":["ansible_collection","docker","file","yum"],"lifecycle_environments":[{"id":7,"name":"Test","description":null,"library":false,"organization_id":6,"created_at":"2024-07-10
+        14:13:11 UTC","updated_at":"2024-07-10 14:13:11 UTC","label":"test","registry_name_pattern":null,"registry_unauthenticated_pull":false,"prior":"Dev","prior_id":6,"organization":"Test
+        Organization"}],"features":[{"capabilities":[],"name":"Container_Gateway","id":4},{"capabilities":["single","ssh"],"name":"Dynflow","id":17},{"capabilities":["cockpit"],"name":"Script","id":19},{"capabilities":["ansible","certguard","container","core","file","rpm"],"name":"Pulpcore","id":3},{"capabilities":[],"name":"Templates","id":5},{"capabilities":[],"name":"Logs","id":13},{"capabilities":[],"name":"Registration","id":16}],"locations":[],"organizations":[]}'
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      connection: [Keep-Alive]
-      content-length: ['632']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline''
-          ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      foreman_api_version: ['2']
-      foreman_current_location: [; ANY]
-      foreman_current_organization: [; ANY]
-      foreman_version: [2.2.0-rc3]
-      keep-alive: ['timeout=15, max=97']
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Length:
+      - '1710'
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.12.0-develop
+      Keep-Alive:
+      - timeout=15, max=97
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json;version=2]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: ['apypie (https://github.com/Apipie/apypie)']
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/capsules/15/content/lifecycle_environments
+    uri: https://foreman.example.org/katello/api/capsules/12/content/lifecycle_environments
   response:
-    body: {string: !!python/unicode '{"total":1,"subtotal":1,"page":null,"per_page":null,"error":null,"search":null,"sort":{"by":null,"order":null},"results":[{"library":false,"registry_name_pattern":null,"registry_unauthenticated_pull":false,"id":4,"name":"Test","label":"test","description":null,"organization_id":4,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":4},"created_at":"2020-10-20
-        15:09:31 UTC","updated_at":"2020-10-20 15:09:31 UTC","prior":{"name":"Dev","id":3},"successor":null,"counts":{"content_hosts":0,"content_views":0},"permissions":{"create_lifecycle_environments":true,"view_lifecycle_environments":true,"edit_lifecycle_environments":true,"destroy_lifecycle_environments":true,"promote_or_remove_content_views_to_environments":true}}]}
+    body:
+      string: '{"total":1,"subtotal":1,"selectable":1,"page":null,"per_page":null,"error":null,"search":null,"sort":{"by":null,"order":null},"results":[{"library":false,"registry_name_pattern":null,"registry_unauthenticated_pull":false,"id":7,"name":"Test","label":"test","description":null,"organization_id":6,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":6},"created_at":"2024-07-10
+        14:13:11 UTC","updated_at":"2024-07-10 14:13:11 UTC","prior":{"name":"Dev","id":6},"successor":null,"counts":{"content_hosts":0,"content_views":0},"permissions":{"create_lifecycle_environments":true,"view_lifecycle_environments":true,"edit_lifecycle_environments":true,"destroy_lifecycle_environments":true,"promote_or_remove_content_views_to_environments":true},"content_views":[]}]}
 
-'}
+        '
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      connection: [Keep-Alive]
-      content-length: ['751']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline''
-          ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      foreman_api_version: ['2']
-      foreman_current_location: [; ANY]
-      foreman_current_organization: [; ANY]
-      foreman_version: [2.2.0-rc3]
-      keep-alive: ['timeout=15, max=96']
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Length:
+      - '785'
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.12.0-develop
+      Keep-Alive:
+      - timeout=15, max=96
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/test_playbooks/fixtures/katello_smart_proxy-4.yml
+++ b/tests/test_playbooks/fixtures/katello_smart_proxy-4.yml
@@ -2,145 +2,239 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: [application/json;version=2]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: ['apypie (https://github.com/Apipie/apypie)']
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
     uri: https://foreman.example.org/api/status
   response:
-    body: {string: !!python/unicode '{"result":"ok","status":200,"version":"2.2.0-rc3","api_version":2}'}
+    body:
+      string: '{"satellite_version":"6.16.0","result":"ok","status":200,"version":"3.12.0-develop","api_version":2}'
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      connection: [Keep-Alive]
-      content-length: ['66']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline''
-          ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      foreman_api_version: ['2']
-      foreman_current_location: [; ANY]
-      foreman_current_organization: [; ANY]
-      foreman_version: [2.2.0-rc3]
-      keep-alive: ['timeout=15, max=100']
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Length:
+      - '100'
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.12.0-develop
+      Keep-Alive:
+      - timeout=15, max=100
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json;version=2]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: ['apypie (https://github.com/Apipie/apypie)']
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/smart_proxies?per_page=4294967296&search=name%3D%22Smart+Proxy%22
+    uri: https://foreman.example.org/api/smart_proxies?search=name%3D%22Smart+Proxy%22&per_page=4294967296
   response:
-    body: {string: !!python/unicode "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\":
-        1,\n  \"per_page\": 4294967296,\n  \"search\": \"name=\\\"Smart Proxy\\\"\",\n
-        \ \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
-        [{\"created_at\":\"2020-10-21 09:15:38 UTC\",\"updated_at\":\"2020-10-21 09:15:38
-        UTC\",\"name\":\"Smart Proxy\",\"id\":15,\"url\":\"http://foreman-proxy.example.com:8000\",\"remote_execution_pubkey\":null,\"download_policy\":\"on_demand\",\"supported_pulp_types\":{\"pulp2\":{\"supported_types\":[\"deb\",\"docker\",\"file\",\"puppet\",\"yum\"]},\"pulp3\":{\"supported_types\":[],\"overriden_to_pulp2\":[]}},\"features\":[{\"capabilities\":[],\"name\":\"Pulp
-        Node\",\"id\":3},{\"capabilities\":[],\"name\":\"Templates\",\"id\":1},{\"capabilities\":[],\"name\":\"Puppet
-        CA\",\"id\":9},{\"capabilities\":[],\"name\":\"Puppet\",\"id\":8},{\"capabilities\":[],\"name\":\"Logs\",\"id\":13}]}]\n}\n"}
+    body:
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+        4294967296,\n  \"search\": \"name=\\\"Smart Proxy\\\"\",\n  \"sort\": {\n
+        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\":\"2024-07-10
+        14:13:12 UTC\",\"updated_at\":\"2024-07-10 14:13:12 UTC\",\"hosts_count\":0,\"name\":\"Smart
+        Proxy\",\"id\":12,\"url\":\"https://foreman-proxy.example.com:9090\",\"remote_execution_pubkey\":\"ssh-rsa
+        AAAAB3NzaC1yc2EAAAADAQABAAABgQCkn5pNuZ47pHDMpL1or9cDtaDJaJXn2EdrmcQBiXQOhoWjSn3R2da7ThZkjXGTirQrMeU8FeDpZUso368rUGU4PFg8JHCwuNF7X+mcOeodK3EJyGHIfsj172xF8wAHUc4tK2MSIKDfVd8MvX4M3qPN80290wmhCh4YrKFA30az96eSP4RDt19m3/qxTXpcmSRyuw1NKr0DUs4lCG08uV4hMpheypT21HM8eb3NSic73fY0nTLOerTwo9BUdQugjdiBNjlA9o9MzSZ6acCiOqAxqYEnVlWKqfgsy/55uBCAi4rO78sIKptvb+g1i1l86HNj/6xtwlrsXNft1p6MwcGDb66naRDARhzNLWUlrM6yqXpOkHEK1w76zaNw0RfwsxFSbZx5TueQQ1QI/DIxcIX0bIBSiVsp39TneEwFQqXu0a7dvst4LAKIOii6GtEc6FIcuCX49x6qe0VsJvHBS3LgKBcfTUUvWkm67qNX3Xaik1MKjvredkcH+7byxL+TiDE=
+        foreman-proxy@foreman-proxy.example.com\",\"download_policy\":\"on_demand\",\"supported_pulp_types\":[\"ansible_collection\",\"docker\",\"file\",\"yum\"],\"lifecycle_environments\":[{\"id\":7,\"name\":\"Test\",\"description\":null,\"library\":false,\"organization_id\":6,\"created_at\":\"2024-07-10
+        14:13:11 UTC\",\"updated_at\":\"2024-07-10 14:13:11 UTC\",\"label\":\"test\",\"registry_name_pattern\":null,\"registry_unauthenticated_pull\":false,\"prior\":\"Dev\",\"prior_id\":6,\"organization\":\"Test
+        Organization\"}],\"features\":[{\"capabilities\":[],\"name\":\"Container_Gateway\",\"id\":4},{\"capabilities\":[\"single\",\"ssh\"],\"name\":\"Dynflow\",\"id\":17},{\"capabilities\":[\"cockpit\"],\"name\":\"Script\",\"id\":19},{\"capabilities\":[\"ansible\",\"certguard\",\"container\",\"core\",\"file\",\"rpm\"],\"name\":\"Pulpcore\",\"id\":3},{\"capabilities\":[],\"name\":\"Templates\",\"id\":5},{\"capabilities\":[],\"name\":\"Logs\",\"id\":13},{\"capabilities\":[],\"name\":\"Registration\",\"id\":16}]}]\n}\n"
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      connection: [Keep-Alive]
-      content-length: ['775']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline''
-          ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      foreman_api_version: ['2']
-      foreman_current_location: [; ANY]
-      foreman_current_organization: [; ANY]
-      foreman_version: [2.2.0-rc3]
-      keep-alive: ['timeout=15, max=99']
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Length:
+      - '1853'
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.12.0-develop
+      Keep-Alive:
+      - timeout=15, max=99
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json;version=2]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: ['apypie (https://github.com/Apipie/apypie)']
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/smart_proxies/15
+    uri: https://foreman.example.org/api/smart_proxies/12
   response:
-    body: {string: !!python/unicode '{"created_at":"2020-10-21 09:15:38 UTC","updated_at":"2020-10-21
-        09:15:38 UTC","name":"Smart Proxy","id":15,"url":"http://foreman-proxy.example.com:8000","remote_execution_pubkey":null,"download_policy":"on_demand","supported_pulp_types":{"pulp2":{"supported_types":["deb","docker","file","puppet","yum"]},"pulp3":{"supported_types":[],"overriden_to_pulp2":[]}},"features":[{"capabilities":[],"name":"Pulp
-        Node","id":3},{"capabilities":[],"name":"Templates","id":1},{"capabilities":[],"name":"Puppet
-        CA","id":9},{"capabilities":[],"name":"Puppet","id":8},{"capabilities":[],"name":"Logs","id":13}],"locations":[],"organizations":[]}'}
+    body:
+      string: '{"created_at":"2024-07-10 14:13:12 UTC","updated_at":"2024-07-10 14:13:12
+        UTC","hosts_count":0,"name":"Smart Proxy","id":12,"url":"https://foreman-proxy.example.com:9090","remote_execution_pubkey":"ssh-rsa
+        AAAAB3NzaC1yc2EAAAADAQABAAABgQCkn5pNuZ47pHDMpL1or9cDtaDJaJXn2EdrmcQBiXQOhoWjSn3R2da7ThZkjXGTirQrMeU8FeDpZUso368rUGU4PFg8JHCwuNF7X+mcOeodK3EJyGHIfsj172xF8wAHUc4tK2MSIKDfVd8MvX4M3qPN80290wmhCh4YrKFA30az96eSP4RDt19m3/qxTXpcmSRyuw1NKr0DUs4lCG08uV4hMpheypT21HM8eb3NSic73fY0nTLOerTwo9BUdQugjdiBNjlA9o9MzSZ6acCiOqAxqYEnVlWKqfgsy/55uBCAi4rO78sIKptvb+g1i1l86HNj/6xtwlrsXNft1p6MwcGDb66naRDARhzNLWUlrM6yqXpOkHEK1w76zaNw0RfwsxFSbZx5TueQQ1QI/DIxcIX0bIBSiVsp39TneEwFQqXu0a7dvst4LAKIOii6GtEc6FIcuCX49x6qe0VsJvHBS3LgKBcfTUUvWkm67qNX3Xaik1MKjvredkcH+7byxL+TiDE=
+        foreman-proxy@foreman-proxy.example.com","download_policy":"on_demand","supported_pulp_types":["ansible_collection","docker","file","yum"],"lifecycle_environments":[{"id":7,"name":"Test","description":null,"library":false,"organization_id":6,"created_at":"2024-07-10
+        14:13:11 UTC","updated_at":"2024-07-10 14:13:11 UTC","label":"test","registry_name_pattern":null,"registry_unauthenticated_pull":false,"prior":"Dev","prior_id":6,"organization":"Test
+        Organization"}],"features":[{"capabilities":[],"name":"Container_Gateway","id":4},{"capabilities":["single","ssh"],"name":"Dynflow","id":17},{"capabilities":["cockpit"],"name":"Script","id":19},{"capabilities":["ansible","certguard","container","core","file","rpm"],"name":"Pulpcore","id":3},{"capabilities":[],"name":"Templates","id":5},{"capabilities":[],"name":"Logs","id":13},{"capabilities":[],"name":"Registration","id":16}],"locations":[],"organizations":[]}'
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      connection: [Keep-Alive]
-      content-length: ['632']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline''
-          ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      foreman_api_version: ['2']
-      foreman_current_location: [; ANY]
-      foreman_current_organization: [; ANY]
-      foreman_version: [2.2.0-rc3]
-      keep-alive: ['timeout=15, max=98']
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Length:
+      - '1710'
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.12.0-develop
+      Keep-Alive:
+      - timeout=15, max=98
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
-    body: !!python/unicode '{"smart_proxy": {"download_policy": "background"}}'
+    body: '{"smart_proxy": {"download_policy": "immediate"}}'
     headers:
-      Accept: [application/json;version=2]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['50']
-      Content-Type: [application/json]
-      User-Agent: ['apypie (https://github.com/Apipie/apypie)']
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '49'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: PUT
-    uri: https://foreman.example.org/api/smart_proxies/15
+    uri: https://foreman.example.org/api/smart_proxies/12
   response:
-    body: {string: !!python/unicode '{"created_at":"2020-10-21 09:15:38 UTC","updated_at":"2020-10-21
-        09:15:45 UTC","name":"Smart Proxy","id":15,"url":"http://foreman-proxy.example.com:8000","remote_execution_pubkey":null,"download_policy":"background","supported_pulp_types":{"pulp2":{"supported_types":["deb","docker","file","puppet","yum"]},"pulp3":{"supported_types":[],"overriden_to_pulp2":[]}},"features":[{"capabilities":[],"name":"Pulp
-        Node","id":3},{"capabilities":[],"name":"Templates","id":1},{"capabilities":[],"name":"Puppet
-        CA","id":9},{"capabilities":[],"name":"Puppet","id":8},{"capabilities":[],"name":"Logs","id":13},{"capabilities":[],"name":"Pulp
-        Node","id":3},{"capabilities":[],"name":"Templates","id":1},{"capabilities":[],"name":"Puppet
-        CA","id":9},{"capabilities":[],"name":"Puppet","id":8},{"capabilities":[],"name":"Logs","id":13}],"locations":[],"organizations":[]}'}
+    body:
+      string: '{"created_at":"2024-07-10 14:13:12 UTC","updated_at":"2024-07-10 14:13:18
+        UTC","hosts_count":0,"name":"Smart Proxy","id":12,"url":"https://foreman-proxy.example.com:9090","remote_execution_pubkey":"ssh-rsa
+        AAAAB3NzaC1yc2EAAAADAQABAAABgQCkn5pNuZ47pHDMpL1or9cDtaDJaJXn2EdrmcQBiXQOhoWjSn3R2da7ThZkjXGTirQrMeU8FeDpZUso368rUGU4PFg8JHCwuNF7X+mcOeodK3EJyGHIfsj172xF8wAHUc4tK2MSIKDfVd8MvX4M3qPN80290wmhCh4YrKFA30az96eSP4RDt19m3/qxTXpcmSRyuw1NKr0DUs4lCG08uV4hMpheypT21HM8eb3NSic73fY0nTLOerTwo9BUdQugjdiBNjlA9o9MzSZ6acCiOqAxqYEnVlWKqfgsy/55uBCAi4rO78sIKptvb+g1i1l86HNj/6xtwlrsXNft1p6MwcGDb66naRDARhzNLWUlrM6yqXpOkHEK1w76zaNw0RfwsxFSbZx5TueQQ1QI/DIxcIX0bIBSiVsp39TneEwFQqXu0a7dvst4LAKIOii6GtEc6FIcuCX49x6qe0VsJvHBS3LgKBcfTUUvWkm67qNX3Xaik1MKjvredkcH+7byxL+TiDE=
+        foreman-proxy@foreman-proxy.example.com","download_policy":"immediate","supported_pulp_types":["ansible_collection","docker","file","yum"],"lifecycle_environments":[{"id":7,"name":"Test","description":null,"library":false,"organization_id":6,"created_at":"2024-07-10
+        14:13:11 UTC","updated_at":"2024-07-10 14:13:11 UTC","label":"test","registry_name_pattern":null,"registry_unauthenticated_pull":false,"prior":"Dev","prior_id":6,"organization":"Test
+        Organization"}],"features":[{"capabilities":[],"name":"Container_Gateway","id":4},{"capabilities":["single","ssh"],"name":"Dynflow","id":17},{"capabilities":["cockpit"],"name":"Script","id":19},{"capabilities":["ansible","certguard","container","core","file","rpm"],"name":"Pulpcore","id":3},{"capabilities":[],"name":"Templates","id":5},{"capabilities":[],"name":"Logs","id":13},{"capabilities":[],"name":"Registration","id":16},{"capabilities":[],"name":"Container_Gateway","id":4},{"capabilities":["single","ssh"],"name":"Dynflow","id":17},{"capabilities":["cockpit"],"name":"Script","id":19},{"capabilities":["ansible","certguard","container","core","file","rpm"],"name":"Pulpcore","id":3},{"capabilities":[],"name":"Templates","id":5},{"capabilities":[],"name":"Logs","id":13},{"capabilities":[],"name":"Registration","id":16}],"locations":[],"organizations":[]}'
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      connection: [Keep-Alive]
-      content-length: ['856']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline''
-          ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      foreman_api_version: ['2']
-      foreman_current_location: [; ANY]
-      foreman_current_organization: [; ANY]
-      foreman_version: [2.2.0-rc3]
-      keep-alive: ['timeout=15, max=97']
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Length:
+      - '2112'
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.12.0-develop
+      Keep-Alive:
+      - timeout=15, max=97
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/test_playbooks/fixtures/katello_smart_proxy-5.yml
+++ b/tests/test_playbooks/fixtures/katello_smart_proxy-5.yml
@@ -2,106 +2,176 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: [application/json;version=2]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: ['apypie (https://github.com/Apipie/apypie)']
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
     uri: https://foreman.example.org/api/status
   response:
-    body: {string: !!python/unicode '{"result":"ok","status":200,"version":"2.2.0-rc3","api_version":2}'}
+    body:
+      string: '{"satellite_version":"6.16.0","result":"ok","status":200,"version":"3.12.0-develop","api_version":2}'
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      connection: [Keep-Alive]
-      content-length: ['66']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline''
-          ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      foreman_api_version: ['2']
-      foreman_current_location: [; ANY]
-      foreman_current_organization: [; ANY]
-      foreman_version: [2.2.0-rc3]
-      keep-alive: ['timeout=15, max=100']
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Length:
+      - '100'
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.12.0-develop
+      Keep-Alive:
+      - timeout=15, max=100
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json;version=2]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: ['apypie (https://github.com/Apipie/apypie)']
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/smart_proxies?per_page=4294967296&search=name%3D%22Smart+Proxy%22
+    uri: https://foreman.example.org/api/smart_proxies?search=name%3D%22Smart+Proxy%22&per_page=4294967296
   response:
-    body: {string: !!python/unicode "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\":
-        1,\n  \"per_page\": 4294967296,\n  \"search\": \"name=\\\"Smart Proxy\\\"\",\n
-        \ \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
-        [{\"created_at\":\"2020-10-21 09:15:38 UTC\",\"updated_at\":\"2020-10-21 09:15:45
-        UTC\",\"name\":\"Smart Proxy\",\"id\":15,\"url\":\"http://foreman-proxy.example.com:8000\",\"remote_execution_pubkey\":null,\"download_policy\":\"background\",\"supported_pulp_types\":{\"pulp2\":{\"supported_types\":[\"deb\",\"docker\",\"file\",\"puppet\",\"yum\"]},\"pulp3\":{\"supported_types\":[],\"overriden_to_pulp2\":[]}},\"features\":[{\"capabilities\":[],\"name\":\"Pulp
-        Node\",\"id\":3},{\"capabilities\":[],\"name\":\"Templates\",\"id\":1},{\"capabilities\":[],\"name\":\"Puppet
-        CA\",\"id\":9},{\"capabilities\":[],\"name\":\"Puppet\",\"id\":8},{\"capabilities\":[],\"name\":\"Logs\",\"id\":13}]}]\n}\n"}
+    body:
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+        4294967296,\n  \"search\": \"name=\\\"Smart Proxy\\\"\",\n  \"sort\": {\n
+        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\":\"2024-07-10
+        14:13:12 UTC\",\"updated_at\":\"2024-07-10 14:13:18 UTC\",\"hosts_count\":0,\"name\":\"Smart
+        Proxy\",\"id\":12,\"url\":\"https://foreman-proxy.example.com:9090\",\"remote_execution_pubkey\":\"ssh-rsa
+        AAAAB3NzaC1yc2EAAAADAQABAAABgQCkn5pNuZ47pHDMpL1or9cDtaDJaJXn2EdrmcQBiXQOhoWjSn3R2da7ThZkjXGTirQrMeU8FeDpZUso368rUGU4PFg8JHCwuNF7X+mcOeodK3EJyGHIfsj172xF8wAHUc4tK2MSIKDfVd8MvX4M3qPN80290wmhCh4YrKFA30az96eSP4RDt19m3/qxTXpcmSRyuw1NKr0DUs4lCG08uV4hMpheypT21HM8eb3NSic73fY0nTLOerTwo9BUdQugjdiBNjlA9o9MzSZ6acCiOqAxqYEnVlWKqfgsy/55uBCAi4rO78sIKptvb+g1i1l86HNj/6xtwlrsXNft1p6MwcGDb66naRDARhzNLWUlrM6yqXpOkHEK1w76zaNw0RfwsxFSbZx5TueQQ1QI/DIxcIX0bIBSiVsp39TneEwFQqXu0a7dvst4LAKIOii6GtEc6FIcuCX49x6qe0VsJvHBS3LgKBcfTUUvWkm67qNX3Xaik1MKjvredkcH+7byxL+TiDE=
+        foreman-proxy@foreman-proxy.example.com\",\"download_policy\":\"immediate\",\"supported_pulp_types\":[\"ansible_collection\",\"docker\",\"file\",\"yum\"],\"lifecycle_environments\":[{\"id\":7,\"name\":\"Test\",\"description\":null,\"library\":false,\"organization_id\":6,\"created_at\":\"2024-07-10
+        14:13:11 UTC\",\"updated_at\":\"2024-07-10 14:13:11 UTC\",\"label\":\"test\",\"registry_name_pattern\":null,\"registry_unauthenticated_pull\":false,\"prior\":\"Dev\",\"prior_id\":6,\"organization\":\"Test
+        Organization\"}],\"features\":[{\"capabilities\":[],\"name\":\"Container_Gateway\",\"id\":4},{\"capabilities\":[\"single\",\"ssh\"],\"name\":\"Dynflow\",\"id\":17},{\"capabilities\":[\"cockpit\"],\"name\":\"Script\",\"id\":19},{\"capabilities\":[\"ansible\",\"certguard\",\"container\",\"core\",\"file\",\"rpm\"],\"name\":\"Pulpcore\",\"id\":3},{\"capabilities\":[],\"name\":\"Templates\",\"id\":5},{\"capabilities\":[],\"name\":\"Logs\",\"id\":13},{\"capabilities\":[],\"name\":\"Registration\",\"id\":16}]}]\n}\n"
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      connection: [Keep-Alive]
-      content-length: ['776']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline''
-          ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      foreman_api_version: ['2']
-      foreman_current_location: [; ANY]
-      foreman_current_organization: [; ANY]
-      foreman_version: [2.2.0-rc3]
-      keep-alive: ['timeout=15, max=99']
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Length:
+      - '1853'
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.12.0-develop
+      Keep-Alive:
+      - timeout=15, max=99
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json;version=2]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: ['apypie (https://github.com/Apipie/apypie)']
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/smart_proxies/15
+    uri: https://foreman.example.org/api/smart_proxies/12
   response:
-    body: {string: !!python/unicode '{"created_at":"2020-10-21 09:15:38 UTC","updated_at":"2020-10-21
-        09:15:45 UTC","name":"Smart Proxy","id":15,"url":"http://foreman-proxy.example.com:8000","remote_execution_pubkey":null,"download_policy":"background","supported_pulp_types":{"pulp2":{"supported_types":["deb","docker","file","puppet","yum"]},"pulp3":{"supported_types":[],"overriden_to_pulp2":[]}},"features":[{"capabilities":[],"name":"Pulp
-        Node","id":3},{"capabilities":[],"name":"Templates","id":1},{"capabilities":[],"name":"Puppet
-        CA","id":9},{"capabilities":[],"name":"Puppet","id":8},{"capabilities":[],"name":"Logs","id":13}],"locations":[],"organizations":[]}'}
+    body:
+      string: '{"created_at":"2024-07-10 14:13:12 UTC","updated_at":"2024-07-10 14:13:18
+        UTC","hosts_count":0,"name":"Smart Proxy","id":12,"url":"https://foreman-proxy.example.com:9090","remote_execution_pubkey":"ssh-rsa
+        AAAAB3NzaC1yc2EAAAADAQABAAABgQCkn5pNuZ47pHDMpL1or9cDtaDJaJXn2EdrmcQBiXQOhoWjSn3R2da7ThZkjXGTirQrMeU8FeDpZUso368rUGU4PFg8JHCwuNF7X+mcOeodK3EJyGHIfsj172xF8wAHUc4tK2MSIKDfVd8MvX4M3qPN80290wmhCh4YrKFA30az96eSP4RDt19m3/qxTXpcmSRyuw1NKr0DUs4lCG08uV4hMpheypT21HM8eb3NSic73fY0nTLOerTwo9BUdQugjdiBNjlA9o9MzSZ6acCiOqAxqYEnVlWKqfgsy/55uBCAi4rO78sIKptvb+g1i1l86HNj/6xtwlrsXNft1p6MwcGDb66naRDARhzNLWUlrM6yqXpOkHEK1w76zaNw0RfwsxFSbZx5TueQQ1QI/DIxcIX0bIBSiVsp39TneEwFQqXu0a7dvst4LAKIOii6GtEc6FIcuCX49x6qe0VsJvHBS3LgKBcfTUUvWkm67qNX3Xaik1MKjvredkcH+7byxL+TiDE=
+        foreman-proxy@foreman-proxy.example.com","download_policy":"immediate","supported_pulp_types":["ansible_collection","docker","file","yum"],"lifecycle_environments":[{"id":7,"name":"Test","description":null,"library":false,"organization_id":6,"created_at":"2024-07-10
+        14:13:11 UTC","updated_at":"2024-07-10 14:13:11 UTC","label":"test","registry_name_pattern":null,"registry_unauthenticated_pull":false,"prior":"Dev","prior_id":6,"organization":"Test
+        Organization"}],"features":[{"capabilities":[],"name":"Container_Gateway","id":4},{"capabilities":["single","ssh"],"name":"Dynflow","id":17},{"capabilities":["cockpit"],"name":"Script","id":19},{"capabilities":["ansible","certguard","container","core","file","rpm"],"name":"Pulpcore","id":3},{"capabilities":[],"name":"Templates","id":5},{"capabilities":[],"name":"Logs","id":13},{"capabilities":[],"name":"Registration","id":16}],"locations":[],"organizations":[]}'
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      connection: [Keep-Alive]
-      content-length: ['633']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline''
-          ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      foreman_api_version: ['2']
-      foreman_current_location: [; ANY]
-      foreman_current_organization: [; ANY]
-      foreman_version: [2.2.0-rc3]
-      keep-alive: ['timeout=15, max=98']
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Length:
+      - '1710'
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.12.0-develop
+      Keep-Alive:
+      - timeout=15, max=98
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/test_playbooks/fixtures/katello_smart_proxy-6.yml
+++ b/tests/test_playbooks/fixtures/katello_smart_proxy-6.yml
@@ -2,104 +2,175 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: [application/json;version=2]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: ['apypie (https://github.com/Apipie/apypie)']
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
     uri: https://foreman.example.org/api/status
   response:
-    body: {string: !!python/unicode '{"result":"ok","status":200,"version":"2.2.0-rc3","api_version":2}'}
+    body:
+      string: '{"satellite_version":"6.16.0","result":"ok","status":200,"version":"3.12.0-develop","api_version":2}'
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      connection: [Keep-Alive]
-      content-length: ['66']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline''
-          ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      foreman_api_version: ['2']
-      foreman_current_location: [; ANY]
-      foreman_current_organization: [; ANY]
-      foreman_version: [2.2.0-rc3]
-      keep-alive: ['timeout=15, max=100']
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Length:
+      - '100'
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.12.0-develop
+      Keep-Alive:
+      - timeout=15, max=100
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json;version=2]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: ['apypie (https://github.com/Apipie/apypie)']
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/smart_proxies?per_page=4294967296&search=name%3D%22Smart+Proxy%22
+    uri: https://foreman.example.org/api/smart_proxies?search=name%3D%22Smart+Proxy%22&per_page=4294967296
   response:
-    body: {string: !!python/unicode "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\":
-        1,\n  \"per_page\": 4294967296,\n  \"search\": \"name=\\\"Smart Proxy\\\"\",\n
-        \ \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
-        [{\"created_at\":\"2020-10-21 09:15:38 UTC\",\"updated_at\":\"2020-10-21 09:15:45
-        UTC\",\"name\":\"Smart Proxy\",\"id\":15,\"url\":\"http://foreman-proxy.example.com:8000\",\"remote_execution_pubkey\":null,\"download_policy\":\"background\",\"supported_pulp_types\":{\"pulp2\":{\"supported_types\":[\"deb\",\"docker\",\"file\",\"puppet\",\"yum\"]},\"pulp3\":{\"supported_types\":[],\"overriden_to_pulp2\":[]}},\"features\":[{\"capabilities\":[],\"name\":\"Pulp
-        Node\",\"id\":3},{\"capabilities\":[],\"name\":\"Templates\",\"id\":1},{\"capabilities\":[],\"name\":\"Puppet
-        CA\",\"id\":9},{\"capabilities\":[],\"name\":\"Puppet\",\"id\":8},{\"capabilities\":[],\"name\":\"Logs\",\"id\":13}]}]\n}\n"}
+    body:
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+        4294967296,\n  \"search\": \"name=\\\"Smart Proxy\\\"\",\n  \"sort\": {\n
+        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\":\"2024-07-10
+        14:13:12 UTC\",\"updated_at\":\"2024-07-10 14:13:18 UTC\",\"hosts_count\":0,\"name\":\"Smart
+        Proxy\",\"id\":12,\"url\":\"https://foreman-proxy.example.com:9090\",\"remote_execution_pubkey\":\"ssh-rsa
+        AAAAB3NzaC1yc2EAAAADAQABAAABgQCkn5pNuZ47pHDMpL1or9cDtaDJaJXn2EdrmcQBiXQOhoWjSn3R2da7ThZkjXGTirQrMeU8FeDpZUso368rUGU4PFg8JHCwuNF7X+mcOeodK3EJyGHIfsj172xF8wAHUc4tK2MSIKDfVd8MvX4M3qPN80290wmhCh4YrKFA30az96eSP4RDt19m3/qxTXpcmSRyuw1NKr0DUs4lCG08uV4hMpheypT21HM8eb3NSic73fY0nTLOerTwo9BUdQugjdiBNjlA9o9MzSZ6acCiOqAxqYEnVlWKqfgsy/55uBCAi4rO78sIKptvb+g1i1l86HNj/6xtwlrsXNft1p6MwcGDb66naRDARhzNLWUlrM6yqXpOkHEK1w76zaNw0RfwsxFSbZx5TueQQ1QI/DIxcIX0bIBSiVsp39TneEwFQqXu0a7dvst4LAKIOii6GtEc6FIcuCX49x6qe0VsJvHBS3LgKBcfTUUvWkm67qNX3Xaik1MKjvredkcH+7byxL+TiDE=
+        foreman-proxy@foreman-proxy.example.com\",\"download_policy\":\"immediate\",\"supported_pulp_types\":[\"ansible_collection\",\"docker\",\"file\",\"yum\"],\"lifecycle_environments\":[{\"id\":7,\"name\":\"Test\",\"description\":null,\"library\":false,\"organization_id\":6,\"created_at\":\"2024-07-10
+        14:13:11 UTC\",\"updated_at\":\"2024-07-10 14:13:11 UTC\",\"label\":\"test\",\"registry_name_pattern\":null,\"registry_unauthenticated_pull\":false,\"prior\":\"Dev\",\"prior_id\":6,\"organization\":\"Test
+        Organization\"}],\"features\":[{\"capabilities\":[],\"name\":\"Container_Gateway\",\"id\":4},{\"capabilities\":[\"single\",\"ssh\"],\"name\":\"Dynflow\",\"id\":17},{\"capabilities\":[\"cockpit\"],\"name\":\"Script\",\"id\":19},{\"capabilities\":[\"ansible\",\"certguard\",\"container\",\"core\",\"file\",\"rpm\"],\"name\":\"Pulpcore\",\"id\":3},{\"capabilities\":[],\"name\":\"Templates\",\"id\":5},{\"capabilities\":[],\"name\":\"Logs\",\"id\":13},{\"capabilities\":[],\"name\":\"Registration\",\"id\":16}]}]\n}\n"
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      connection: [Keep-Alive]
-      content-length: ['776']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline''
-          ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      foreman_api_version: ['2']
-      foreman_current_location: [; ANY]
-      foreman_current_organization: [; ANY]
-      foreman_version: [2.2.0-rc3]
-      keep-alive: ['timeout=15, max=99']
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Length:
+      - '1853'
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.12.0-develop
+      Keep-Alive:
+      - timeout=15, max=99
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json;version=2]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: ['apypie (https://github.com/Apipie/apypie)']
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: DELETE
-    uri: https://foreman.example.org/api/smart_proxies/15
+    uri: https://foreman.example.org/api/smart_proxies/12
   response:
-    body: {string: !!python/unicode '{"id":15,"name":"Smart Proxy","url":"http://foreman-proxy.example.com:8000","created_at":"2020-10-21T09:15:38.009Z","updated_at":"2020-10-21T09:15:45.892Z","pubkey":null,"expired_logs":"0","puppet_path":null,"download_policy":"background"}'}
+    body:
+      string: '{"id":12,"name":"Smart Proxy","url":"https://foreman-proxy.example.com:9090","created_at":"2024-07-10T14:13:12.420Z","updated_at":"2024-07-10T14:13:18.817Z","pubkey":"ssh-rsa
+        AAAAB3NzaC1yc2EAAAADAQABAAABgQCkn5pNuZ47pHDMpL1or9cDtaDJaJXn2EdrmcQBiXQOhoWjSn3R2da7ThZkjXGTirQrMeU8FeDpZUso368rUGU4PFg8JHCwuNF7X+mcOeodK3EJyGHIfsj172xF8wAHUc4tK2MSIKDfVd8MvX4M3qPN80290wmhCh4YrKFA30az96eSP4RDt19m3/qxTXpcmSRyuw1NKr0DUs4lCG08uV4hMpheypT21HM8eb3NSic73fY0nTLOerTwo9BUdQugjdiBNjlA9o9MzSZ6acCiOqAxqYEnVlWKqfgsy/55uBCAi4rO78sIKptvb+g1i1l86HNj/6xtwlrsXNft1p6MwcGDb66naRDARhzNLWUlrM6yqXpOkHEK1w76zaNw0RfwsxFSbZx5TueQQ1QI/DIxcIX0bIBSiVsp39TneEwFQqXu0a7dvst4LAKIOii6GtEc6FIcuCX49x6qe0VsJvHBS3LgKBcfTUUvWkm67qNX3Xaik1MKjvredkcH+7byxL+TiDE=
+        foreman-proxy@foreman-proxy.example.com","expired_logs":"0","puppet_path":null,"download_policy":"immediate","http_proxy_id":null,"content_counts":null}'
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      connection: [Keep-Alive]
-      content-length: ['239']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline''
-          ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      foreman_api_version: ['2']
-      foreman_current_location: [; ANY]
-      foreman_current_organization: [; ANY]
-      foreman_version: [2.2.0-rc3]
-      keep-alive: ['timeout=15, max=98']
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Length:
+      - '916'
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.12.0-develop
+      Keep-Alive:
+      - timeout=15, max=98
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/test_playbooks/fixtures/katello_smart_proxy-7.yml
+++ b/tests/test_playbooks/fixtures/katello_smart_proxy-7.yml
@@ -2,68 +2,111 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: [application/json;version=2]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: ['apypie (https://github.com/Apipie/apypie)']
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
     uri: https://foreman.example.org/api/status
   response:
-    body: {string: !!python/unicode '{"result":"ok","status":200,"version":"2.2.0-rc3","api_version":2}'}
+    body:
+      string: '{"satellite_version":"6.16.0","result":"ok","status":200,"version":"3.12.0-develop","api_version":2}'
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      connection: [Keep-Alive]
-      content-length: ['66']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline''
-          ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      foreman_api_version: ['2']
-      foreman_current_location: [; ANY]
-      foreman_current_organization: [; ANY]
-      foreman_version: [2.2.0-rc3]
-      keep-alive: ['timeout=15, max=100']
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Length:
+      - '100'
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.12.0-develop
+      Keep-Alive:
+      - timeout=15, max=100
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json;version=2]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: ['apypie (https://github.com/Apipie/apypie)']
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/smart_proxies?per_page=4294967296&search=name%3D%22Smart+Proxy%22
+    uri: https://foreman.example.org/api/smart_proxies?search=name%3D%22Smart+Proxy%22&per_page=4294967296
   response:
-    body: {string: !!python/unicode "{\n  \"total\": 2,\n  \"subtotal\": 0,\n  \"page\":
-        1,\n  \"per_page\": 4294967296,\n  \"search\": \"name=\\\"Smart Proxy\\\"\",\n
-        \ \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
-        []\n}\n"}
+    body:
+      string: "{\n  \"total\": 1,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\":
+        4294967296,\n  \"search\": \"name=\\\"Smart Proxy\\\"\",\n  \"sort\": {\n
+        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": []\n}\n"
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      connection: [Keep-Alive]
-      content-length: ['177']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline''
-          ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      foreman_api_version: ['2']
-      foreman_current_location: [; ANY]
-      foreman_current_organization: [; ANY]
-      foreman_version: [2.2.0-rc3]
-      keep-alive: ['timeout=15, max=99']
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Length:
+      - '177'
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.12.0-develop
+      Keep-Alive:
+      - timeout=15, max=99
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/test_playbooks/fixtures/smart_proxy-0.yml
+++ b/tests/test_playbooks/fixtures/smart_proxy-0.yml
@@ -2,105 +2,172 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: [application/json;version=2]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: ['apypie (https://github.com/Apipie/apypie)']
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
     uri: https://foreman.example.org/api/status
   response:
-    body: {string: !!python/unicode '{"result":"ok","status":200,"version":"2.2.0-rc3","api_version":2}'}
+    body:
+      string: '{"satellite_version":"6.16.0","result":"ok","status":200,"version":"3.12.0-develop","api_version":2}'
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      connection: [Keep-Alive]
-      content-length: ['66']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline''
-          ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      foreman_api_version: ['2']
-      foreman_current_location: [; ANY]
-      foreman_current_organization: [; ANY]
-      foreman_version: [2.2.0-rc3]
-      keep-alive: ['timeout=15, max=100']
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Length:
+      - '100'
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.12.0-develop
+      Keep-Alive:
+      - timeout=15, max=100
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json;version=2]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: ['apypie (https://github.com/Apipie/apypie)']
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/smart_proxies?per_page=4294967296&search=name%3D%22Smart+Proxy%22
+    uri: https://foreman.example.org/api/smart_proxies?search=name%3D%22Smart+Proxy%22&per_page=4294967296
   response:
-    body: {string: !!python/unicode "{\n  \"total\": 2,\n  \"subtotal\": 0,\n  \"page\":
-        1,\n  \"per_page\": 4294967296,\n  \"search\": \"name=\\\"Smart Proxy\\\"\",\n
-        \ \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
-        []\n}\n"}
+    body:
+      string: "{\n  \"total\": 1,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\":
+        4294967296,\n  \"search\": \"name=\\\"Smart Proxy\\\"\",\n  \"sort\": {\n
+        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": []\n}\n"
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      connection: [Keep-Alive]
-      content-length: ['177']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline''
-          ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      foreman_api_version: ['2']
-      foreman_current_location: [; ANY]
-      foreman_current_organization: [; ANY]
-      foreman_version: [2.2.0-rc3]
-      keep-alive: ['timeout=15, max=99']
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Length:
+      - '177'
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.12.0-develop
+      Keep-Alive:
+      - timeout=15, max=99
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
-    body: !!python/unicode '{"smart_proxy": {"url": "http://foreman-proxy.example.com:8000",
-      "name": "Smart Proxy"}}'
+    body: '{"smart_proxy": {"name": "Smart Proxy", "url": "https://foreman-proxy.example.com:9090"}}'
     headers:
-      Accept: [application/json;version=2]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['88']
-      Content-Type: [application/json]
-      User-Agent: ['apypie (https://github.com/Apipie/apypie)']
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '111'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: POST
     uri: https://foreman.example.org/api/smart_proxies
   response:
-    body: {string: !!python/unicode '{"created_at":"2020-10-20 15:41:46 UTC","updated_at":"2020-10-20
-        15:41:46 UTC","name":"Smart Proxy","id":13,"url":"http://foreman-proxy.example.com:8000","remote_execution_pubkey":null,"download_policy":"on_demand","supported_pulp_types":{"pulp2":{"supported_types":["deb","docker","file","puppet","yum"]},"pulp3":{"supported_types":[],"overriden_to_pulp2":[]}},"features":[{"capabilities":[],"name":"Pulp
-        Node","id":3},{"capabilities":[],"name":"Templates","id":1},{"capabilities":[],"name":"Puppet
-        CA","id":9},{"capabilities":[],"name":"Puppet","id":8},{"capabilities":[],"name":"Logs","id":13}],"locations":[],"organizations":[]}'}
+    body:
+      string: '{"created_at":"2024-07-10 14:25:39 UTC","updated_at":"2024-07-10 14:25:39
+        UTC","hosts_count":0,"name":"Smart Proxy","id":14,"url":"https://foreman-proxy.example.com:9090","remote_execution_pubkey":"ssh-rsa
+        AAAAB3NzaC1yc2EAAAADAQABAAABgQCkn5pNuZ47pHDMpL1or9cDtaDJaJXn2EdrmcQBiXQOhoWjSn3R2da7ThZkjXGTirQrMeU8FeDpZUso368rUGU4PFg8JHCwuNF7X+mcOeodK3EJyGHIfsj172xF8wAHUc4tK2MSIKDfVd8MvX4M3qPN80290wmhCh4YrKFA30az96eSP4RDt19m3/qxTXpcmSRyuw1NKr0DUs4lCG08uV4hMpheypT21HM8eb3NSic73fY0nTLOerTwo9BUdQugjdiBNjlA9o9MzSZ6acCiOqAxqYEnVlWKqfgsy/55uBCAi4rO78sIKptvb+g1i1l86HNj/6xtwlrsXNft1p6MwcGDb66naRDARhzNLWUlrM6yqXpOkHEK1w76zaNw0RfwsxFSbZx5TueQQ1QI/DIxcIX0bIBSiVsp39TneEwFQqXu0a7dvst4LAKIOii6GtEc6FIcuCX49x6qe0VsJvHBS3LgKBcfTUUvWkm67qNX3Xaik1MKjvredkcH+7byxL+TiDE=
+        foreman-proxy@foreman-proxy.example.com","download_policy":"on_demand","supported_pulp_types":["ansible_collection","docker","file","yum"],"lifecycle_environments":[],"features":[{"capabilities":[],"name":"Container_Gateway","id":4},{"capabilities":["single","ssh"],"name":"Dynflow","id":17},{"capabilities":["cockpit"],"name":"Script","id":19},{"capabilities":["ansible","certguard","container","core","file","rpm"],"name":"Pulpcore","id":3},{"capabilities":[],"name":"Templates","id":5},{"capabilities":[],"name":"Logs","id":13},{"capabilities":[],"name":"Registration","id":16},{"capabilities":[],"name":"Container_Gateway","id":4},{"capabilities":["single","ssh"],"name":"Dynflow","id":17},{"capabilities":["cockpit"],"name":"Script","id":19},{"capabilities":["ansible","certguard","container","core","file","rpm"],"name":"Pulpcore","id":3},{"capabilities":[],"name":"Templates","id":5},{"capabilities":[],"name":"Logs","id":13},{"capabilities":[],"name":"Registration","id":16}],"locations":[],"organizations":[]}'
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      connection: [Keep-Alive]
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline''
-          ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      foreman_api_version: ['2']
-      foreman_current_location: [; ANY]
-      foreman_current_organization: [; ANY]
-      foreman_version: [2.2.0-rc3]
-      keep-alive: ['timeout=15, max=98']
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      transfer-encoding: [chunked]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-xss-protection: [1; mode=block]
-    status: {code: 201, message: Created}
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Length:
+      - '1813'
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.12.0-develop
+      Keep-Alive:
+      - timeout=15, max=98
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
 version: 1

--- a/tests/test_playbooks/fixtures/smart_proxy-1.yml
+++ b/tests/test_playbooks/fixtures/smart_proxy-1.yml
@@ -2,106 +2,172 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: [application/json;version=2]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: ['apypie (https://github.com/Apipie/apypie)']
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
     uri: https://foreman.example.org/api/status
   response:
-    body: {string: !!python/unicode '{"result":"ok","status":200,"version":"2.2.0-rc3","api_version":2}'}
+    body:
+      string: '{"satellite_version":"6.16.0","result":"ok","status":200,"version":"3.12.0-develop","api_version":2}'
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      connection: [Keep-Alive]
-      content-length: ['66']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline''
-          ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      foreman_api_version: ['2']
-      foreman_current_location: [; ANY]
-      foreman_current_organization: [; ANY]
-      foreman_version: [2.2.0-rc3]
-      keep-alive: ['timeout=15, max=100']
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Length:
+      - '100'
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.12.0-develop
+      Keep-Alive:
+      - timeout=15, max=100
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json;version=2]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: ['apypie (https://github.com/Apipie/apypie)']
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/smart_proxies?per_page=4294967296&search=name%3D%22Smart+Proxy%22
+    uri: https://foreman.example.org/api/smart_proxies?search=name%3D%22Smart+Proxy%22&per_page=4294967296
   response:
-    body: {string: !!python/unicode "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\":
-        1,\n  \"per_page\": 4294967296,\n  \"search\": \"name=\\\"Smart Proxy\\\"\",\n
-        \ \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
-        [{\"created_at\":\"2020-10-20 15:41:46 UTC\",\"updated_at\":\"2020-10-20 15:41:46
-        UTC\",\"name\":\"Smart Proxy\",\"id\":13,\"url\":\"http://foreman-proxy.example.com:8000\",\"remote_execution_pubkey\":null,\"download_policy\":\"on_demand\",\"supported_pulp_types\":{\"pulp2\":{\"supported_types\":[\"deb\",\"docker\",\"file\",\"puppet\",\"yum\"]},\"pulp3\":{\"supported_types\":[],\"overriden_to_pulp2\":[]}},\"features\":[{\"capabilities\":[],\"name\":\"Pulp
-        Node\",\"id\":3},{\"capabilities\":[],\"name\":\"Templates\",\"id\":1},{\"capabilities\":[],\"name\":\"Puppet
-        CA\",\"id\":9},{\"capabilities\":[],\"name\":\"Puppet\",\"id\":8},{\"capabilities\":[],\"name\":\"Logs\",\"id\":13}]}]\n}\n"}
+    body:
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+        4294967296,\n  \"search\": \"name=\\\"Smart Proxy\\\"\",\n  \"sort\": {\n
+        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\":\"2024-07-10
+        14:25:39 UTC\",\"updated_at\":\"2024-07-10 14:25:39 UTC\",\"hosts_count\":0,\"name\":\"Smart
+        Proxy\",\"id\":14,\"url\":\"https://foreman-proxy.example.com:9090\",\"remote_execution_pubkey\":\"ssh-rsa
+        AAAAB3NzaC1yc2EAAAADAQABAAABgQCkn5pNuZ47pHDMpL1or9cDtaDJaJXn2EdrmcQBiXQOhoWjSn3R2da7ThZkjXGTirQrMeU8FeDpZUso368rUGU4PFg8JHCwuNF7X+mcOeodK3EJyGHIfsj172xF8wAHUc4tK2MSIKDfVd8MvX4M3qPN80290wmhCh4YrKFA30az96eSP4RDt19m3/qxTXpcmSRyuw1NKr0DUs4lCG08uV4hMpheypT21HM8eb3NSic73fY0nTLOerTwo9BUdQugjdiBNjlA9o9MzSZ6acCiOqAxqYEnVlWKqfgsy/55uBCAi4rO78sIKptvb+g1i1l86HNj/6xtwlrsXNft1p6MwcGDb66naRDARhzNLWUlrM6yqXpOkHEK1w76zaNw0RfwsxFSbZx5TueQQ1QI/DIxcIX0bIBSiVsp39TneEwFQqXu0a7dvst4LAKIOii6GtEc6FIcuCX49x6qe0VsJvHBS3LgKBcfTUUvWkm67qNX3Xaik1MKjvredkcH+7byxL+TiDE=
+        foreman-proxy@foreman-proxy.example.com\",\"download_policy\":\"on_demand\",\"supported_pulp_types\":[\"ansible_collection\",\"docker\",\"file\",\"yum\"],\"lifecycle_environments\":[],\"features\":[{\"capabilities\":[],\"name\":\"Container_Gateway\",\"id\":4},{\"capabilities\":[\"single\",\"ssh\"],\"name\":\"Dynflow\",\"id\":17},{\"capabilities\":[\"cockpit\"],\"name\":\"Script\",\"id\":19},{\"capabilities\":[\"ansible\",\"certguard\",\"container\",\"core\",\"file\",\"rpm\"],\"name\":\"Pulpcore\",\"id\":3},{\"capabilities\":[],\"name\":\"Templates\",\"id\":5},{\"capabilities\":[],\"name\":\"Logs\",\"id\":13},{\"capabilities\":[],\"name\":\"Registration\",\"id\":16}]}]\n}\n"
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      connection: [Keep-Alive]
-      content-length: ['775']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline''
-          ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      foreman_api_version: ['2']
-      foreman_current_location: [; ANY]
-      foreman_current_organization: [; ANY]
-      foreman_version: [2.2.0-rc3]
-      keep-alive: ['timeout=15, max=99']
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Length:
+      - '1554'
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.12.0-develop
+      Keep-Alive:
+      - timeout=15, max=99
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json;version=2]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: ['apypie (https://github.com/Apipie/apypie)']
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/smart_proxies/13
+    uri: https://foreman.example.org/api/smart_proxies/14
   response:
-    body: {string: !!python/unicode '{"created_at":"2020-10-20 15:41:46 UTC","updated_at":"2020-10-20
-        15:41:46 UTC","name":"Smart Proxy","id":13,"url":"http://foreman-proxy.example.com:8000","remote_execution_pubkey":null,"download_policy":"on_demand","supported_pulp_types":{"pulp2":{"supported_types":["deb","docker","file","puppet","yum"]},"pulp3":{"supported_types":[],"overriden_to_pulp2":[]}},"features":[{"capabilities":[],"name":"Pulp
-        Node","id":3},{"capabilities":[],"name":"Templates","id":1},{"capabilities":[],"name":"Puppet
-        CA","id":9},{"capabilities":[],"name":"Puppet","id":8},{"capabilities":[],"name":"Logs","id":13}],"locations":[],"organizations":[]}'}
+    body:
+      string: '{"created_at":"2024-07-10 14:25:39 UTC","updated_at":"2024-07-10 14:25:39
+        UTC","hosts_count":0,"name":"Smart Proxy","id":14,"url":"https://foreman-proxy.example.com:9090","remote_execution_pubkey":"ssh-rsa
+        AAAAB3NzaC1yc2EAAAADAQABAAABgQCkn5pNuZ47pHDMpL1or9cDtaDJaJXn2EdrmcQBiXQOhoWjSn3R2da7ThZkjXGTirQrMeU8FeDpZUso368rUGU4PFg8JHCwuNF7X+mcOeodK3EJyGHIfsj172xF8wAHUc4tK2MSIKDfVd8MvX4M3qPN80290wmhCh4YrKFA30az96eSP4RDt19m3/qxTXpcmSRyuw1NKr0DUs4lCG08uV4hMpheypT21HM8eb3NSic73fY0nTLOerTwo9BUdQugjdiBNjlA9o9MzSZ6acCiOqAxqYEnVlWKqfgsy/55uBCAi4rO78sIKptvb+g1i1l86HNj/6xtwlrsXNft1p6MwcGDb66naRDARhzNLWUlrM6yqXpOkHEK1w76zaNw0RfwsxFSbZx5TueQQ1QI/DIxcIX0bIBSiVsp39TneEwFQqXu0a7dvst4LAKIOii6GtEc6FIcuCX49x6qe0VsJvHBS3LgKBcfTUUvWkm67qNX3Xaik1MKjvredkcH+7byxL+TiDE=
+        foreman-proxy@foreman-proxy.example.com","download_policy":"on_demand","supported_pulp_types":["ansible_collection","docker","file","yum"],"lifecycle_environments":[],"features":[{"capabilities":[],"name":"Container_Gateway","id":4},{"capabilities":["single","ssh"],"name":"Dynflow","id":17},{"capabilities":["cockpit"],"name":"Script","id":19},{"capabilities":["ansible","certguard","container","core","file","rpm"],"name":"Pulpcore","id":3},{"capabilities":[],"name":"Templates","id":5},{"capabilities":[],"name":"Logs","id":13},{"capabilities":[],"name":"Registration","id":16}],"locations":[],"organizations":[]}'
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      connection: [Keep-Alive]
-      content-length: ['632']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline''
-          ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      foreman_api_version: ['2']
-      foreman_current_location: [; ANY]
-      foreman_current_organization: [; ANY]
-      foreman_version: [2.2.0-rc3]
-      keep-alive: ['timeout=15, max=98']
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Length:
+      - '1411'
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.12.0-develop
+      Keep-Alive:
+      - timeout=15, max=98
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/test_playbooks/fixtures/smart_proxy-2.yml
+++ b/tests/test_playbooks/fixtures/smart_proxy-2.yml
@@ -2,104 +2,173 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: [application/json;version=2]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: ['apypie (https://github.com/Apipie/apypie)']
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
     uri: https://foreman.example.org/api/status
   response:
-    body: {string: !!python/unicode '{"result":"ok","status":200,"version":"2.2.0-rc3","api_version":2}'}
+    body:
+      string: '{"satellite_version":"6.16.0","result":"ok","status":200,"version":"3.12.0-develop","api_version":2}'
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      connection: [Keep-Alive]
-      content-length: ['66']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline''
-          ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      foreman_api_version: ['2']
-      foreman_current_location: [; ANY]
-      foreman_current_organization: [; ANY]
-      foreman_version: [2.2.0-rc3]
-      keep-alive: ['timeout=15, max=100']
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Length:
+      - '100'
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.12.0-develop
+      Keep-Alive:
+      - timeout=15, max=100
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json;version=2]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: ['apypie (https://github.com/Apipie/apypie)']
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/smart_proxies?per_page=4294967296&search=name%3D%22Smart+Proxy%22
+    uri: https://foreman.example.org/api/smart_proxies?search=name%3D%22Smart+Proxy%22&per_page=4294967296
   response:
-    body: {string: !!python/unicode "{\n  \"total\": 3,\n  \"subtotal\": 1,\n  \"page\":
-        1,\n  \"per_page\": 4294967296,\n  \"search\": \"name=\\\"Smart Proxy\\\"\",\n
-        \ \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
-        [{\"created_at\":\"2020-10-20 15:41:46 UTC\",\"updated_at\":\"2020-10-20 15:41:46
-        UTC\",\"name\":\"Smart Proxy\",\"id\":13,\"url\":\"http://foreman-proxy.example.com:8000\",\"remote_execution_pubkey\":null,\"download_policy\":\"on_demand\",\"supported_pulp_types\":{\"pulp2\":{\"supported_types\":[\"deb\",\"docker\",\"file\",\"puppet\",\"yum\"]},\"pulp3\":{\"supported_types\":[],\"overriden_to_pulp2\":[]}},\"features\":[{\"capabilities\":[],\"name\":\"Pulp
-        Node\",\"id\":3},{\"capabilities\":[],\"name\":\"Templates\",\"id\":1},{\"capabilities\":[],\"name\":\"Puppet
-        CA\",\"id\":9},{\"capabilities\":[],\"name\":\"Puppet\",\"id\":8},{\"capabilities\":[],\"name\":\"Logs\",\"id\":13}]}]\n}\n"}
+    body:
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+        4294967296,\n  \"search\": \"name=\\\"Smart Proxy\\\"\",\n  \"sort\": {\n
+        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\":\"2024-07-10
+        14:25:39 UTC\",\"updated_at\":\"2024-07-10 14:25:39 UTC\",\"hosts_count\":0,\"name\":\"Smart
+        Proxy\",\"id\":14,\"url\":\"https://foreman-proxy.example.com:9090\",\"remote_execution_pubkey\":\"ssh-rsa
+        AAAAB3NzaC1yc2EAAAADAQABAAABgQCkn5pNuZ47pHDMpL1or9cDtaDJaJXn2EdrmcQBiXQOhoWjSn3R2da7ThZkjXGTirQrMeU8FeDpZUso368rUGU4PFg8JHCwuNF7X+mcOeodK3EJyGHIfsj172xF8wAHUc4tK2MSIKDfVd8MvX4M3qPN80290wmhCh4YrKFA30az96eSP4RDt19m3/qxTXpcmSRyuw1NKr0DUs4lCG08uV4hMpheypT21HM8eb3NSic73fY0nTLOerTwo9BUdQugjdiBNjlA9o9MzSZ6acCiOqAxqYEnVlWKqfgsy/55uBCAi4rO78sIKptvb+g1i1l86HNj/6xtwlrsXNft1p6MwcGDb66naRDARhzNLWUlrM6yqXpOkHEK1w76zaNw0RfwsxFSbZx5TueQQ1QI/DIxcIX0bIBSiVsp39TneEwFQqXu0a7dvst4LAKIOii6GtEc6FIcuCX49x6qe0VsJvHBS3LgKBcfTUUvWkm67qNX3Xaik1MKjvredkcH+7byxL+TiDE=
+        foreman-proxy@foreman-proxy.example.com\",\"download_policy\":\"on_demand\",\"supported_pulp_types\":[\"ansible_collection\",\"docker\",\"file\",\"yum\"],\"lifecycle_environments\":[],\"features\":[{\"capabilities\":[],\"name\":\"Container_Gateway\",\"id\":4},{\"capabilities\":[\"single\",\"ssh\"],\"name\":\"Dynflow\",\"id\":17},{\"capabilities\":[\"cockpit\"],\"name\":\"Script\",\"id\":19},{\"capabilities\":[\"ansible\",\"certguard\",\"container\",\"core\",\"file\",\"rpm\"],\"name\":\"Pulpcore\",\"id\":3},{\"capabilities\":[],\"name\":\"Templates\",\"id\":5},{\"capabilities\":[],\"name\":\"Logs\",\"id\":13},{\"capabilities\":[],\"name\":\"Registration\",\"id\":16}]}]\n}\n"
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      connection: [Keep-Alive]
-      content-length: ['775']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline''
-          ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      foreman_api_version: ['2']
-      foreman_current_location: [; ANY]
-      foreman_current_organization: [; ANY]
-      foreman_version: [2.2.0-rc3]
-      keep-alive: ['timeout=15, max=99']
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Length:
+      - '1554'
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.12.0-develop
+      Keep-Alive:
+      - timeout=15, max=99
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json;version=2]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: ['apypie (https://github.com/Apipie/apypie)']
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: DELETE
-    uri: https://foreman.example.org/api/smart_proxies/13
+    uri: https://foreman.example.org/api/smart_proxies/14
   response:
-    body: {string: !!python/unicode '{"id":13,"name":"Smart Proxy","url":"http://foreman-proxy.example.com:8000","created_at":"2020-10-20T15:41:46.087Z","updated_at":"2020-10-20T15:41:46.087Z","pubkey":null,"expired_logs":"0","puppet_path":null,"download_policy":"on_demand"}'}
+    body:
+      string: '{"id":14,"name":"Smart Proxy","url":"https://foreman-proxy.example.com:9090","created_at":"2024-07-10T14:25:39.746Z","updated_at":"2024-07-10T14:25:39.964Z","pubkey":"ssh-rsa
+        AAAAB3NzaC1yc2EAAAADAQABAAABgQCkn5pNuZ47pHDMpL1or9cDtaDJaJXn2EdrmcQBiXQOhoWjSn3R2da7ThZkjXGTirQrMeU8FeDpZUso368rUGU4PFg8JHCwuNF7X+mcOeodK3EJyGHIfsj172xF8wAHUc4tK2MSIKDfVd8MvX4M3qPN80290wmhCh4YrKFA30az96eSP4RDt19m3/qxTXpcmSRyuw1NKr0DUs4lCG08uV4hMpheypT21HM8eb3NSic73fY0nTLOerTwo9BUdQugjdiBNjlA9o9MzSZ6acCiOqAxqYEnVlWKqfgsy/55uBCAi4rO78sIKptvb+g1i1l86HNj/6xtwlrsXNft1p6MwcGDb66naRDARhzNLWUlrM6yqXpOkHEK1w76zaNw0RfwsxFSbZx5TueQQ1QI/DIxcIX0bIBSiVsp39TneEwFQqXu0a7dvst4LAKIOii6GtEc6FIcuCX49x6qe0VsJvHBS3LgKBcfTUUvWkm67qNX3Xaik1MKjvredkcH+7byxL+TiDE=
+        foreman-proxy@foreman-proxy.example.com","expired_logs":"0","puppet_path":null,"download_policy":"on_demand","http_proxy_id":null,"content_counts":null}'
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      connection: [Keep-Alive]
-      content-length: ['238']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline''
-          ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      foreman_api_version: ['2']
-      foreman_current_location: [; ANY]
-      foreman_current_organization: [; ANY]
-      foreman_version: [2.2.0-rc3]
-      keep-alive: ['timeout=15, max=98']
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Length:
+      - '916'
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.12.0-develop
+      Keep-Alive:
+      - timeout=15, max=98
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/test_playbooks/fixtures/smart_proxy-3.yml
+++ b/tests/test_playbooks/fixtures/smart_proxy-3.yml
@@ -2,68 +2,111 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: [application/json;version=2]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: ['apypie (https://github.com/Apipie/apypie)']
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
     uri: https://foreman.example.org/api/status
   response:
-    body: {string: !!python/unicode '{"result":"ok","status":200,"version":"2.2.0-rc3","api_version":2}'}
+    body:
+      string: '{"satellite_version":"6.16.0","result":"ok","status":200,"version":"3.12.0-develop","api_version":2}'
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      connection: [Keep-Alive]
-      content-length: ['66']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline''
-          ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      foreman_api_version: ['2']
-      foreman_current_location: [; ANY]
-      foreman_current_organization: [; ANY]
-      foreman_version: [2.2.0-rc3]
-      keep-alive: ['timeout=15, max=100']
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Length:
+      - '100'
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.12.0-develop
+      Keep-Alive:
+      - timeout=15, max=100
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json;version=2]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: ['apypie (https://github.com/Apipie/apypie)']
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/api/smart_proxies?per_page=4294967296&search=name%3D%22Smart+Proxy%22
+    uri: https://foreman.example.org/api/smart_proxies?search=name%3D%22Smart+Proxy%22&per_page=4294967296
   response:
-    body: {string: !!python/unicode "{\n  \"total\": 2,\n  \"subtotal\": 0,\n  \"page\":
-        1,\n  \"per_page\": 4294967296,\n  \"search\": \"name=\\\"Smart Proxy\\\"\",\n
-        \ \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\":
-        []\n}\n"}
+    body:
+      string: "{\n  \"total\": 1,\n  \"subtotal\": 0,\n  \"page\": 1,\n  \"per_page\":
+        4294967296,\n  \"search\": \"name=\\\"Smart Proxy\\\"\",\n  \"sort\": {\n
+        \   \"by\": null,\n    \"order\": null\n  },\n  \"results\": []\n}\n"
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      connection: [Keep-Alive]
-      content-length: ['177']
-      content-security-policy: ['default-src ''self''; child-src ''self''; connect-src
-          ''self'' ws: wss:; img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline''
-          ''self''; style-src ''unsafe-inline'' ''self''']
-      content-type: [application/json; charset=utf-8]
-      foreman_api_version: ['2']
-      foreman_current_location: [; ANY]
-      foreman_current_organization: [; ANY]
-      foreman_version: [2.2.0-rc3]
-      keep-alive: ['timeout=15, max=99']
-      strict-transport-security: [max-age=631139040; includeSubdomains]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-download-options: [noopen]
-      x-frame-options: [sameorigin]
-      x-permitted-cross-domain-policies: [none]
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Length:
+      - '177'
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.12.0-develop
+      Keep-Alive:
+      - timeout=15, max=99
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/test_playbooks/katello_smart_proxy.yml
+++ b/tests/test_playbooks/katello_smart_proxy.yml
@@ -82,12 +82,12 @@
           - 'Test'
     - include_tasks: tasks/smart_proxy.yml
       vars:
-        smart_proxy_download_policy: background
+        smart_proxy_download_policy: immediate
         smart_proxy_state: present
         expected_change: true
     - include_tasks: tasks/smart_proxy.yml
       vars:
-        smart_proxy_download_policy: background
+        smart_proxy_download_policy: immediate
         smart_proxy_state: present
         expected_change: false
     - include_tasks: tasks/smart_proxy.yml

--- a/tests/test_playbooks/puppetclasses_import.yml
+++ b/tests/test_playbooks/puppetclasses_import.yml
@@ -25,10 +25,10 @@
     - include_tasks: tasks/puppetclasses_import.yml
       vars:
         expected_change: true
-        puppetclasses_smart_proxy: "{{ foreman_proxy }}"
+        puppetclasses_smart_proxy: "{{ foreman_host }}"
     - include_tasks: tasks/puppetclasses_import.yml
       vars:
-        puppetclasses_smart_proxy: "{{ foreman_proxy }}"
+        puppetclasses_smart_proxy: "{{ foreman_host }}"
         expected_change: false
 
 - hosts: localhost

--- a/tests/test_playbooks/smart_proxy.yml
+++ b/tests/test_playbooks/smart_proxy.yml
@@ -42,7 +42,7 @@
         expected_change: true
         expected_diff: true
         expected_diff_before: "{}"
-        expected_diff_after: "foreman-proxy.example.com"
+        expected_diff_after: "{{ foreman_proxy }}"
     - include_tasks: tasks/smart_proxy.yml
       vars:
         smart_proxy_state: present
@@ -52,7 +52,7 @@
         smart_proxy_state: absent
         expected_change: true
         expected_diff: true
-        expected_diff_before: "foreman-proxy.example.com"
+        expected_diff_before: "{{ foreman_proxy }}"
         expected_diff_after: "{}"
     - include_tasks: tasks/smart_proxy.yml
       vars:

--- a/tests/test_playbooks/tasks/smart_proxy.yml
+++ b/tests/test_playbooks/tasks/smart_proxy.yml
@@ -2,7 +2,7 @@
 - name: "Ensure Smart Proxy '{{ smart_proxy_name }}' is {{ smart_proxy_state }}"
   vars:
     smart_proxy_name: "Smart Proxy"
-    smart_proxy_url: "http://foreman-proxy.example.com:8000"
+    smart_proxy_url: "https://{{ foreman_proxy }}:9090"
   smart_proxy:
     username: "{{ foreman_username }}"
     password: "{{ foreman_password }}"

--- a/tests/test_playbooks/vars/hostgroup.yml
+++ b/tests/test_playbooks/vars/hostgroup.yml
@@ -25,11 +25,11 @@ hostgroup:
     - bar.example.com
   subnet: Test subnet4
   subne6: Test subnet6
-  puppet_server: "{{ foreman_proxy }}"
-  puppet_ca: "{{ foreman_proxy }}"
-  dns_proxy: "{{ foreman_proxy }}"
-  openscap_proxy: "{{ foreman_proxy }}"
-  content_source: "{{ foreman_proxy }}"
+  puppet_server: "{{ foreman_host }}"
+  puppet_ca: "{{ foreman_host }}"
+  dns_proxy: "{{ foreman_host }}"
+  openscap_proxy: "{{ foreman_host }}"
+  content_source: "{{ foreman_host }}"
   lifecycle_environment: "Library"
   content_view:
     name: my_content

--- a/tests/test_playbooks/vars/server.yml.example
+++ b/tests/test_playbooks/vars/server.yml.example
@@ -5,7 +5,7 @@ foreman_password: "changeme"
 foreman_server_url: "https://foreman.example.com"
 foreman_validate_certs: false
 
-foreman_proxy: "foreman.example.com"
+foreman_proxy: "foreman-proxy.example.com"
 
 # Parameter for snapshot test
 snapshot_host_name: "test_host"

--- a/tests/test_playbooks/vars/subnet.yml
+++ b/tests/test_playbooks/vars/subnet.yml
@@ -9,4 +9,4 @@ subnet_locs:
 subnet_doms:
   - foo.example.com
   - bar.example.com
-subnet_proxy: "{{ foreman_proxy }}"
+subnet_proxy: "{{ foreman_host }}"


### PR DESCRIPTION
1. Changed the `foreman_proxy` value to `foreman-proxy.example.com`
2. Changed any test that was previously using `foreman_proxy` to use `foreman_host` as they were the same value
3. `foreman_proxy` will be used to point to a real external smart proxy