### PR TITLE
don't require password_hash when creating an OS

### DIFF
--- a/plugins/modules/operatingsystem.py
+++ b/plugins/modules/operatingsystem.py
@@ -221,7 +221,7 @@ def main():
 
         if not entity and (module.state == 'present' or module.state == 'present_with_defaults'):
             # we actually attempt to create a new one...
-            for param_name in ['major', 'os_family', 'password_hash']:
+            for param_name in ['major', 'os_family']:
                 if param_name not in module_params.keys():
                     module.fail_json(msg='{0} is a required parameter to create a new operating system.'.format(param_name))
 


### PR DESCRIPTION
this has a working default value, no idea why it was set to required
when new.
