### PR TITLE
Also wait for repository metadata in library export test

### DIFF
--- a/tests/test_playbooks/content_export_library.yml
+++ b/tests/test_playbooks/content_export_library.yml
@@ -15,6 +15,9 @@
     - include_tasks: tasks/repository.yml
       vars:
         repository_state: present
+    - name: Wait for Repository metadata generation
+      ansible.builtin.pause:
+        seconds: 2
 
 - hosts: tests
   collections:


### PR DESCRIPTION
Similar to cfb2bb0cbc79b49bc02b8f3677cf042dd5116850
