### PR TITLE
Add support for setting metadata_expire via the repository module

### DIFF
--- a/plugins/modules/repository.py
+++ b/plugins/modules/repository.py
@@ -268,6 +268,7 @@ options:
       - Set the metadata expiration time (in seconds) for a yum repository.
     type: int
     required: false
+    version_added: 5.4.0
 extends_documentation_fragment:
   - theforeman.foreman.foreman
   - theforeman.foreman.foreman.entity_state_with_defaults

--- a/plugins/modules/repository.py
+++ b/plugins/modules/repository.py
@@ -263,6 +263,11 @@ options:
     type: int
     required: false
     version_added: 5.4.0
+  metadata_expire:
+    description:
+      - Set the metadata expiration time (in seconds) for a yum repository.
+    type: int
+    required: false
 extends_documentation_fragment:
   - theforeman.foreman.foreman
   - theforeman.foreman.foreman.entity_state_with_defaults
@@ -359,6 +364,7 @@ def main():
             include_tags=dict(type='list', elements='str'),
             exclude_tags=dict(type='list', elements='str'),
             retain_package_versions_count=dict(type='int'),
+            metadata_expire=dict(type="int"),
         ),
         mutually_exclusive=[
             ['mirror_on_sync', 'mirroring_policy']
@@ -389,7 +395,7 @@ def main():
             module.fail_json(msg="({0}) can only be used with content_type 'ansible_collection'".format(",".join(invalid_list)))
 
     if module.foreman_params['content_type'] != 'yum':
-        invalid_list = [key for key in ['ignorable_content', 'os_versions'] if key in module.foreman_params]
+        invalid_list = [key for key in ['ignorable_content', 'os_versions', 'metadata_expire'] if key in module.foreman_params]
         if invalid_list:
             module.fail_json(msg="({0}) can only be used with content_type 'yum'".format(",".join(invalid_list)))
 


### PR DESCRIPTION
This PR adds support for setting the metadata_expire option for yum repositories.
The version_added attribute is still missing because I am unsure which version I'd have to set it to. Should that be `version_added: 5.4.0` or already `5.5.0`?