### PR TITLE
use the libvirt CR url defined in compute_profile.yml

### DIFF
--- a/tests/test_playbooks/hostgroup.yml
+++ b/tests/test_playbooks/hostgroup.yml
@@ -83,7 +83,7 @@
         compute_resource_organizations: "{{ hostgroup.organizations }}"
         compute_resource_locations: "{{ hostgroup.locations }}"
         compute_resource_provider: 'libvirt'
-        compute_resource_provider_params: "{{ hostgroup.compute_resource.params }}"
+        compute_resource_provider_params: "{{ libvirt.compute_resource.params }}"
         compute_resource_state: present
     - include_tasks: tasks/compute_profile.yml
       vars:

--- a/tests/test_playbooks/vars/hostgroup.yml
+++ b/tests/test_playbooks/vars/hostgroup.yml
@@ -16,8 +16,6 @@ hostgroup:
     minor: 6
   compute_resource:
     name: 'libvirt-cr'
-    params:
-      url: "qemu:///system"
   compute_profile:
     name: 'myprofile'
   domains:


### PR DESCRIPTION
this allows overriding it in just one place instead of two
