### PR TITLE
use Foreman 3.15 in inventory tests

### DIFF
--- a/tests/test_playbooks/inventory_plugin.yml
+++ b/tests/test_playbooks/inventory_plugin.yml
@@ -15,7 +15,7 @@
       testhost1.example.com: group_a
       testhost2.example.com: group_b/group_c
     foreman_container: "quay.io/foreman/foreman"
-    foreman_version: "3.14-stable"
+    foreman_version: "3.15-stable"
     foreman_host: "foreman"
     foreman_port: "3000"
     postgres_version: "13"

--- a/tests/test_playbooks/inventory_plugin_ansible.yml
+++ b/tests/test_playbooks/inventory_plugin_ansible.yml
@@ -15,7 +15,7 @@
       testhost1.example.com: group_a
       testhost2.example.com: group_b/group_c
     foreman_container: "quay.io/evgeni/foreman-ansible"
-    foreman_version: "3.14-ansible"
+    foreman_version: "3.15-ansible"
     foreman_host: "foremanansible"
     foreman_port: "3001"
     postgres_version: "13"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated test playbooks to use Foreman version 3.15 for improved compatibility and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->