### PR TITLE
Fix typo in doc

### DIFF
--- a/plugins/modules/repository_set.py
+++ b/plugins/modules/repository_set.py
@@ -46,7 +46,7 @@ options:
   repositories:
     description:
       - Release version and base architecture of the repositories to enable.
-      - Some reposotory sets require only I(basearch) or only I(releasever) to be set.
+      - Some repository sets require only I(basearch) or only I(releasever) to be set.
       - See the examples how you can obtain this information using M(theforeman.foreman.resource_info).
       - Required when I(all_repositories) is unset or C(false).
     required: false


### PR DESCRIPTION
This fixes a small typo in `repository_set` docs.