### PR TITLE
correct external usergroup tests

### DIFF
--- a/tests/test_playbooks/external_usergroup.yml
+++ b/tests/test_playbooks/external_usergroup.yml
@@ -20,6 +20,7 @@
       vars:
         auth_source_ldap_state: present
         auth_source_ldap_tls: false
+        auth_source_ldap_account_password: "{{ default_auth_source_ldap_account_password }}"
     - include_tasks: tasks/external_usergroup.yml
       vars:
         external_usergroup_state: absent

--- a/tests/test_playbooks/tasks/external_usergroup.yml
+++ b/tests/test_playbooks/tasks/external_usergroup.yml
@@ -1,7 +1,6 @@
 ---
 - name: "Ensure external usergroup '{{ external_usergroup_name }}' is {{ external_usergroup_state }}"
   vars:
-    external_usergroup_name: "admins"
     external_usergroup_state: present
   external_usergroup:
     username: "{{ foreman_username }}"


### PR DESCRIPTION
- **don't override external_usergroup_name**
- **correctly setup LDAP auth source in ext usergroup tests**
