### PR TITLE
set collections_path in ansible.cfg for tests

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,5 +1,8 @@
 [defaults]
+# Ansible 2.9
 collections_paths = build/collections
+# Ansible 2.10+
+collections_path = build/collections
 inventory = tests/inventory/hosts
 retry_files_enabled = False
 devel_warning = False


### PR DESCRIPTION
devel (2.19+) dropped support for the old, deprecated collections_paths
