### PR TITLE
Fix typo in user's default_organization parameter description

### DIFF
--- a/plugins/modules/user.py
+++ b/plugins/modules/user.py
@@ -75,7 +75,7 @@ options:
     type: str
   default_organization:
     description:
-      - The organizxation that the user uses by default
+      - The organization that the user uses by default
     required: false
     type: str
   auth_source:


### PR DESCRIPTION
Fixes: 9ccd95ceb47a ("Create foreman_user module (#296)")