### PR TITLE
Fix _assert_no_warnings(run) in test_crud

### DIFF
--- a/tests/test_playbooks/tasks/wait_for_task.yml
+++ b/tests/test_playbooks/tasks/wait_for_task.yml
@@ -7,10 +7,10 @@
     validate_certs: "{{ foreman_validate_certs }}"
     resource: foreman_tasks
     search: "(label = Actions::Katello::Product::Destroy and action ~ 'Test Product' and state = running)"
-  register: tasks
+  register: tasks_list
 - assert:
     fail_msg: "Verification that tasks are runing"
-    that: tasks.resources | length > 0
+    that: tasks_list.resources | length > 0
 
 - name: wait for the task to finish
   wait_for_task:
@@ -20,7 +20,7 @@
     validate_certs: "{{ foreman_validate_certs }}"
     task: "{{ item }}"
     timeout: 900
-  loop: "{{ tasks.resources | map(attribute='id') | list }}"
+  loop: "{{ tasks_list.resources | map(attribute='id') | list }}"
 
 - name: "Search for previously created task"
   resource_info:
@@ -30,8 +30,8 @@
     validate_certs: "{{ foreman_validate_certs }}"
     resource: foreman_tasks
     search: "(label = Actions::Katello::Product::Destroy and action ~ 'Test Product' and state = running)"
-  register: tasks
+  register: tasks_list
 - assert:
     fail_msg: "Verification that no task is runing anymore"
-    that: tasks.resources | length == 0
+    that: tasks_list.resources | length == 0
 ...


### PR DESCRIPTION
Rename `tasks` variable to `tasks_list` as `tasks` is a reserved name and triggers the warning "Found variable using reserved name: tasks"