### PR TITLE
content_upload - lower chunk size to 1MB to avoid generating too big request

### DIFF
--- a/changelogs/fragments/1862-content-upload-chunk-size.yml
+++ b/changelogs/fragments/1862-content-upload-chunk-size.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - content_upload - lower chunk size to 1MB to avoid generating too big requests (https://github.com/theforeman/foreman-ansible-modules/issues/1862)

--- a/plugins/modules/content_upload.py
+++ b/plugins/modules/content_upload.py
@@ -111,7 +111,7 @@ except ImportError:
     HAS_RPM = False
     RPM_IMP_ERR = traceback.format_exc()
 
-CONTENT_CHUNK_SIZE = 2 * 1024 * 1024
+CONTENT_CHUNK_SIZE = 1 * 1024 * 1024
 
 
 def get_deb_info(path):


### PR DESCRIPTION
This is a workaround, 2MB chunks should be fine, while we figure out how
to properly multipart-encode our uploads.
