### PR TITLE
configure tests to run with Python 3.6+ only

### DIFF
--- a/tests/config.yml
+++ b/tests/config.yml
@@ -1,0 +1,3 @@
+---
+modules:
+  python_requires: ">=3.6"


### PR DESCRIPTION
this avoids sanity on Galaxy complain that it can't import the code on
Python 2 (which we don't support anymore)
