### PR TITLE
don't set expected_change: false when doing setup for import info

### DIFF
--- a/tests/test_playbooks/content_import_info.yml
+++ b/tests/test_playbooks/content_import_info.yml
@@ -29,7 +29,6 @@
       include_tasks: tasks/content_import.yml # Full export
       vars:
         import_type: "repository"
-        expected_change: false
 
 - hosts: tests
   collections:


### PR DESCRIPTION
depending on the state of the system there might be a change, but we
don't care -- this is setup only
