### PR TITLE
workaround to ensure LCE and CV are always sent together

### DIFF
--- a/changelogs/fragments/1867-host-always-send-lce-cv.yml
+++ b/changelogs/fragments/1867-host-always-send-lce-cv.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - host - ensure LCE and CV are always sent together when updating one of them

--- a/plugins/module_utils/foreman_helper.py
+++ b/plugins/module_utils/foreman_helper.py
@@ -1080,6 +1080,13 @@ class ForemanAnsibleModule(AnsibleModule):
                 old_value = sorted(old_value, key=operator.itemgetter(sort_key))
             if new_value != old_value:
                 payload[key] = value
+        # workaround to ensure LCE and CV are always sent together, even if only one changed
+        # using the values from the existing entity, so the user doesn't need to pass it in their playbook
+        if resource == 'hosts':
+            if 'content_view_id' in payload and 'lifecycle_environment_id' not in payload:
+                payload['lifecycle_environment_id'] = current_flat_entity['lifecycle_environment_id']
+            elif 'lifecycle_environment_id' in payload and 'content_view_id' not in payload:
+                payload['content_view_id'] = current_flat_entity['content_view_id']
         if self._validate_supported_payload(resource, 'update', payload):
             self.set_changed()
             payload['id'] = current_flat_entity['id']


### PR DESCRIPTION
With the introduction of Content View Environments in Katello, you need
to either set a CVE or both LCE and CV to update where a host is
consuming content from. As we currently don't have a way to correctly
set the CVE, this workaround ensures LCE and CV are always sent so that
Katello can correctly calculate the CVE for us in the background.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when updating host entities by ensuring both content view and lifecycle environment fields are always updated together, preventing potential inconsistencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->