### PR TITLE
repositories role -- allow additional product options

### DIFF
--- a/roles/repositories/tasks/main.yml
+++ b/roles/repositories/tasks/main.yml
@@ -39,9 +39,14 @@
     validate_certs: "{{ foreman_validate_certs | default(omit) }}"
     organization: "{{ foreman_organization }}"
     name: "{{ item.name }}"
+    description: "{{ item.description | default(omit) }}"
     label: "{{ item.label | default(omit) }}"
     gpg_key: "{{ item.gpg_key | default(omit) }}"
+    ssl_ca_cert: "{{ item.ssl_ca_cert | default(omit) }}"
+    ssl_client_cert: "{{ item.ssl_client_cert | default(omit) }}"
+    ssl_client_key: "{{ item.ssl_client_key | default(omit) }}"
     state: "{{ item.state | default(omit) }}"
+    sync_plan: "{{ item.sync_plan | default(omit) }}"
   with_items:
     - "{{ foreman_products | selectattr('repositories', 'defined') | map('combine', {'repositories': '[FILTERED]'}) | list }}"
 


### PR DESCRIPTION
When using the repositories role, new products are created if needed by calling the `theforeman.foreman.product` module.  The  module allows options such as `description` and `sync_plan` to be set for the product.

This change allows the repositories role to use these additional options if they are provided:

- description
- ssl_ca_cert
- ssl_client_cert
- ssl_client_key
- sync_plan

Example config:

```
foreman_products:
    - name: MariaDB
      description: MariaDB Open Source Server
      sync_plan: Weekly sync
      repositories:
        - name: MariaDB 11.2 RHEL 8 - x86_64
          label: mariadb-11-2-for-rhel-8-x86_64-rpms
          content_type: yum
          url: https://mirror.mariadb.org/yum/11.2/rhel8-amd64/
          gpg_key: RPM-GPG-KEY-MariaDB
          download_policy: on_demand
          os_versions: rhel-8
```