### PR TITLE
drop fallback to Host API when Reports API fails

### DIFF
--- a/changelogs/fragments/drop-host-api-fallback.yml
+++ b/changelogs/fragments/drop-host-api-fallback.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - inventory - Drop fallback to Host API when Reports API fails, as this leads to possibly wrong data being used

--- a/plugins/inventory/foreman.py
+++ b/plugins/inventory/foreman.py
@@ -474,13 +474,10 @@ class InventoryModule(BaseInventoryPlugin, Cacheable, Constructable):
     def _populate_report_api(self):
         self.groups = dict()
         self.hosts = dict()
-        try:
-            # We need a deep copy of the data, as we modify it below and this would also modify the cache
-            host_data = copy.deepcopy(self._post_request())
-        except Exception as exc:
-            self.display.warning("Failed to use Reports API, falling back to Hosts API: {0}".format(exc))
-            self._populate_host_api()
-            return
+
+        # We need a deep copy of the data, as we modify it below and this would also modify the cache
+        host_data = copy.deepcopy(self._post_request())
+
         self.group_prefix = self.get_option('group_prefix')
 
         hostnames = self.get_option('hostnames')


### PR DESCRIPTION
The results the Host API returns are different from the Reports API, so
when the user asks for Reports API (via `use_reports_api`), they should
get exactly that, as otherwise their Playbooks/Roles might miss-behave
given different data is fed into them.
