### PR TITLE
explicitly set a mirror when creating install medium for hostgroup

### DIFF
--- a/tests/test_playbooks/hostgroup.yml
+++ b/tests/test_playbooks/hostgroup.yml
@@ -75,6 +75,7 @@
           - "{{ hostgroup.os.name }} {{ hostgroup.os.major }}.{{ hostgroup.os.minor }}"
         installation_medium_locations: "{{ hostgroup.locations }}"
         installation_medium_organizations: "{{ hostgroup.organizations }}"
+        installation_medium_path: "https://mirror.example.com/{{ hostgroup.os.name }}/"
         installation_medium_state: present
     - include_tasks: tasks/compute_resource.yml
       vars:


### PR DESCRIPTION
otherwise we get the same path as the real installation medium tests and
might fail these accidentally
