### PR TITLE
Harden release flow by using the gh release tool

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,6 @@ jobs:
       - name: Deploy Ansible Collection
         run: make publish GALAXY_API_KEY=${{ secrets.GALAXY_API_KEY }}
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
-        with:
-          files: theforeman-foreman-*.tar.gz
-          body_path: release-changelog.txt
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release create ${{ github.ref_name }} -F release-changelog.txt theforeman-foreman-*.tar.gz


### PR DESCRIPTION
<del>Ansible has the GALAXY_TOKEN configuration option (since https://github.com/ansible/ansible/commit/576335e53dc7721811a9dfe02b29a36ec7f27e56), which is exposed via the ANSIBLE_GALAXY_TOKEN environment variable. This means we don't need to pass it on the command line and can instead pass it in securely.</del> This was dropped in https://github.com/ansible/ansible/commit/83909bfa22573777e3db5688773bda59721962ad.

It avoids the use of an external action to create the release and instead uses the `gh` command line tool. This reduces the attack surface in case the action gets compromised.

Disclaimer: untested.