### PR TITLE
make ansible-lint shutup about jinja spacing

### DIFF
--- a/roles/content_view_version_cleanup/tasks/find_and_delete_unused_cv_versions.yml
+++ b/roles/content_view_version_cleanup/tasks/find_and_delete_unused_cv_versions.yml
@@ -11,7 +11,7 @@
       content_view_id: "{{ foreman_cv.id }}"
   register: __foreman_versions
 
-- name: "Delete unused content view versions of {{ foreman_cv.name }}"
+- name: "Delete unused content view versions of {{ foreman_cv.name }}"  # noqa: jinja[spacing]
   ansible.builtin.include_tasks: delete_cv_versions.yml
   vars:
     foreman_cv_name: "{{ foreman_cv.name }}"

--- a/roles/content_view_version_cleanup/tasks/main.yml
+++ b/roles/content_view_version_cleanup/tasks/main.yml
@@ -16,7 +16,7 @@
     search: "{{ foreman_content_view_version_cleanup_search | default(omit) }}"
   register: __foreman_all_cvs
 
-- name: "Delete unused composite content view versions"
+- name: "Delete unused composite content view versions"  # noqa: jinja[spacing]
   ansible.builtin.include_tasks: delete_cv_versions.yml
   vars:
     foreman_cv_name: "{{ __foreman_ccv.name }}"
@@ -28,7 +28,7 @@
     loop_var: "__foreman_ccv"
   when: (__foreman_ccv.versions | rejectattr('environment_ids') | map(attribute='version') | reverse | list)[(foreman_content_view_version_cleanup_keep | int):]
 
-- name: "Find and delete unused content view versions"
+- name: "Find and delete unused content view versions"  # noqa: jinja[spacing]
   ansible.builtin.include_tasks: find_and_delete_unused_cv_versions.yml
   loop: "{{ __foreman_all_cvs.resources | rejectattr('composite') | list }}"
   loop_control:


### PR DESCRIPTION
it doesn't understand that this is python *inside* jinja and while it's
valid python to have a space before the :, it doesn't make things more
readable
