### PR TITLE
Fix exception when serializing results to json

### DIFF
--- a/plugins/callback/foreman.py
+++ b/plugins/callback/foreman.py
@@ -146,7 +146,7 @@ def build_log_foreman(data_list):
                     'source': task.get('name'),
                 },
                 'messages': {
-                    'message': json.dumps(result, sort_keys=True),
+                    'message': json.dumps(result, sort_keys=True, cls=AnsibleNoVaultJSONEncoder),
                 },
                 'level': level,
             }

--- a/tests/fixtures/callback/dir_store/foreman/testhost-report.json
+++ b/tests/fixtures/callback/dir_store/foreman/testhost-report.json
@@ -73,7 +73,7 @@
         "log": {
           "level": "info",
           "messages": {
-            "message": "{\"ansible_facts\": {\"geheim\": \"admin\"}, \"changed\": false, \"failed\": false, \"module\": \"set_fact\"}"
+            "message": "{\"ansible_facts\": {\"crypt\": \"ENCRYPTED_VAULT_VALUE_NOT_REPORTED\", \"geheim\": \"admin\", \"unsafe\": \"THIS IS {{ crypt }}\\n\"}, \"changed\": false, \"failed\": false, \"module\": \"set_fact\"}"
           },
           "sources": {
             "source": "Vault fact"


### PR DESCRIPTION
Fix the 'Object of type AnsibleVaultEncryptedUnicode is not JSON serializable' exception when serializing the results to json.

This happens when executing make test TEST="tests/test_callback.py"