### PR TITLE
correctly encode content uploads as multipart/form-data

### DIFF
--- a/changelogs/fragments/1862-content-upload-multipart.yml
+++ b/changelogs/fragments/1862-content-upload-multipart.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - content_upload - correctly encode content uploads as multipart/form-data (https://github.com/theforeman/foreman-ansible-modules/issues/1862)

--- a/plugins/modules/content_upload.py
+++ b/plugins/modules/content_upload.py
@@ -203,8 +203,9 @@ def main():
 
                 with open(b_src, 'rb') as contentfile:
                     for chunk in iter(lambda: contentfile.read(CONTENT_CHUNK_SIZE), b""):
-                        data = {'content': chunk, 'offset': offset, 'size': size}
-                        module.resource_action('content_uploads', 'update', params=content_upload_scope, data=data)
+                        data = {'offset': offset, 'size': size}
+                        files = {'content': chunk}
+                        module.resource_action('content_uploads', 'update', params=content_upload_scope, data=data, files=files)
 
                         offset += len(chunk)
 


### PR DESCRIPTION
before this, they were encoded as application/x-www-form-urlencoded, and
while this technically works, it makes the request 2-3× larger,
sometimes hitting limits in Rack/Rails.

Fixes: #1862
