### PR TITLE
Add environments for rolling content views

### DIFF
--- a/changelogs/fragments/add-rolling-content-view-environments.yml
+++ b/changelogs/fragments/add-rolling-content-view-environments.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - content_view - add support for lifecycle environments in rolling content views

--- a/plugins/modules/content_view.py
+++ b/plugins/modules/content_view.py
@@ -78,6 +78,14 @@ options:
       - A rolling content view contains latest synced state of repositories.
     type: bool
     version_added: 5.5.0
+  lifecycle_environments:
+    description:
+      - List of lifecycle environments that content of this rolling content view will be promoted to.
+      - Only valid for I(rolling=True).
+    required: False
+    type: list
+    elements: str
+    version_added: 5.9.0
   composite:
     description:
       - A composite view contains other content views.
@@ -192,6 +200,7 @@ def main():
             solve_dependencies=dict(type='bool'),
             import_only=dict(type='bool'),
             components=dict(type='nested_list', foreman_spec=cvc_foreman_spec, resolve=False),
+            lifecycle_environments=dict(type='entity_list', flat_name='environment_ids'),
             repositories=dict(type='entity_list', elements='dict', resolve=False, options=dict(
                 name=dict(required=True),
                 product=dict(required=True),
@@ -200,7 +209,7 @@ def main():
         argument_spec=dict(
             state=dict(default='present', choices=['present_with_defaults', 'present', 'absent']),
         ),
-        mutually_exclusive=[['repositories', 'components']],
+        mutually_exclusive=[['repositories', 'components'], ['lifecycle_environments', 'components']],
         entity_opts=dict(thin=False),
     )
 
@@ -225,6 +234,10 @@ def main():
                         product = module.find_resource_by_name('products', repository['product'], params=scope, thin=True)
                         repositories.append(module.find_resource_by_name('repositories', repository['name'], params={'product_id': product['id']}, thin=True))
                     module.foreman_params['repositories'] = repositories
+
+            if 'lifecycle_environments' in module.foreman_params:
+                if module.foreman_params['rolling'] is not True:
+                    module.fail_json(msg="Lifecycle Environments can only be specified for Rolling Content View.")
 
         if entity and module.desired_absent:
             for lce in entity.get('environments', []):

--- a/roles/content_views/tasks/_create_content_view.yml
+++ b/roles/content_views/tasks/_create_content_view.yml
@@ -10,6 +10,8 @@
     auto_publish: "{{ content_view.auto_publish | default(omit) }}"
     components: "{{ content_view.components | default(omit) }}"
     composite: "{{ content_view.components | default(content_view.composite) | default(false) | ternary(true, false) }}"
+    rolling: "{{ content_view.rolling | default(false) }}"
+    lifecycle_environments: "{{ content_view.lifecycle_environments | default(omit) }}"
     description: "{{ content_view.description | default(omit) }}"
     label: "{{ content_view.label | default(omit) }}"
     repositories: "{{ content_view.repositories | default(omit) }}"

--- a/tests/test_playbooks/content_view.yml
+++ b/tests/test_playbooks/content_view.yml
@@ -23,6 +23,22 @@
       vars:
         product_name: "Test Product 2"
         repository_state: present
+    - include_tasks: tasks/lifecycle_environment.yml
+      vars:
+        lifecycle_environment_state: present
+        lifecycle_environment_name: "{{ item.name }}"
+        lifecycle_environment_label: "{{ item.label }}"
+        lifecycle_environment_prior: "{{ item.prior }}"
+      loop:
+        - name: Test
+          label: test
+          prior: Library
+        - name: QA
+          label: qa
+          prior: Test
+        - name: Prod
+          label: prod
+          prior: QA
     - include_tasks: tasks/content_view.yml
       vars:
         content_view_name: "Test Composite Content View"
@@ -214,6 +230,10 @@
       vars:
         content_view_state: present
         expected_change: true
+        lifecycle_environments:
+          - QA
+          - Test
+          - Prod
         rolling: true
         repositories:
           - name: "Test Repository"
@@ -225,6 +245,10 @@
       vars:
         content_view_state: present
         expected_change: false
+        lifecycle_environments:
+          - QA
+          - Prod
+          - Test
         rolling: true
         repositories:
           - name: "Test Repository"
@@ -233,6 +257,10 @@
       vars:
         content_view_state: absent
         expected_change: true
+        lifecycle_environments:
+          - Test
+          - QA
+          - Prod
         rolling: true
         repositories:
           - name: "Test Repository"

--- a/tests/test_playbooks/fixtures/content_view-0.yml
+++ b/tests/test_playbooks/fixtures/content_view-0.yml
@@ -14,16 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"2.1.2","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.16.0-develop","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '71'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -33,25 +31,27 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=100
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '62'
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
@@ -70,21 +70,18 @@ interactions:
     uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
-        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\"\
-        :\"Test_Organization\",\"created_at\":\"2020-09-14 10:19:21 UTC\",\"updated_at\"\
-        :\"2020-09-14 10:19:21 UTC\",\"id\":14,\"name\":\"Test Organization\",\"title\"\
-        :\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+        4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2025-07-11
+        15:21:41 UTC\",\"updated_at\":\"2025-07-11 15:21:45 UTC\",\"id\":3,\"name\":\"Test
+        Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '388'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -94,25 +91,27 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=99
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '389'
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
@@ -128,10 +127,10 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/14/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/3/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
   response:
     body:
-      string: '{"total":1,"subtotal":0,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+      string: '{"total":1,"subtotal":0,"selectable":0,"page":1,"per_page":4294967296,"error":null,"search":"name=\"Test
         Content View\"","sort":{"by":"name","order":"asc"},"results":[]}
 
         '
@@ -140,10 +139,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '170'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -151,27 +148,29 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 14; Test Organization
+      - 3; Test Organization
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=98
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '157'
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
@@ -187,14 +186,13 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/14/products?search=name%3D%22Test+Product%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/3/products?search=name%3D%22Test+Product%22&per_page=4294967296
   response:
     body:
-      string: '{"total":2,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Product\"","sort":{"by":"name","order":"asc"},"results":[{"id":18,"cp_id":"956117903760","name":"Test
-        Product","label":"Test_Product","description":"A happy little test product","provider_id":25,"sync_plan_id":null,"sync_summary":{},"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"sync_state":null,"last_sync":"2020-09-14
-        10:19:27 UTC","last_sync_words":"less than a minute","organization_id":14,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":14},"sync_plan":null,"repository_count":1}]}
+      string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":4294967296,"error":null,"search":"name=\"Test
+        Product\"","sort":{"by":"name","order":"asc"},"results":[{"id":1,"cp_id":"624377688211","name":"Test
+        Product","label":"Test_Product","description":"A happy little test product","provider_id":3,"sync_plan_id":null,"sync_summary":{},"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"sync_state":null,"last_sync":null,"last_sync_words":null,"organization_id":3,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":3},"sync_plan":null,"repository_count":1}]}
 
         '
     headers:
@@ -202,10 +200,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '625'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -213,27 +209,29 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 14; Test Organization
+      - 3; Test Organization
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=97
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '653'
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
@@ -249,15 +247,16 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/products/18/repositories?search=name%3D%22Test+Repository%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/products/1/repositories?search=name%3D%22Test+Repository%22&per_page=4294967296
   response:
     body:
-      string: '{"total":1,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Repository\"","sort":{"by":"name","order":"asc"},"results":[{"backend_identifier":"1819fd9f-8231-43ee-9132-a87a073ba3d7","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"http://centos7-katello-3-16.yatsu.example.com/pulp/repos/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"id":30,"name":"Test
-        Repository","label":"Test_Repository","description":null,"last_sync":null,"content_view":{"id":29,"name":"Default
-        Organization View"},"content_view_version":{"id":18,"name":"Default Organization
-        View 1.0","content_view_id":29},"kt_environment":{"id":13,"name":"Library"},"content_type":"yum","url":null,"arch":"noarch","content_id":"1600078766677","major":null,"minor":null,"product":{"id":18,"cp_id":"956117903760","name":"Test
-        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","content_counts":{"ostree_branch":0,"docker_manifest":0,"docker_manifest_list":0,"docker_tag":0,"rpm":0,"srpm":0,"package":0,"package_group":0,"erratum":0,"puppet_module":0,"file":0,"deb":0,"module_stream":0,"ansible_collection":0},"last_sync_words":null}]}
+      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":4294967296,"error":null,"search":"name=\"Test
+        Repository\"","sort":{"by":"name","order":"asc"},"results":[{"backend_identifier":"f5cc71fb-3e1f-48d2-8db4-68349096758f","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"https://foreman.example.com/pulp/content/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"full_gpg_key_path":null,"version_href":"/pulp/api/v3/repositories/rpm/rpm/0197fa14-1de9-7a8c-ac85-fff97edefbdd/versions/0/","remote_href":null,"publication_href":"/pulp/api/v3/publications/rpm/rpm/0197fa14-239a-7acb-a6b3-ba44220d968c/","content_counts":{"rpm":0,"erratum":0,"package_group":0,"srpm":0,"module_stream":0},"mirroring_policy":"mirror_content_only","id":1,"name":"Test
+        Repository","label":"Test_Repository","description":null,"organization_id":3,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":3},"content_view_versions":[],"filters":[],"last_sync":null,"content_view":{"id":2,"name":"Default
+        Organization View"},"content_view_version":{"id":2,"name":"Default Organization
+        View 1.0","content_view_id":2},"kt_environment":{"id":2,"name":"Library"},"content_type":"yum","url":null,"docker_upstream_name":null,"arch":"noarch","os_versions":[],"content_id":"1752247312252","generic_remote_options":null,"major":null,"minor":null,"product":{"id":1,"cp_id":"624377688211","name":"Test
+        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","last_sync_words":null}],"org_repository_count":2}
 
         '
     headers:
@@ -265,10 +264,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '1679'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -278,30 +275,32 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=96
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '1319'
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"name": "Test Content View", "composite": false, "repository_ids": [30],
+    body: '{"name": "Test Content View", "composite": false, "repository_ids": [1],
       "auto_publish": false}'
     headers:
       Accept:
@@ -311,20 +310,20 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '96'
+      - '95'
       Content-Type:
       - application/json
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: POST
-    uri: https://foreman.example.org/katello/api/organizations/14/content_views
+    uri: https://foreman.example.org/katello/api/organizations/3/content_views
   response:
     body:
-      string: '  {"content_host_count":0,"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[30],"id":30,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":14,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":14},"created_at":"2020-09-14
-        10:19:35 UTC","updated_at":"2020-09-14 10:19:35 UTC","environments":[],"repositories":[{"id":30,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true},"duplicate_repositories_to_publish":[]}
+      string: '  {"content_host_count":0,"composite":false,"rolling":false,"component_ids":[],"duplicate_repositories_to_publish":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"filtered":false,"needs_publish":true,"environment_ids":[],"repository_ids":[1],"id":3,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":3,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":3},"created_at":"2025-07-11
+        15:22:07 UTC","updated_at":"2025-07-11 15:22:07 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":1,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[],"errors":null}
 
         '
     headers:
@@ -332,10 +331,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '991'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -343,25 +340,29 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 14; Test Organization
+      - 3; Test Organization
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=95
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
+      x-xss-protection:
+      - '0'
     status:
       code: 201
       message: Created

--- a/tests/test_playbooks/fixtures/content_view-1.yml
+++ b/tests/test_playbooks/fixtures/content_view-1.yml
@@ -14,16 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"2.1.2","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.16.0-develop","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '71'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -33,25 +31,27 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=100
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '62'
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
@@ -70,21 +70,18 @@ interactions:
     uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
-        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\"\
-        :\"Test_Organization\",\"created_at\":\"2020-09-14 10:19:21 UTC\",\"updated_at\"\
-        :\"2020-09-14 10:19:21 UTC\",\"id\":14,\"name\":\"Test Organization\",\"title\"\
-        :\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+        4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2025-07-11
+        15:21:41 UTC\",\"updated_at\":\"2025-07-11 15:21:45 UTC\",\"id\":3,\"name\":\"Test
+        Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '388'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -94,25 +91,27 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=99
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '389'
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
@@ -128,15 +127,15 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/14/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/3/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
   response:
     body:
-      string: '{"total":2,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[30],"id":30,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":14,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":14},"created_at":"2020-09-14
-        10:19:35 UTC","updated_at":"2020-09-14 10:19:35 UTC","environments":[],"repositories":[{"id":30,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
+      string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":4294967296,"error":null,"search":"name=\"Test
+        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"rolling":false,"component_ids":[],"duplicate_repositories_to_publish":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"filtered":false,"needs_publish":true,"environment_ids":[],"repository_ids":[1],"id":3,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":3,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":3},"created_at":"2025-07-11
+        15:22:07 UTC","updated_at":"2025-07-11 15:22:07 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":1,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
 
         '
     headers:
@@ -144,10 +143,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '1121'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -155,27 +152,29 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 14; Test Organization
+      - 3; Test Organization
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=98
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '1040'
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
@@ -191,14 +190,14 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/30
+    uri: https://foreman.example.org/katello/api/content_views/3
   response:
     body:
-      string: '  {"content_host_count":0,"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[30],"id":30,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":14,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":14},"created_at":"2020-09-14
-        10:19:35 UTC","updated_at":"2020-09-14 10:19:35 UTC","environments":[],"repositories":[{"id":30,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true},"duplicate_repositories_to_publish":[]}
+      string: '  {"content_host_count":0,"composite":false,"rolling":false,"component_ids":[],"duplicate_repositories_to_publish":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"filtered":false,"needs_publish":true,"environment_ids":[],"repository_ids":[1],"id":3,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":3,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":3},"created_at":"2025-07-11
+        15:22:07 UTC","updated_at":"2025-07-11 15:22:07 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":1,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[],"errors":null}
 
         '
     headers:
@@ -206,10 +205,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '991'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -219,25 +216,27 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=97
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '948'
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
@@ -253,14 +252,13 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/14/products?search=name%3D%22Test+Product%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/3/products?search=name%3D%22Test+Product%22&per_page=4294967296
   response:
     body:
-      string: '{"total":2,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Product\"","sort":{"by":"name","order":"asc"},"results":[{"id":18,"cp_id":"956117903760","name":"Test
-        Product","label":"Test_Product","description":"A happy little test product","provider_id":25,"sync_plan_id":null,"sync_summary":{},"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"sync_state":null,"last_sync":"2020-09-14
-        10:19:27 UTC","last_sync_words":"less than a minute","organization_id":14,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":14},"sync_plan":null,"repository_count":1}]}
+      string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":4294967296,"error":null,"search":"name=\"Test
+        Product\"","sort":{"by":"name","order":"asc"},"results":[{"id":1,"cp_id":"624377688211","name":"Test
+        Product","label":"Test_Product","description":"A happy little test product","provider_id":3,"sync_plan_id":null,"sync_summary":{},"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"sync_state":null,"last_sync":null,"last_sync_words":null,"organization_id":3,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":3},"sync_plan":null,"repository_count":1}]}
 
         '
     headers:
@@ -268,10 +266,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '625'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -279,27 +275,29 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 14; Test Organization
+      - 3; Test Organization
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=96
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '653'
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
@@ -315,15 +313,16 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/products/18/repositories?search=name%3D%22Test+Repository%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/products/1/repositories?search=name%3D%22Test+Repository%22&per_page=4294967296
   response:
     body:
-      string: '{"total":1,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Repository\"","sort":{"by":"name","order":"asc"},"results":[{"backend_identifier":"1819fd9f-8231-43ee-9132-a87a073ba3d7","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"http://centos7-katello-3-16.yatsu.example.com/pulp/repos/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"id":30,"name":"Test
-        Repository","label":"Test_Repository","description":null,"last_sync":null,"content_view":{"id":29,"name":"Default
-        Organization View"},"content_view_version":{"id":18,"name":"Default Organization
-        View 1.0","content_view_id":29},"kt_environment":{"id":13,"name":"Library"},"content_type":"yum","url":null,"arch":"noarch","content_id":"1600078766677","major":null,"minor":null,"product":{"id":18,"cp_id":"956117903760","name":"Test
-        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","content_counts":{"ostree_branch":0,"docker_manifest":0,"docker_manifest_list":0,"docker_tag":0,"rpm":0,"srpm":0,"package":0,"package_group":0,"erratum":0,"puppet_module":0,"file":0,"deb":0,"module_stream":0,"ansible_collection":0},"last_sync_words":null}]}
+      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":4294967296,"error":null,"search":"name=\"Test
+        Repository\"","sort":{"by":"name","order":"asc"},"results":[{"backend_identifier":"f5cc71fb-3e1f-48d2-8db4-68349096758f","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"https://foreman.example.com/pulp/content/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"full_gpg_key_path":null,"version_href":"/pulp/api/v3/repositories/rpm/rpm/0197fa14-1de9-7a8c-ac85-fff97edefbdd/versions/0/","remote_href":null,"publication_href":"/pulp/api/v3/publications/rpm/rpm/0197fa14-239a-7acb-a6b3-ba44220d968c/","content_counts":{"rpm":0,"erratum":0,"package_group":0,"srpm":0,"module_stream":0},"mirroring_policy":"mirror_content_only","id":1,"name":"Test
+        Repository","label":"Test_Repository","description":null,"organization_id":3,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":3},"content_view_versions":[],"filters":[],"last_sync":null,"content_view":{"id":2,"name":"Default
+        Organization View"},"content_view_version":{"id":2,"name":"Default Organization
+        View 1.0","content_view_id":2},"kt_environment":{"id":2,"name":"Library"},"content_type":"yum","url":null,"docker_upstream_name":null,"arch":"noarch","os_versions":[],"content_id":"1752247312252","generic_remote_options":null,"major":null,"minor":null,"product":{"id":1,"cp_id":"624377688211","name":"Test
+        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","last_sync_words":null}],"org_repository_count":2}
 
         '
     headers:
@@ -331,10 +330,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '1679'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -344,25 +341,27 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=95
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '1319'
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/content_view-10.yml
+++ b/tests/test_playbooks/fixtures/content_view-10.yml
@@ -14,16 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"2.1.2","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.16.0-develop","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '71'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -33,25 +31,27 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=100
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '62'
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
@@ -70,21 +70,18 @@ interactions:
     uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
-        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\"\
-        :\"Test_Organization\",\"created_at\":\"2020-09-14 10:19:21 UTC\",\"updated_at\"\
-        :\"2020-09-14 10:19:21 UTC\",\"id\":14,\"name\":\"Test Organization\",\"title\"\
-        :\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+        4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2025-07-11
+        15:21:41 UTC\",\"updated_at\":\"2025-07-11 15:21:45 UTC\",\"id\":3,\"name\":\"Test
+        Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '388'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -94,25 +91,27 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=99
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '389'
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
@@ -128,24 +127,25 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/14/content_views?search=name%3D%22Test+Composite+Content+View%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/3/content_views?search=name%3D%22Test+Composite+Content+View%22&per_page=4294967296
   response:
     body:
-      string: '{"total":3,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Composite Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":true,"component_ids":[19],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":true,"solve_dependencies":false,"repository_ids":[32],"id":32,"name":"Test
-        Composite Content View","label":"Test_Composite_Content_View","description":null,"organization_id":14,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":14},"created_at":"2020-09-14
-        10:19:50 UTC","updated_at":"2020-09-14 10:19:53 UTC","environments":[],"repositories":[{"id":32,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[{"id":19,"name":"Test
-        Content View 1.0","content_view_id":31,"version":"1.0","environments":[{"id":13,"name":"Library","label":"Library"}],"content_view":{"id":31,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0"},"repositories":[{"id":32,"name":"Test
-        Repository","label":"Test_Repository","description":null}]}],"content_view_components":[{"latest":false,"id":6,"created_at":"2020-09-14
-        10:19:50 UTC","updated_at":"2020-09-14 10:19:50 UTC","composite_content_view":{"id":32,"name":"Test
-        Composite Content View","label":"Test_Composite_Content_View","description":null,"next_version":1,"latest_version":null,"version_count":0},"content_view":{"id":31,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0","version_count":1},"content_view_version":{"id":19,"name":"Test
-        Content View 1.0","content_view_id":31,"version":"1.0","content_view":{"id":31,"name":"Test
-        Content View","label":"Test_Content_View","description":null},"environments":[{"id":13,"name":"Library","label":"Library"}],"repositories":[{"id":32,"name":"Test
-        Repository","label":"Test_Repository","description":null}]}}],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
+      string: '{"total":3,"subtotal":1,"selectable":1,"page":1,"per_page":4294967296,"error":null,"search":"name=\"Test
+        Composite Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":true,"rolling":false,"component_ids":[3],"duplicate_repositories_to_publish":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":true,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":1,"related_composite_cvs":[],"filtered":false,"needs_publish":true,"environment_ids":[],"repository_ids":[3],"id":5,"name":"Test
+        Composite Content View","label":"Test_Composite_Content_View","description":null,"organization_id":3,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":3},"created_at":"2025-07-11
+        15:22:26 UTC","updated_at":"2025-07-11 15:22:30 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":3,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"versions":[],"components":[{"id":3,"name":"Test
+        Content View 1.0","content_view_id":4,"version":"1.0","environments":[{"id":2,"name":"Library","label":"Library"}],"content_view":{"id":4,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0"},"repositories":[{"id":3,"name":"Test
+        Repository","label":"Test_Repository","description":null}]}],"content_view_components":[{"latest":false,"id":1,"created_at":"2025-07-11
+        15:22:27 UTC","updated_at":"2025-07-11 15:22:27 UTC","composite_content_view":{"id":5,"name":"Test
+        Composite Content View","label":"Test_Composite_Content_View","description":null,"next_version":1,"latest_version":null,"version_count":0},"content_view":{"id":4,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0","version_count":1},"content_view_version":{"id":3,"name":"Test
+        Content View 1.0","content_view_id":4,"version":"1.0","content_view":{"id":4,"name":"Test
+        Content View","label":"Test_Content_View","description":null},"environments":[{"id":2,"name":"Library","label":"Library"}],"repositories":[{"id":3,"name":"Test
+        Repository","label":"Test_Repository","description":null}]},"component_content_view_versions":[{"id":3,"version":"1.0","description":null,"published_at_words":"less
+        than a minute"}]}],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
 
         '
     headers:
@@ -153,10 +153,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '2438'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -164,27 +162,29 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 14; Test Organization
+      - 3; Test Organization
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=98
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '2248'
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
@@ -200,23 +200,24 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/32
+    uri: https://foreman.example.org/katello/api/content_views/5
   response:
     body:
-      string: '  {"content_host_count":0,"composite":true,"component_ids":[19],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":true,"solve_dependencies":false,"repository_ids":[32],"id":32,"name":"Test
-        Composite Content View","label":"Test_Composite_Content_View","description":null,"organization_id":14,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":14},"created_at":"2020-09-14
-        10:19:50 UTC","updated_at":"2020-09-14 10:19:53 UTC","environments":[],"repositories":[{"id":32,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[{"id":19,"name":"Test
-        Content View 1.0","content_view_id":31,"version":"1.0","environments":[{"id":13,"name":"Library","label":"Library"}],"content_view":{"id":31,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0"},"repositories":[{"id":32,"name":"Test
-        Repository","label":"Test_Repository","description":null}]}],"content_view_components":[{"latest":false,"id":6,"created_at":"2020-09-14
-        10:19:50 UTC","updated_at":"2020-09-14 10:19:50 UTC","composite_content_view":{"id":32,"name":"Test
-        Composite Content View","label":"Test_Composite_Content_View","description":null,"next_version":1,"latest_version":null,"version_count":0},"content_view":{"id":31,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0","version_count":1},"content_view_version":{"id":19,"name":"Test
-        Content View 1.0","content_view_id":31,"version":"1.0","content_view":{"id":31,"name":"Test
-        Content View","label":"Test_Content_View","description":null},"environments":[{"id":13,"name":"Library","label":"Library"}],"repositories":[{"id":32,"name":"Test
-        Repository","label":"Test_Repository","description":null}]}}],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true},"duplicate_repositories_to_publish":[]}
+      string: '  {"content_host_count":0,"composite":true,"rolling":false,"component_ids":[3],"duplicate_repositories_to_publish":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":true,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":1,"related_composite_cvs":[],"filtered":false,"needs_publish":true,"environment_ids":[],"repository_ids":[3],"id":5,"name":"Test
+        Composite Content View","label":"Test_Composite_Content_View","description":null,"organization_id":3,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":3},"created_at":"2025-07-11
+        15:22:26 UTC","updated_at":"2025-07-11 15:22:30 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":3,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"versions":[],"components":[{"id":3,"name":"Test
+        Content View 1.0","content_view_id":4,"version":"1.0","environments":[{"id":2,"name":"Library","label":"Library"}],"content_view":{"id":4,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0"},"repositories":[{"id":3,"name":"Test
+        Repository","label":"Test_Repository","description":null}]}],"content_view_components":[{"latest":false,"id":1,"created_at":"2025-07-11
+        15:22:27 UTC","updated_at":"2025-07-11 15:22:27 UTC","composite_content_view":{"id":5,"name":"Test
+        Composite Content View","label":"Test_Composite_Content_View","description":null,"next_version":1,"latest_version":null,"version_count":0},"content_view":{"id":4,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0","version_count":1},"content_view_version":{"id":3,"name":"Test
+        Content View 1.0","content_view_id":4,"version":"1.0","content_view":{"id":4,"name":"Test
+        Content View","label":"Test_Content_View","description":null},"environments":[{"id":2,"name":"Library","label":"Library"}],"repositories":[{"id":3,"name":"Test
+        Repository","label":"Test_Repository","description":null}]},"component_content_view_versions":[{"id":3,"version":"1.0","description":null,"published_at_words":"less
+        than a minute"}]}],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[],"errors":null}
 
         '
     headers:
@@ -224,10 +225,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '2298'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -237,25 +236,27 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=97
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '2146'
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
@@ -271,17 +272,20 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/14/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/3/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
   response:
     body:
-      string: '{"total":3,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":1,"latest_version":"1.0","auto_publish":false,"solve_dependencies":false,"repository_ids":[30],"id":31,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":14,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":14},"created_at":"2020-09-14
-        10:19:43 UTC","updated_at":"2020-09-14 10:19:44 UTC","environments":[{"id":13,"name":"Library","label":"Library","permissions":{"readable":true}}],"repositories":[{"id":30,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[{"id":19,"version":"1.0","published":"2020-09-14
-        10:19:44 UTC","environment_ids":[13]}],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"2.0","last_published":"2020-09-14
-        10:19:44 UTC","permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
+      string: '{"total":3,"subtotal":1,"selectable":1,"page":1,"per_page":4294967296,"error":null,"search":"name=\"Test
+        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"rolling":false,"component_ids":[],"duplicate_repositories_to_publish":[],"default":false,"version_count":1,"latest_version":"1.0","latest_version_id":3,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":1,"related_composite_cvs":[{"id":5,"name":"Test
+        Composite Content View"}],"filtered":false,"needs_publish":false,"environment_ids":[2],"repository_ids":[1],"id":4,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":3,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":3},"created_at":"2025-07-11
+        15:22:18 UTC","updated_at":"2025-07-11 15:22:20 UTC","last_task":{"id":"6f661932-5bdd-4f8f-a521-f5875e5339f4","started_at":"2025-07-11
+        15:22:19 UTC","result":"success","last_sync_words":"less than a minute"},"latest_version_environments":[{"id":2,"name":"Library","label":"Library"}],"repositories":[{"id":1,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"versions":[{"id":3,"version":"1.0","published":"2025-07-11
+        15:22:20 UTC","description":null,"environment_ids":[2],"filters_applied":false,"published_at_words":"less
+        than a minute"}],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"2.0","last_published":"2025-07-11
+        15:22:20 UTC","environments":[{"id":2,"label":"Library","name":"Library","activation_keys":[],"hosts":[],"permissions":{"readable":true}}]}]}
 
         '
     headers:
@@ -289,10 +293,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '1644'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -300,27 +302,29 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 14; Test Organization
+      - 3; Test Organization
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=96
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '1224'
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
@@ -336,16 +340,19 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/31
+    uri: https://foreman.example.org/katello/api/content_views/4
   response:
     body:
-      string: '  {"content_host_count":0,"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":1,"latest_version":"1.0","auto_publish":false,"solve_dependencies":false,"repository_ids":[30],"id":31,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":14,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":14},"created_at":"2020-09-14
-        10:19:43 UTC","updated_at":"2020-09-14 10:19:44 UTC","environments":[{"id":13,"name":"Library","label":"Library","permissions":{"readable":true}}],"repositories":[{"id":30,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[{"id":19,"version":"1.0","published":"2020-09-14
-        10:19:44 UTC","environment_ids":[13]}],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"2.0","last_published":"2020-09-14
-        10:19:44 UTC","permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true},"duplicate_repositories_to_publish":[]}
+      string: '  {"content_host_count":0,"composite":false,"rolling":false,"component_ids":[],"duplicate_repositories_to_publish":[],"default":false,"version_count":1,"latest_version":"1.0","latest_version_id":3,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":1,"related_composite_cvs":[{"id":5,"name":"Test
+        Composite Content View"}],"filtered":false,"needs_publish":false,"environment_ids":[2],"repository_ids":[1],"id":4,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":3,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":3},"created_at":"2025-07-11
+        15:22:18 UTC","updated_at":"2025-07-11 15:22:20 UTC","last_task":{"id":"6f661932-5bdd-4f8f-a521-f5875e5339f4","started_at":"2025-07-11
+        15:22:19 UTC","result":"success","last_sync_words":"less than a minute"},"latest_version_environments":[{"id":2,"name":"Library","label":"Library"}],"repositories":[{"id":1,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"versions":[{"id":3,"version":"1.0","published":"2025-07-11
+        15:22:20 UTC","description":null,"environment_ids":[2],"filters_applied":false,"published_at_words":"less
+        than a minute"}],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"2.0","last_published":"2025-07-11
+        15:22:20 UTC","environments":[{"id":2,"label":"Library","name":"Library","activation_keys":[],"hosts":[],"permissions":{"readable":true}}],"errors":null}
 
         '
     headers:
@@ -353,10 +360,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '1514'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -366,25 +371,27 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=95
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '1132'
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
@@ -404,16 +411,17 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: PUT
-    uri: https://foreman.example.org/katello/api/content_views/32/content_view_components/6
+    uri: https://foreman.example.org/katello/api/content_views/5/content_view_components/1
   response:
     body:
-      string: '  {"latest":true,"id":6,"created_at":"2020-09-14 10:19:50 UTC","updated_at":"2020-09-14
-        10:19:55 UTC","composite_content_view":{"id":32,"name":"Test Composite Content
-        View","label":"Test_Composite_Content_View","description":null,"next_version":1,"latest_version":null,"version_count":0},"content_view":{"id":31,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0","version_count":1},"content_view_version":{"id":19,"name":"Test
-        Content View 1.0","content_view_id":31,"version":"1.0","content_view":{"id":31,"name":"Test
-        Content View","label":"Test_Content_View","description":null},"environments":[{"id":13,"name":"Library","label":"Library"}],"repositories":[{"id":32,"name":"Test
-        Repository","label":"Test_Repository","description":null}]}}
+      string: '  {"latest":true,"id":1,"created_at":"2025-07-11 15:22:27 UTC","updated_at":"2025-07-11
+        15:22:33 UTC","composite_content_view":{"id":5,"name":"Test Composite Content
+        View","label":"Test_Composite_Content_View","description":null,"next_version":1,"latest_version":null,"version_count":0},"content_view":{"id":4,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0","version_count":1},"content_view_version":{"id":3,"name":"Test
+        Content View 1.0","content_view_id":4,"version":"1.0","content_view":{"id":4,"name":"Test
+        Content View","label":"Test_Content_View","description":null},"environments":[{"id":2,"name":"Library","label":"Library"}],"repositories":[{"id":3,"name":"Test
+        Repository","label":"Test_Repository","description":null}]},"component_content_view_versions":[{"id":3,"version":"1.0","description":null,"published_at_words":"less
+        than a minute"}]}
 
         '
     headers:
@@ -421,10 +429,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '920'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -434,25 +440,27 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=94
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '805'
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/content_view-11.yml
+++ b/tests/test_playbooks/fixtures/content_view-11.yml
@@ -14,16 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"2.1.2","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.16.0-develop","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '71'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -33,25 +31,27 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=100
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '62'
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
@@ -70,21 +70,18 @@ interactions:
     uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
-        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\"\
-        :\"Test_Organization\",\"created_at\":\"2020-09-14 10:19:21 UTC\",\"updated_at\"\
-        :\"2020-09-14 10:19:21 UTC\",\"id\":14,\"name\":\"Test Organization\",\"title\"\
-        :\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+        4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2025-07-11
+        15:21:41 UTC\",\"updated_at\":\"2025-07-11 15:21:45 UTC\",\"id\":3,\"name\":\"Test
+        Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '388'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -94,25 +91,27 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=99
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '389'
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
@@ -128,24 +127,25 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/14/content_views?search=name%3D%22Test+Composite+Content+View%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/3/content_views?search=name%3D%22Test+Composite+Content+View%22&per_page=4294967296
   response:
     body:
-      string: '{"total":3,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Composite Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":true,"component_ids":[19],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":true,"solve_dependencies":false,"repository_ids":[32],"id":32,"name":"Test
-        Composite Content View","label":"Test_Composite_Content_View","description":null,"organization_id":14,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":14},"created_at":"2020-09-14
-        10:19:50 UTC","updated_at":"2020-09-14 10:19:53 UTC","environments":[],"repositories":[{"id":32,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[{"id":19,"name":"Test
-        Content View 1.0","content_view_id":31,"version":"1.0","environments":[{"id":13,"name":"Library","label":"Library"}],"content_view":{"id":31,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0"},"repositories":[{"id":32,"name":"Test
-        Repository","label":"Test_Repository","description":null}]}],"content_view_components":[{"latest":true,"id":6,"created_at":"2020-09-14
-        10:19:50 UTC","updated_at":"2020-09-14 10:19:55 UTC","composite_content_view":{"id":32,"name":"Test
-        Composite Content View","label":"Test_Composite_Content_View","description":null,"next_version":1,"latest_version":null,"version_count":0},"content_view":{"id":31,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0","version_count":1},"content_view_version":{"id":19,"name":"Test
-        Content View 1.0","content_view_id":31,"version":"1.0","content_view":{"id":31,"name":"Test
-        Content View","label":"Test_Content_View","description":null},"environments":[{"id":13,"name":"Library","label":"Library"}],"repositories":[{"id":32,"name":"Test
-        Repository","label":"Test_Repository","description":null}]}}],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
+      string: '{"total":3,"subtotal":1,"selectable":1,"page":1,"per_page":4294967296,"error":null,"search":"name=\"Test
+        Composite Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":true,"rolling":false,"component_ids":[3],"duplicate_repositories_to_publish":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":true,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":1,"related_composite_cvs":[],"filtered":false,"needs_publish":true,"environment_ids":[],"repository_ids":[3],"id":5,"name":"Test
+        Composite Content View","label":"Test_Composite_Content_View","description":null,"organization_id":3,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":3},"created_at":"2025-07-11
+        15:22:26 UTC","updated_at":"2025-07-11 15:22:30 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":3,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"versions":[],"components":[{"id":3,"name":"Test
+        Content View 1.0","content_view_id":4,"version":"1.0","environments":[{"id":2,"name":"Library","label":"Library"}],"content_view":{"id":4,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0"},"repositories":[{"id":3,"name":"Test
+        Repository","label":"Test_Repository","description":null}]}],"content_view_components":[{"latest":true,"id":1,"created_at":"2025-07-11
+        15:22:27 UTC","updated_at":"2025-07-11 15:22:33 UTC","composite_content_view":{"id":5,"name":"Test
+        Composite Content View","label":"Test_Composite_Content_View","description":null,"next_version":1,"latest_version":null,"version_count":0},"content_view":{"id":4,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0","version_count":1},"content_view_version":{"id":3,"name":"Test
+        Content View 1.0","content_view_id":4,"version":"1.0","content_view":{"id":4,"name":"Test
+        Content View","label":"Test_Content_View","description":null},"environments":[{"id":2,"name":"Library","label":"Library"}],"repositories":[{"id":3,"name":"Test
+        Repository","label":"Test_Repository","description":null}]},"component_content_view_versions":[{"id":3,"version":"1.0","description":null,"published_at_words":"less
+        than a minute"}]}],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
 
         '
     headers:
@@ -153,10 +153,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '2437'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -164,27 +162,29 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 14; Test Organization
+      - 3; Test Organization
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=98
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '2247'
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
@@ -200,23 +200,24 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/32
+    uri: https://foreman.example.org/katello/api/content_views/5
   response:
     body:
-      string: '  {"content_host_count":0,"composite":true,"component_ids":[19],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":true,"solve_dependencies":false,"repository_ids":[32],"id":32,"name":"Test
-        Composite Content View","label":"Test_Composite_Content_View","description":null,"organization_id":14,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":14},"created_at":"2020-09-14
-        10:19:50 UTC","updated_at":"2020-09-14 10:19:53 UTC","environments":[],"repositories":[{"id":32,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[{"id":19,"name":"Test
-        Content View 1.0","content_view_id":31,"version":"1.0","environments":[{"id":13,"name":"Library","label":"Library"}],"content_view":{"id":31,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0"},"repositories":[{"id":32,"name":"Test
-        Repository","label":"Test_Repository","description":null}]}],"content_view_components":[{"latest":true,"id":6,"created_at":"2020-09-14
-        10:19:50 UTC","updated_at":"2020-09-14 10:19:55 UTC","composite_content_view":{"id":32,"name":"Test
-        Composite Content View","label":"Test_Composite_Content_View","description":null,"next_version":1,"latest_version":null,"version_count":0},"content_view":{"id":31,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0","version_count":1},"content_view_version":{"id":19,"name":"Test
-        Content View 1.0","content_view_id":31,"version":"1.0","content_view":{"id":31,"name":"Test
-        Content View","label":"Test_Content_View","description":null},"environments":[{"id":13,"name":"Library","label":"Library"}],"repositories":[{"id":32,"name":"Test
-        Repository","label":"Test_Repository","description":null}]}}],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true},"duplicate_repositories_to_publish":[]}
+      string: '  {"content_host_count":0,"composite":true,"rolling":false,"component_ids":[3],"duplicate_repositories_to_publish":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":true,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":1,"related_composite_cvs":[],"filtered":false,"needs_publish":true,"environment_ids":[],"repository_ids":[3],"id":5,"name":"Test
+        Composite Content View","label":"Test_Composite_Content_View","description":null,"organization_id":3,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":3},"created_at":"2025-07-11
+        15:22:26 UTC","updated_at":"2025-07-11 15:22:30 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":3,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"versions":[],"components":[{"id":3,"name":"Test
+        Content View 1.0","content_view_id":4,"version":"1.0","environments":[{"id":2,"name":"Library","label":"Library"}],"content_view":{"id":4,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0"},"repositories":[{"id":3,"name":"Test
+        Repository","label":"Test_Repository","description":null}]}],"content_view_components":[{"latest":true,"id":1,"created_at":"2025-07-11
+        15:22:27 UTC","updated_at":"2025-07-11 15:22:33 UTC","composite_content_view":{"id":5,"name":"Test
+        Composite Content View","label":"Test_Composite_Content_View","description":null,"next_version":1,"latest_version":null,"version_count":0},"content_view":{"id":4,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0","version_count":1},"content_view_version":{"id":3,"name":"Test
+        Content View 1.0","content_view_id":4,"version":"1.0","content_view":{"id":4,"name":"Test
+        Content View","label":"Test_Content_View","description":null},"environments":[{"id":2,"name":"Library","label":"Library"}],"repositories":[{"id":3,"name":"Test
+        Repository","label":"Test_Repository","description":null}]},"component_content_view_versions":[{"id":3,"version":"1.0","description":null,"published_at_words":"less
+        than a minute"}]}],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[],"errors":null}
 
         '
     headers:
@@ -224,10 +225,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '2297'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -237,25 +236,27 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=97
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '2145'
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
@@ -271,17 +272,20 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/14/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/3/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
   response:
     body:
-      string: '{"total":3,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":1,"latest_version":"1.0","auto_publish":false,"solve_dependencies":false,"repository_ids":[30],"id":31,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":14,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":14},"created_at":"2020-09-14
-        10:19:43 UTC","updated_at":"2020-09-14 10:19:44 UTC","environments":[{"id":13,"name":"Library","label":"Library","permissions":{"readable":true}}],"repositories":[{"id":30,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[{"id":19,"version":"1.0","published":"2020-09-14
-        10:19:44 UTC","environment_ids":[13]}],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"2.0","last_published":"2020-09-14
-        10:19:44 UTC","permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
+      string: '{"total":3,"subtotal":1,"selectable":1,"page":1,"per_page":4294967296,"error":null,"search":"name=\"Test
+        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"rolling":false,"component_ids":[],"duplicate_repositories_to_publish":[],"default":false,"version_count":1,"latest_version":"1.0","latest_version_id":3,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":1,"related_composite_cvs":[{"id":5,"name":"Test
+        Composite Content View"}],"filtered":false,"needs_publish":false,"environment_ids":[2],"repository_ids":[1],"id":4,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":3,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":3},"created_at":"2025-07-11
+        15:22:18 UTC","updated_at":"2025-07-11 15:22:20 UTC","last_task":{"id":"6f661932-5bdd-4f8f-a521-f5875e5339f4","started_at":"2025-07-11
+        15:22:19 UTC","result":"success","last_sync_words":"less than a minute"},"latest_version_environments":[{"id":2,"name":"Library","label":"Library"}],"repositories":[{"id":1,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"versions":[{"id":3,"version":"1.0","published":"2025-07-11
+        15:22:20 UTC","description":null,"environment_ids":[2],"filters_applied":false,"published_at_words":"less
+        than a minute"}],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"2.0","last_published":"2025-07-11
+        15:22:20 UTC","environments":[{"id":2,"label":"Library","name":"Library","activation_keys":[],"hosts":[],"permissions":{"readable":true}}]}]}
 
         '
     headers:
@@ -289,10 +293,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '1644'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -300,27 +302,29 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 14; Test Organization
+      - 3; Test Organization
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=96
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '1224'
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
@@ -336,16 +340,19 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/31
+    uri: https://foreman.example.org/katello/api/content_views/4
   response:
     body:
-      string: '  {"content_host_count":0,"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":1,"latest_version":"1.0","auto_publish":false,"solve_dependencies":false,"repository_ids":[30],"id":31,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":14,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":14},"created_at":"2020-09-14
-        10:19:43 UTC","updated_at":"2020-09-14 10:19:44 UTC","environments":[{"id":13,"name":"Library","label":"Library","permissions":{"readable":true}}],"repositories":[{"id":30,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[{"id":19,"version":"1.0","published":"2020-09-14
-        10:19:44 UTC","environment_ids":[13]}],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"2.0","last_published":"2020-09-14
-        10:19:44 UTC","permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true},"duplicate_repositories_to_publish":[]}
+      string: '  {"content_host_count":0,"composite":false,"rolling":false,"component_ids":[],"duplicate_repositories_to_publish":[],"default":false,"version_count":1,"latest_version":"1.0","latest_version_id":3,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":1,"related_composite_cvs":[{"id":5,"name":"Test
+        Composite Content View"}],"filtered":false,"needs_publish":false,"environment_ids":[2],"repository_ids":[1],"id":4,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":3,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":3},"created_at":"2025-07-11
+        15:22:18 UTC","updated_at":"2025-07-11 15:22:20 UTC","last_task":{"id":"6f661932-5bdd-4f8f-a521-f5875e5339f4","started_at":"2025-07-11
+        15:22:19 UTC","result":"success","last_sync_words":"less than a minute"},"latest_version_environments":[{"id":2,"name":"Library","label":"Library"}],"repositories":[{"id":1,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"versions":[{"id":3,"version":"1.0","published":"2025-07-11
+        15:22:20 UTC","description":null,"environment_ids":[2],"filters_applied":false,"published_at_words":"less
+        than a minute"}],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"2.0","last_published":"2025-07-11
+        15:22:20 UTC","environments":[{"id":2,"label":"Library","name":"Library","activation_keys":[],"hosts":[],"permissions":{"readable":true}}],"errors":null}
 
         '
     headers:
@@ -353,10 +360,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '1514'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -366,25 +371,27 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=95
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '1132'
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/content_view-12.yml
+++ b/tests/test_playbooks/fixtures/content_view-12.yml
@@ -14,16 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"2.1.2","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.16.0-develop","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '71'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -33,25 +31,27 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=100
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '62'
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
@@ -70,21 +70,18 @@ interactions:
     uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
-        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\"\
-        :\"Test_Organization\",\"created_at\":\"2020-09-14 10:19:21 UTC\",\"updated_at\"\
-        :\"2020-09-14 10:19:21 UTC\",\"id\":14,\"name\":\"Test Organization\",\"title\"\
-        :\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+        4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2025-07-11
+        15:21:41 UTC\",\"updated_at\":\"2025-07-11 15:21:45 UTC\",\"id\":3,\"name\":\"Test
+        Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '388'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -94,25 +91,27 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=99
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '389'
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
@@ -128,24 +127,25 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/14/content_views?search=name%3D%22Test+Composite+Content+View%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/3/content_views?search=name%3D%22Test+Composite+Content+View%22&per_page=4294967296
   response:
     body:
-      string: '{"total":3,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Composite Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":true,"component_ids":[19],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":true,"solve_dependencies":false,"repository_ids":[32],"id":32,"name":"Test
-        Composite Content View","label":"Test_Composite_Content_View","description":null,"organization_id":14,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":14},"created_at":"2020-09-14
-        10:19:50 UTC","updated_at":"2020-09-14 10:19:53 UTC","environments":[],"repositories":[{"id":32,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[{"id":19,"name":"Test
-        Content View 1.0","content_view_id":31,"version":"1.0","environments":[{"id":13,"name":"Library","label":"Library"}],"content_view":{"id":31,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0"},"repositories":[{"id":32,"name":"Test
-        Repository","label":"Test_Repository","description":null}]}],"content_view_components":[{"latest":true,"id":6,"created_at":"2020-09-14
-        10:19:50 UTC","updated_at":"2020-09-14 10:19:55 UTC","composite_content_view":{"id":32,"name":"Test
-        Composite Content View","label":"Test_Composite_Content_View","description":null,"next_version":1,"latest_version":null,"version_count":0},"content_view":{"id":31,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0","version_count":1},"content_view_version":{"id":19,"name":"Test
-        Content View 1.0","content_view_id":31,"version":"1.0","content_view":{"id":31,"name":"Test
-        Content View","label":"Test_Content_View","description":null},"environments":[{"id":13,"name":"Library","label":"Library"}],"repositories":[{"id":32,"name":"Test
-        Repository","label":"Test_Repository","description":null}]}}],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
+      string: '{"total":3,"subtotal":1,"selectable":1,"page":1,"per_page":4294967296,"error":null,"search":"name=\"Test
+        Composite Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":true,"rolling":false,"component_ids":[3],"duplicate_repositories_to_publish":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":true,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":1,"related_composite_cvs":[],"filtered":false,"needs_publish":true,"environment_ids":[],"repository_ids":[3],"id":5,"name":"Test
+        Composite Content View","label":"Test_Composite_Content_View","description":null,"organization_id":3,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":3},"created_at":"2025-07-11
+        15:22:26 UTC","updated_at":"2025-07-11 15:22:30 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":3,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"versions":[],"components":[{"id":3,"name":"Test
+        Content View 1.0","content_view_id":4,"version":"1.0","environments":[{"id":2,"name":"Library","label":"Library"}],"content_view":{"id":4,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0"},"repositories":[{"id":3,"name":"Test
+        Repository","label":"Test_Repository","description":null}]}],"content_view_components":[{"latest":true,"id":1,"created_at":"2025-07-11
+        15:22:27 UTC","updated_at":"2025-07-11 15:22:33 UTC","composite_content_view":{"id":5,"name":"Test
+        Composite Content View","label":"Test_Composite_Content_View","description":null,"next_version":1,"latest_version":null,"version_count":0},"content_view":{"id":4,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0","version_count":1},"content_view_version":{"id":3,"name":"Test
+        Content View 1.0","content_view_id":4,"version":"1.0","content_view":{"id":4,"name":"Test
+        Content View","label":"Test_Content_View","description":null},"environments":[{"id":2,"name":"Library","label":"Library"}],"repositories":[{"id":3,"name":"Test
+        Repository","label":"Test_Repository","description":null}]},"component_content_view_versions":[{"id":3,"version":"1.0","description":null,"published_at_words":"less
+        than a minute"}]}],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
 
         '
     headers:
@@ -153,10 +153,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '2437'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -164,27 +162,29 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 14; Test Organization
+      - 3; Test Organization
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=98
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '2247'
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
@@ -200,23 +200,24 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/32
+    uri: https://foreman.example.org/katello/api/content_views/5
   response:
     body:
-      string: '  {"content_host_count":0,"composite":true,"component_ids":[19],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":true,"solve_dependencies":false,"repository_ids":[32],"id":32,"name":"Test
-        Composite Content View","label":"Test_Composite_Content_View","description":null,"organization_id":14,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":14},"created_at":"2020-09-14
-        10:19:50 UTC","updated_at":"2020-09-14 10:19:53 UTC","environments":[],"repositories":[{"id":32,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[{"id":19,"name":"Test
-        Content View 1.0","content_view_id":31,"version":"1.0","environments":[{"id":13,"name":"Library","label":"Library"}],"content_view":{"id":31,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0"},"repositories":[{"id":32,"name":"Test
-        Repository","label":"Test_Repository","description":null}]}],"content_view_components":[{"latest":true,"id":6,"created_at":"2020-09-14
-        10:19:50 UTC","updated_at":"2020-09-14 10:19:55 UTC","composite_content_view":{"id":32,"name":"Test
-        Composite Content View","label":"Test_Composite_Content_View","description":null,"next_version":1,"latest_version":null,"version_count":0},"content_view":{"id":31,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0","version_count":1},"content_view_version":{"id":19,"name":"Test
-        Content View 1.0","content_view_id":31,"version":"1.0","content_view":{"id":31,"name":"Test
-        Content View","label":"Test_Content_View","description":null},"environments":[{"id":13,"name":"Library","label":"Library"}],"repositories":[{"id":32,"name":"Test
-        Repository","label":"Test_Repository","description":null}]}}],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true},"duplicate_repositories_to_publish":[]}
+      string: '  {"content_host_count":0,"composite":true,"rolling":false,"component_ids":[3],"duplicate_repositories_to_publish":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":true,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":1,"related_composite_cvs":[],"filtered":false,"needs_publish":true,"environment_ids":[],"repository_ids":[3],"id":5,"name":"Test
+        Composite Content View","label":"Test_Composite_Content_View","description":null,"organization_id":3,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":3},"created_at":"2025-07-11
+        15:22:26 UTC","updated_at":"2025-07-11 15:22:30 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":3,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"versions":[],"components":[{"id":3,"name":"Test
+        Content View 1.0","content_view_id":4,"version":"1.0","environments":[{"id":2,"name":"Library","label":"Library"}],"content_view":{"id":4,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0"},"repositories":[{"id":3,"name":"Test
+        Repository","label":"Test_Repository","description":null}]}],"content_view_components":[{"latest":true,"id":1,"created_at":"2025-07-11
+        15:22:27 UTC","updated_at":"2025-07-11 15:22:33 UTC","composite_content_view":{"id":5,"name":"Test
+        Composite Content View","label":"Test_Composite_Content_View","description":null,"next_version":1,"latest_version":null,"version_count":0},"content_view":{"id":4,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0","version_count":1},"content_view_version":{"id":3,"name":"Test
+        Content View 1.0","content_view_id":4,"version":"1.0","content_view":{"id":4,"name":"Test
+        Content View","label":"Test_Content_View","description":null},"environments":[{"id":2,"name":"Library","label":"Library"}],"repositories":[{"id":3,"name":"Test
+        Repository","label":"Test_Repository","description":null}]},"component_content_view_versions":[{"id":3,"version":"1.0","description":null,"published_at_words":"less
+        than a minute"}]}],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[],"errors":null}
 
         '
     headers:
@@ -224,10 +225,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '2297'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -237,25 +236,27 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=97
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '2145'
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/content_view-13.yml
+++ b/tests/test_playbooks/fixtures/content_view-13.yml
@@ -14,16 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"2.1.2","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.16.0-develop","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '71'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -33,25 +31,27 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=100
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '62'
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
@@ -70,21 +70,18 @@ interactions:
     uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
-        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\"\
-        :\"Test_Organization\",\"created_at\":\"2020-09-14 10:19:21 UTC\",\"updated_at\"\
-        :\"2020-09-14 10:19:21 UTC\",\"id\":14,\"name\":\"Test Organization\",\"title\"\
-        :\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+        4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2025-07-11
+        15:21:41 UTC\",\"updated_at\":\"2025-07-11 15:21:45 UTC\",\"id\":3,\"name\":\"Test
+        Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '388'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -94,25 +91,27 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=99
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '389'
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
@@ -128,24 +127,25 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/14/content_views?search=name%3D%22Test+Composite+Content+View%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/3/content_views?search=name%3D%22Test+Composite+Content+View%22&per_page=4294967296
   response:
     body:
-      string: '{"total":3,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Composite Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":true,"component_ids":[19],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":true,"solve_dependencies":false,"repository_ids":[32],"id":32,"name":"Test
-        Composite Content View","label":"Test_Composite_Content_View","description":null,"organization_id":14,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":14},"created_at":"2020-09-14
-        10:19:50 UTC","updated_at":"2020-09-14 10:19:53 UTC","environments":[],"repositories":[{"id":32,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[{"id":19,"name":"Test
-        Content View 1.0","content_view_id":31,"version":"1.0","environments":[{"id":13,"name":"Library","label":"Library"}],"content_view":{"id":31,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0"},"repositories":[{"id":32,"name":"Test
-        Repository","label":"Test_Repository","description":null}]}],"content_view_components":[{"latest":true,"id":6,"created_at":"2020-09-14
-        10:19:50 UTC","updated_at":"2020-09-14 10:19:55 UTC","composite_content_view":{"id":32,"name":"Test
-        Composite Content View","label":"Test_Composite_Content_View","description":null,"next_version":1,"latest_version":null,"version_count":0},"content_view":{"id":31,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0","version_count":1},"content_view_version":{"id":19,"name":"Test
-        Content View 1.0","content_view_id":31,"version":"1.0","content_view":{"id":31,"name":"Test
-        Content View","label":"Test_Content_View","description":null},"environments":[{"id":13,"name":"Library","label":"Library"}],"repositories":[{"id":32,"name":"Test
-        Repository","label":"Test_Repository","description":null}]}}],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
+      string: '{"total":3,"subtotal":1,"selectable":1,"page":1,"per_page":4294967296,"error":null,"search":"name=\"Test
+        Composite Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":true,"rolling":false,"component_ids":[3],"duplicate_repositories_to_publish":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":true,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":1,"related_composite_cvs":[],"filtered":false,"needs_publish":true,"environment_ids":[],"repository_ids":[3],"id":5,"name":"Test
+        Composite Content View","label":"Test_Composite_Content_View","description":null,"organization_id":3,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":3},"created_at":"2025-07-11
+        15:22:26 UTC","updated_at":"2025-07-11 15:22:30 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":3,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"versions":[],"components":[{"id":3,"name":"Test
+        Content View 1.0","content_view_id":4,"version":"1.0","environments":[{"id":2,"name":"Library","label":"Library"}],"content_view":{"id":4,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0"},"repositories":[{"id":3,"name":"Test
+        Repository","label":"Test_Repository","description":null}]}],"content_view_components":[{"latest":true,"id":1,"created_at":"2025-07-11
+        15:22:27 UTC","updated_at":"2025-07-11 15:22:33 UTC","composite_content_view":{"id":5,"name":"Test
+        Composite Content View","label":"Test_Composite_Content_View","description":null,"next_version":1,"latest_version":null,"version_count":0},"content_view":{"id":4,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0","version_count":1},"content_view_version":{"id":3,"name":"Test
+        Content View 1.0","content_view_id":4,"version":"1.0","content_view":{"id":4,"name":"Test
+        Content View","label":"Test_Content_View","description":null},"environments":[{"id":2,"name":"Library","label":"Library"}],"repositories":[{"id":3,"name":"Test
+        Repository","label":"Test_Repository","description":null}]},"component_content_view_versions":[{"id":3,"version":"1.0","description":null,"published_at_words":"less
+        than a minute"}]}],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
 
         '
     headers:
@@ -153,10 +153,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '2437'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -164,27 +162,29 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 14; Test Organization
+      - 3; Test Organization
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=98
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '2247'
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
@@ -200,23 +200,24 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/32
+    uri: https://foreman.example.org/katello/api/content_views/5
   response:
     body:
-      string: '  {"content_host_count":0,"composite":true,"component_ids":[19],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":true,"solve_dependencies":false,"repository_ids":[32],"id":32,"name":"Test
-        Composite Content View","label":"Test_Composite_Content_View","description":null,"organization_id":14,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":14},"created_at":"2020-09-14
-        10:19:50 UTC","updated_at":"2020-09-14 10:19:53 UTC","environments":[],"repositories":[{"id":32,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[{"id":19,"name":"Test
-        Content View 1.0","content_view_id":31,"version":"1.0","environments":[{"id":13,"name":"Library","label":"Library"}],"content_view":{"id":31,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0"},"repositories":[{"id":32,"name":"Test
-        Repository","label":"Test_Repository","description":null}]}],"content_view_components":[{"latest":true,"id":6,"created_at":"2020-09-14
-        10:19:50 UTC","updated_at":"2020-09-14 10:19:55 UTC","composite_content_view":{"id":32,"name":"Test
-        Composite Content View","label":"Test_Composite_Content_View","description":null,"next_version":1,"latest_version":null,"version_count":0},"content_view":{"id":31,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0","version_count":1},"content_view_version":{"id":19,"name":"Test
-        Content View 1.0","content_view_id":31,"version":"1.0","content_view":{"id":31,"name":"Test
-        Content View","label":"Test_Content_View","description":null},"environments":[{"id":13,"name":"Library","label":"Library"}],"repositories":[{"id":32,"name":"Test
-        Repository","label":"Test_Repository","description":null}]}}],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true},"duplicate_repositories_to_publish":[]}
+      string: '  {"content_host_count":0,"composite":true,"rolling":false,"component_ids":[3],"duplicate_repositories_to_publish":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":true,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":1,"related_composite_cvs":[],"filtered":false,"needs_publish":true,"environment_ids":[],"repository_ids":[3],"id":5,"name":"Test
+        Composite Content View","label":"Test_Composite_Content_View","description":null,"organization_id":3,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":3},"created_at":"2025-07-11
+        15:22:26 UTC","updated_at":"2025-07-11 15:22:30 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":3,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"versions":[],"components":[{"id":3,"name":"Test
+        Content View 1.0","content_view_id":4,"version":"1.0","environments":[{"id":2,"name":"Library","label":"Library"}],"content_view":{"id":4,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0"},"repositories":[{"id":3,"name":"Test
+        Repository","label":"Test_Repository","description":null}]}],"content_view_components":[{"latest":true,"id":1,"created_at":"2025-07-11
+        15:22:27 UTC","updated_at":"2025-07-11 15:22:33 UTC","composite_content_view":{"id":5,"name":"Test
+        Composite Content View","label":"Test_Composite_Content_View","description":null,"next_version":1,"latest_version":null,"version_count":0},"content_view":{"id":4,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0","version_count":1},"content_view_version":{"id":3,"name":"Test
+        Content View 1.0","content_view_id":4,"version":"1.0","content_view":{"id":4,"name":"Test
+        Content View","label":"Test_Content_View","description":null},"environments":[{"id":2,"name":"Library","label":"Library"}],"repositories":[{"id":3,"name":"Test
+        Repository","label":"Test_Repository","description":null}]},"component_content_view_versions":[{"id":3,"version":"1.0","description":null,"published_at_words":"less
+        than a minute"}]}],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[],"errors":null}
 
         '
     headers:
@@ -224,10 +225,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '2297'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -237,30 +236,32 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=97
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '2145'
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"component_ids": [6]}'
+    body: '{"component_ids": [1]}'
     headers:
       Accept:
       - application/json;version=2
@@ -275,10 +276,10 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: PUT
-    uri: https://foreman.example.org/katello/api/content_views/32/content_view_components/remove
+    uri: https://foreman.example.org/katello/api/content_views/5/content_view_components/remove
   response:
     body:
-      string: '{"total":0,"subtotal":0,"page":null,"per_page":null,"error":null,"search":null,"sort":{"by":null,"order":null},"results":[]}
+      string: '{"total":0,"subtotal":0,"selectable":0,"page":null,"per_page":null,"error":null,"search":null,"sort":{"by":null,"order":null},"results":[]}
 
         '
     headers:
@@ -286,10 +287,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '140'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -299,25 +298,27 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=96
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '125'
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/content_view-14.yml
+++ b/tests/test_playbooks/fixtures/content_view-14.yml
@@ -14,16 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"2.1.2","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.16.0-develop","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '71'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -33,25 +31,27 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=100
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '62'
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
@@ -70,21 +70,18 @@ interactions:
     uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
-        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\"\
-        :\"Test_Organization\",\"created_at\":\"2020-09-14 10:19:21 UTC\",\"updated_at\"\
-        :\"2020-09-14 10:19:21 UTC\",\"id\":14,\"name\":\"Test Organization\",\"title\"\
-        :\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+        4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2025-07-11
+        15:21:41 UTC\",\"updated_at\":\"2025-07-11 15:21:45 UTC\",\"id\":3,\"name\":\"Test
+        Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '388'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -94,25 +91,27 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=99
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '389'
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
@@ -128,14 +127,14 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/14/content_views?search=name%3D%22Test+Composite+Content+View%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/3/content_views?search=name%3D%22Test+Composite+Content+View%22&per_page=4294967296
   response:
     body:
-      string: '{"total":3,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Composite Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":true,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":true,"solve_dependencies":false,"repository_ids":[],"id":32,"name":"Test
-        Composite Content View","label":"Test_Composite_Content_View","description":null,"organization_id":14,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":14},"created_at":"2020-09-14
-        10:19:50 UTC","updated_at":"2020-09-14 10:19:53 UTC","environments":[],"repositories":[],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
+      string: '{"total":3,"subtotal":1,"selectable":1,"page":1,"per_page":4294967296,"error":null,"search":"name=\"Test
+        Composite Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":true,"rolling":false,"component_ids":[],"duplicate_repositories_to_publish":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":true,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"filtered":false,"needs_publish":true,"environment_ids":[],"repository_ids":[],"id":5,"name":"Test
+        Composite Content View","label":"Test_Composite_Content_View","description":null,"organization_id":3,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":3},"created_at":"2025-07-11
+        15:22:26 UTC","updated_at":"2025-07-11 15:22:30 UTC","last_task":null,"latest_version_environments":[],"repositories":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
 
         '
     headers:
@@ -143,10 +142,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '1068'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -154,27 +151,29 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 14; Test Organization
+      - 3; Test Organization
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=98
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '985'
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
@@ -190,13 +189,13 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/32
+    uri: https://foreman.example.org/katello/api/content_views/5
   response:
     body:
-      string: '  {"content_host_count":0,"composite":true,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":true,"solve_dependencies":false,"repository_ids":[],"id":32,"name":"Test
-        Composite Content View","label":"Test_Composite_Content_View","description":null,"organization_id":14,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":14},"created_at":"2020-09-14
-        10:19:50 UTC","updated_at":"2020-09-14 10:19:53 UTC","environments":[],"repositories":[],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true},"duplicate_repositories_to_publish":[]}
+      string: '  {"content_host_count":0,"composite":true,"rolling":false,"component_ids":[],"duplicate_repositories_to_publish":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":true,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"filtered":false,"needs_publish":true,"environment_ids":[],"repository_ids":[],"id":5,"name":"Test
+        Composite Content View","label":"Test_Composite_Content_View","description":null,"organization_id":3,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":3},"created_at":"2025-07-11
+        15:22:26 UTC","updated_at":"2025-07-11 15:22:30 UTC","last_task":null,"latest_version_environments":[],"repositories":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[],"errors":null}
 
         '
     headers:
@@ -204,10 +203,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '928'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -217,25 +214,27 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=97
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '883'
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/content_view-15.yml
+++ b/tests/test_playbooks/fixtures/content_view-15.yml
@@ -14,16 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"2.1.2","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.16.0-develop","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '71'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -33,25 +31,27 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=100
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '62'
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
@@ -70,21 +70,18 @@ interactions:
     uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
-        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\"\
-        :\"Test_Organization\",\"created_at\":\"2020-09-14 10:19:21 UTC\",\"updated_at\"\
-        :\"2020-09-14 10:19:21 UTC\",\"id\":14,\"name\":\"Test Organization\",\"title\"\
-        :\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+        4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2025-07-11
+        15:21:41 UTC\",\"updated_at\":\"2025-07-11 15:21:45 UTC\",\"id\":3,\"name\":\"Test
+        Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '388'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -94,25 +91,27 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=99
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '389'
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
@@ -128,14 +127,14 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/14/content_views?search=name%3D%22Test+Composite+Content+View%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/3/content_views?search=name%3D%22Test+Composite+Content+View%22&per_page=4294967296
   response:
     body:
-      string: '{"total":3,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Composite Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":true,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":true,"solve_dependencies":false,"repository_ids":[],"id":32,"name":"Test
-        Composite Content View","label":"Test_Composite_Content_View","description":null,"organization_id":14,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":14},"created_at":"2020-09-14
-        10:19:50 UTC","updated_at":"2020-09-14 10:19:53 UTC","environments":[],"repositories":[],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
+      string: '{"total":3,"subtotal":1,"selectable":1,"page":1,"per_page":4294967296,"error":null,"search":"name=\"Test
+        Composite Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":true,"rolling":false,"component_ids":[],"duplicate_repositories_to_publish":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":true,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"filtered":false,"needs_publish":true,"environment_ids":[],"repository_ids":[],"id":5,"name":"Test
+        Composite Content View","label":"Test_Composite_Content_View","description":null,"organization_id":3,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":3},"created_at":"2025-07-11
+        15:22:26 UTC","updated_at":"2025-07-11 15:22:30 UTC","last_task":null,"latest_version_environments":[],"repositories":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
 
         '
     headers:
@@ -143,10 +142,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '1068'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -154,27 +151,29 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 14; Test Organization
+      - 3; Test Organization
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=98
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '985'
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
@@ -190,13 +189,13 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/32
+    uri: https://foreman.example.org/katello/api/content_views/5
   response:
     body:
-      string: '  {"content_host_count":0,"composite":true,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":true,"solve_dependencies":false,"repository_ids":[],"id":32,"name":"Test
-        Composite Content View","label":"Test_Composite_Content_View","description":null,"organization_id":14,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":14},"created_at":"2020-09-14
-        10:19:50 UTC","updated_at":"2020-09-14 10:19:53 UTC","environments":[],"repositories":[],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true},"duplicate_repositories_to_publish":[]}
+      string: '  {"content_host_count":0,"composite":true,"rolling":false,"component_ids":[],"duplicate_repositories_to_publish":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":true,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"filtered":false,"needs_publish":true,"environment_ids":[],"repository_ids":[],"id":5,"name":"Test
+        Composite Content View","label":"Test_Composite_Content_View","description":null,"organization_id":3,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":3},"created_at":"2025-07-11
+        15:22:26 UTC","updated_at":"2025-07-11 15:22:30 UTC","last_task":null,"latest_version_environments":[],"repositories":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[],"errors":null}
 
         '
     headers:
@@ -204,10 +203,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '928'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -217,25 +214,27 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=97
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '883'
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/content_view-16.yml
+++ b/tests/test_playbooks/fixtures/content_view-16.yml
@@ -14,16 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"2.1.2","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.16.0-develop","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '71'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -33,25 +31,27 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=100
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '62'
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
@@ -70,21 +70,18 @@ interactions:
     uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
-        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\"\
-        :\"Test_Organization\",\"created_at\":\"2020-09-14 10:19:21 UTC\",\"updated_at\"\
-        :\"2020-09-14 10:19:21 UTC\",\"id\":14,\"name\":\"Test Organization\",\"title\"\
-        :\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+        4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2025-07-11
+        15:21:41 UTC\",\"updated_at\":\"2025-07-11 15:21:45 UTC\",\"id\":3,\"name\":\"Test
+        Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '388'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -94,25 +91,27 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=99
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '389'
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
@@ -128,14 +127,14 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/14/content_views?search=name%3D%22Test+Composite+Content+View%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/3/content_views?search=name%3D%22Test+Composite+Content+View%22&per_page=4294967296
   response:
     body:
-      string: '{"total":3,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Composite Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":true,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":true,"solve_dependencies":false,"repository_ids":[],"id":32,"name":"Test
-        Composite Content View","label":"Test_Composite_Content_View","description":null,"organization_id":14,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":14},"created_at":"2020-09-14
-        10:19:50 UTC","updated_at":"2020-09-14 10:19:53 UTC","environments":[],"repositories":[],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
+      string: '{"total":3,"subtotal":1,"selectable":1,"page":1,"per_page":4294967296,"error":null,"search":"name=\"Test
+        Composite Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":true,"rolling":false,"component_ids":[],"duplicate_repositories_to_publish":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":true,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"filtered":false,"needs_publish":true,"environment_ids":[],"repository_ids":[],"id":5,"name":"Test
+        Composite Content View","label":"Test_Composite_Content_View","description":null,"organization_id":3,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":3},"created_at":"2025-07-11
+        15:22:26 UTC","updated_at":"2025-07-11 15:22:30 UTC","last_task":null,"latest_version_environments":[],"repositories":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
 
         '
     headers:
@@ -143,10 +142,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '1068'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -154,27 +151,29 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 14; Test Organization
+      - 3; Test Organization
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=98
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '985'
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
@@ -190,13 +189,13 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/32
+    uri: https://foreman.example.org/katello/api/content_views/5
   response:
     body:
-      string: '  {"content_host_count":0,"composite":true,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":true,"solve_dependencies":false,"repository_ids":[],"id":32,"name":"Test
-        Composite Content View","label":"Test_Composite_Content_View","description":null,"organization_id":14,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":14},"created_at":"2020-09-14
-        10:19:50 UTC","updated_at":"2020-09-14 10:19:53 UTC","environments":[],"repositories":[],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true},"duplicate_repositories_to_publish":[]}
+      string: '  {"content_host_count":0,"composite":true,"rolling":false,"component_ids":[],"duplicate_repositories_to_publish":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":true,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"filtered":false,"needs_publish":true,"environment_ids":[],"repository_ids":[],"id":5,"name":"Test
+        Composite Content View","label":"Test_Composite_Content_View","description":null,"organization_id":3,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":3},"created_at":"2025-07-11
+        15:22:26 UTC","updated_at":"2025-07-11 15:22:30 UTC","last_task":null,"latest_version_environments":[],"repositories":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[],"errors":null}
 
         '
     headers:
@@ -204,10 +203,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '928'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -217,25 +214,27 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=97
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '883'
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
@@ -253,17 +252,17 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: DELETE
-    uri: https://foreman.example.org/katello/api/content_views/32
+    uri: https://foreman.example.org/katello/api/content_views/5
   response:
     body:
-      string: '  {"id":"e0a55fcd-b41d-4a16-992e-02e62680b7cf","label":"Actions::Katello::ContentView::Destroy","pending":true,"action":"Delete
-        content view ''Test Composite Content View''; organization ''Test Organization''","username":"admin","started_at":"2020-09-14
-        10:20:00 UTC","ended_at":null,"state":"planned","result":"pending","progress":0.0,"input":{"content_view":{"id":32,"name":"Test
-        Composite Content View","label":"Test_Composite_Content_View"},"organization":{"id":14,"name":"Test
-        Organization","label":"Test_Organization"},"services_checked":["pulp3"],"remote_user":"admin","remote_cp_user":"admin","current_request_id":null,"current_timezone":"UTC","current_user_id":4,"current_organization_id":null,"current_location_id":null},"output":{},"humanized":{"action":"Delete","input":[["content_view",{"text":"content
-        view ''Test Composite Content View''","link":"/content_views/32/versions"}],["organization",{"text":"organization
-        ''Test Organization''","link":"/organizations/14/edit"}]],"output":"","errors":[]},"cli_example":null,"start_at":"2020-09-14
-        10:20:00 UTC","available_actions":{"cancellable":false,"resumable":false}}
+      string: '  {"id":"07cd27a8-a30e-4bc7-ae1b-45b2083b37f9","label":"Actions::Katello::ContentView::Destroy","pending":true,"action":"Delete
+        content view ''Test Composite Content View''; organization ''Test Organization''","username":"admin","started_at":"2025-07-11
+        15:22:41 UTC","ended_at":null,"state":"planned","result":"pending","progress":0.0,"input":{"content_view":{"id":5,"name":"Test
+        Composite Content View","label":"Test_Composite_Content_View"},"organization":{"id":3,"name":"Test
+        Organization","label":"Test_Organization"},"services_checked":["pulp3"],"remote_user":"admin","remote_cp_user":"admin","current_request_id":"4a17c9a6-753d-4444-8a46-32ab1e71d8e2","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{},"humanized":{"action":"Delete","input":[["content_view",{"text":"content
+        view ''Test Composite Content View''","link":"/content_views/5/versions"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/3/edit"}]],"output":"","errors":[]},"cli_example":null,"start_at":"2025-07-11
+        15:22:41 UTC","available_actions":{"cancellable":false,"resumable":false}}
 
         '
     headers:
@@ -271,10 +270,6 @@ interactions:
       - no-cache
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -284,23 +279,29 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=96
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
       Transfer-Encoding:
       - chunked
-      X-Content-Type-Options:
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
+      - max-age=631139040; includeSubdomains
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
+      x-xss-protection:
+      - '0'
     status:
       code: 202
       message: Accepted
@@ -316,26 +317,24 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/foreman_tasks/api/tasks/e0a55fcd-b41d-4a16-992e-02e62680b7cf
+    uri: https://foreman.example.org/foreman_tasks/api/tasks/07cd27a8-a30e-4bc7-ae1b-45b2083b37f9
   response:
     body:
-      string: '{"id":"e0a55fcd-b41d-4a16-992e-02e62680b7cf","label":"Actions::Katello::ContentView::Destroy","pending":false,"action":"Delete
-        content view ''Test Composite Content View''; organization ''Test Organization''","username":"admin","started_at":"2020-09-14
-        10:20:00 UTC","ended_at":"2020-09-14 10:20:00 UTC","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":32,"name":"Test
-        Composite Content View","label":"Test_Composite_Content_View"},"organization":{"id":14,"name":"Test
-        Organization","label":"Test_Organization"},"services_checked":["pulp3"],"remote_user":"admin","remote_cp_user":"admin","current_request_id":null,"current_timezone":"UTC","current_user_id":4,"current_organization_id":null,"current_location_id":null},"output":{},"humanized":{"action":"Delete","input":[["content_view",{"text":"content
-        view ''Test Composite Content View''","link":"/content_views/32/versions"}],["organization",{"text":"organization
-        ''Test Organization''","link":"/organizations/14/edit"}]],"output":"","errors":[]},"cli_example":null,"start_at":"2020-09-14
-        10:20:00 UTC","available_actions":{"cancellable":false,"resumable":false}}'
+      string: '{"id":"07cd27a8-a30e-4bc7-ae1b-45b2083b37f9","label":"Actions::Katello::ContentView::Destroy","pending":false,"action":"Delete
+        content view ''Test Composite Content View''; organization ''Test Organization''","username":"admin","started_at":"2025-07-11
+        15:22:41 UTC","ended_at":"2025-07-11 15:22:42 UTC","duration":"0.222763","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":5,"name":"Test
+        Composite Content View","label":"Test_Composite_Content_View"},"organization":{"id":3,"name":"Test
+        Organization","label":"Test_Organization"},"services_checked":["pulp3"],"remote_user":"admin","remote_cp_user":"admin","current_request_id":"4a17c9a6-753d-4444-8a46-32ab1e71d8e2","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{},"humanized":{"action":"Delete","input":[["content_view",{"text":"content
+        view ''Test Composite Content View''","link":"/content_views/5/versions"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/3/edit"}]],"output":"","errors":[]},"cli_example":null,"start_at":"2025-07-11
+        15:22:41 UTC","available_actions":{"cancellable":false,"resumable":false}}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '1193'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -345,25 +344,27 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=95
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '1141'
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/content_view-17.yml
+++ b/tests/test_playbooks/fixtures/content_view-17.yml
@@ -14,16 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"2.1.2","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.16.0-develop","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '71'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -33,25 +31,27 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=100
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '62'
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
@@ -70,21 +70,18 @@ interactions:
     uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
-        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\"\
-        :\"Test_Organization\",\"created_at\":\"2020-09-14 10:19:21 UTC\",\"updated_at\"\
-        :\"2020-09-14 10:19:21 UTC\",\"id\":14,\"name\":\"Test Organization\",\"title\"\
-        :\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+        4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2025-07-11
+        15:21:41 UTC\",\"updated_at\":\"2025-07-11 15:21:45 UTC\",\"id\":3,\"name\":\"Test
+        Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '388'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -94,25 +91,27 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=99
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '389'
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
@@ -128,10 +127,10 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/14/content_views?search=name%3D%22Test+Composite+Content+View%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/3/content_views?search=name%3D%22Test+Composite+Content+View%22&per_page=4294967296
   response:
     body:
-      string: '{"total":2,"subtotal":0,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+      string: '{"total":2,"subtotal":0,"selectable":0,"page":1,"per_page":4294967296,"error":null,"search":"name=\"Test
         Composite Content View\"","sort":{"by":"name","order":"asc"},"results":[]}
 
         '
@@ -140,10 +139,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '180'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -151,27 +148,29 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 14; Test Organization
+      - 3; Test Organization
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=98
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '167'
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/content_view-18.yml
+++ b/tests/test_playbooks/fixtures/content_view-18.yml
@@ -14,16 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"2.1.2","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.16.0-develop","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '71'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -33,25 +31,27 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=100
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '62'
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
@@ -70,21 +70,18 @@ interactions:
     uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
-        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\"\
-        :\"Test_Organization\",\"created_at\":\"2020-09-14 10:19:21 UTC\",\"updated_at\"\
-        :\"2020-09-14 10:19:21 UTC\",\"id\":14,\"name\":\"Test Organization\",\"title\"\
-        :\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+        4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2025-07-11
+        15:21:41 UTC\",\"updated_at\":\"2025-07-11 15:21:45 UTC\",\"id\":3,\"name\":\"Test
+        Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '388'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -94,25 +91,27 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=99
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '389'
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
@@ -128,17 +127,19 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/14/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/3/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
   response:
     body:
-      string: '{"total":2,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":1,"latest_version":"1.0","auto_publish":false,"solve_dependencies":false,"repository_ids":[30],"id":31,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":14,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":14},"created_at":"2020-09-14
-        10:19:43 UTC","updated_at":"2020-09-14 10:19:44 UTC","environments":[{"id":13,"name":"Library","label":"Library","permissions":{"readable":true}}],"repositories":[{"id":30,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[{"id":19,"version":"1.0","published":"2020-09-14
-        10:19:44 UTC","environment_ids":[13]}],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"2.0","last_published":"2020-09-14
-        10:19:44 UTC","permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
+      string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":4294967296,"error":null,"search":"name=\"Test
+        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"rolling":false,"component_ids":[],"duplicate_repositories_to_publish":[],"default":false,"version_count":1,"latest_version":"1.0","latest_version_id":3,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"filtered":false,"needs_publish":false,"environment_ids":[2],"repository_ids":[1],"id":4,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":3,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":3},"created_at":"2025-07-11
+        15:22:18 UTC","updated_at":"2025-07-11 15:22:20 UTC","last_task":{"id":"6f661932-5bdd-4f8f-a521-f5875e5339f4","started_at":"2025-07-11
+        15:22:19 UTC","result":"success","last_sync_words":"less than a minute"},"latest_version_environments":[{"id":2,"name":"Library","label":"Library"}],"repositories":[{"id":1,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"versions":[{"id":3,"version":"1.0","published":"2025-07-11
+        15:22:20 UTC","description":null,"environment_ids":[2],"filters_applied":false,"published_at_words":"less
+        than a minute"}],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"2.0","last_published":"2025-07-11
+        15:22:20 UTC","environments":[{"id":2,"label":"Library","name":"Library","activation_keys":[],"hosts":[],"permissions":{"readable":true}}]}]}
 
         '
     headers:
@@ -146,10 +147,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '1599'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -157,27 +156,29 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 14; Test Organization
+      - 3; Test Organization
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=98
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '1224'
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
@@ -193,16 +194,18 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/31
+    uri: https://foreman.example.org/katello/api/content_views/4
   response:
     body:
-      string: '  {"content_host_count":0,"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":1,"latest_version":"1.0","auto_publish":false,"solve_dependencies":false,"repository_ids":[30],"id":31,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":14,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":14},"created_at":"2020-09-14
-        10:19:43 UTC","updated_at":"2020-09-14 10:19:44 UTC","environments":[{"id":13,"name":"Library","label":"Library","permissions":{"readable":true}}],"repositories":[{"id":30,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[{"id":19,"version":"1.0","published":"2020-09-14
-        10:19:44 UTC","environment_ids":[13]}],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"2.0","last_published":"2020-09-14
-        10:19:44 UTC","permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true},"duplicate_repositories_to_publish":[]}
+      string: '  {"content_host_count":0,"composite":false,"rolling":false,"component_ids":[],"duplicate_repositories_to_publish":[],"default":false,"version_count":1,"latest_version":"1.0","latest_version_id":3,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"filtered":false,"needs_publish":false,"environment_ids":[2],"repository_ids":[1],"id":4,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":3,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":3},"created_at":"2025-07-11
+        15:22:18 UTC","updated_at":"2025-07-11 15:22:20 UTC","last_task":{"id":"6f661932-5bdd-4f8f-a521-f5875e5339f4","started_at":"2025-07-11
+        15:22:19 UTC","result":"success","last_sync_words":"less than a minute"},"latest_version_environments":[{"id":2,"name":"Library","label":"Library"}],"repositories":[{"id":1,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"versions":[{"id":3,"version":"1.0","published":"2025-07-11
+        15:22:20 UTC","description":null,"environment_ids":[2],"filters_applied":false,"published_at_words":"less
+        than a minute"}],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"2.0","last_published":"2025-07-11
+        15:22:20 UTC","environments":[{"id":2,"label":"Library","name":"Library","activation_keys":[],"hosts":[],"permissions":{"readable":true}}],"errors":null}
 
         '
     headers:
@@ -210,10 +213,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '1469'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -223,25 +224,27 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=97
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '1132'
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
@@ -259,18 +262,18 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: DELETE
-    uri: https://foreman.example.org/katello/api/content_views/31/environments/13
+    uri: https://foreman.example.org/katello/api/content_views/4/environments/2
   response:
     body:
-      string: '  {"id":"c37fd5ef-a2ab-48e6-b832-9d857012b371","label":"Actions::Katello::ContentView::RemoveFromEnvironment","pending":true,"action":"Remove
-        from Environment content view ''Test Content View''; organization ''Test Organization''","username":"admin","started_at":"2020-09-14
-        10:20:06 UTC","ended_at":null,"state":"planned","result":"pending","progress":0.0,"input":{"content_view":{"id":31,"name":"Test
-        Content View","label":"Test_Content_View"},"organization":{"id":14,"name":"Test
-        Organization","label":"Test_Organization"},"services_checked":["pulp3","candlepin","candlepin_auth"],"history_id":25,"current_request_id":null,"current_timezone":"UTC","current_user_id":4,"current_organization_id":null,"current_location_id":null},"output":{},"humanized":{"action":"Remove
+      string: '  {"id":"92e18900-63f9-40d8-9df0-c7020c72df91","label":"Actions::Katello::ContentView::RemoveFromEnvironment","pending":true,"action":"Remove
+        from Environment content view ''Test Content View''; organization ''Test Organization''","username":"admin","started_at":"2025-07-11
+        15:22:48 UTC","ended_at":null,"state":"planned","result":"pending","progress":0.0,"input":{"content_view":{"id":4,"name":"Test
+        Content View","label":"Test_Content_View"},"organization":{"id":3,"name":"Test
+        Organization","label":"Test_Organization"},"services_checked":["pulp3","candlepin","candlepin_auth"],"history_id":2,"current_request_id":"c75ed979-93ac-4e12-9bb6-3e879eab1a4e","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{},"humanized":{"action":"Remove
         from Environment","input":[["content_view",{"text":"content view ''Test Content
-        View''","link":"/content_views/31/versions"}],["organization",{"text":"organization
-        ''Test Organization''","link":"/organizations/14/edit"}]],"output":"","errors":[]},"cli_example":null,"start_at":"2020-09-14
-        10:20:06 UTC","available_actions":{"cancellable":false,"resumable":false}}
+        View''","link":"/content_views/4/versions"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/3/edit"}]],"output":"","errors":[]},"cli_example":null,"start_at":"2025-07-11
+        15:22:48 UTC","available_actions":{"cancellable":false,"resumable":false}}
 
         '
     headers:
@@ -278,10 +281,6 @@ interactions:
       - no-cache
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -291,23 +290,29 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=96
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
       Transfer-Encoding:
       - chunked
-      X-Content-Type-Options:
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
+      - max-age=631139040; includeSubdomains
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
+      x-xss-protection:
+      - '0'
     status:
       code: 202
       message: Accepted
@@ -323,27 +328,25 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/foreman_tasks/api/tasks/c37fd5ef-a2ab-48e6-b832-9d857012b371
+    uri: https://foreman.example.org/foreman_tasks/api/tasks/92e18900-63f9-40d8-9df0-c7020c72df91
   response:
     body:
-      string: '{"id":"c37fd5ef-a2ab-48e6-b832-9d857012b371","label":"Actions::Katello::ContentView::RemoveFromEnvironment","pending":false,"action":"Remove
-        from Environment content view ''Test Content View''; organization ''Test Organization''","username":"admin","started_at":"2020-09-14
-        10:20:06 UTC","ended_at":"2020-09-14 10:20:06 UTC","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":31,"name":"Test
-        Content View","label":"Test_Content_View"},"organization":{"id":14,"name":"Test
-        Organization","label":"Test_Organization"},"services_checked":["pulp3","candlepin","candlepin_auth"],"history_id":25,"current_request_id":null,"current_timezone":"UTC","current_user_id":4,"current_organization_id":null,"current_location_id":null},"output":{},"humanized":{"action":"Remove
+      string: '{"id":"92e18900-63f9-40d8-9df0-c7020c72df91","label":"Actions::Katello::ContentView::RemoveFromEnvironment","pending":false,"action":"Remove
+        from Environment content view ''Test Content View''; organization ''Test Organization''","username":"admin","started_at":"2025-07-11
+        15:22:48 UTC","ended_at":"2025-07-11 15:22:49 UTC","duration":"0.896691","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":4,"name":"Test
+        Content View","label":"Test_Content_View"},"organization":{"id":3,"name":"Test
+        Organization","label":"Test_Organization"},"services_checked":["pulp3","candlepin","candlepin_auth"],"history_id":2,"current_request_id":"c75ed979-93ac-4e12-9bb6-3e879eab1a4e","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{},"humanized":{"action":"Remove
         from Environment","input":[["content_view",{"text":"content view ''Test Content
-        View''","link":"/content_views/31/versions"}],["organization",{"text":"organization
-        ''Test Organization''","link":"/organizations/14/edit"}]],"output":"","errors":[]},"cli_example":null,"start_at":"2020-09-14
-        10:20:06 UTC","available_actions":{"cancellable":false,"resumable":false}}'
+        View''","link":"/content_views/4/versions"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/3/edit"}]],"output":"","errors":[]},"cli_example":null,"start_at":"2025-07-11
+        15:22:48 UTC","available_actions":{"cancellable":false,"resumable":false}}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '1198'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -353,25 +356,27 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=95
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '1147'
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
@@ -389,17 +394,17 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: DELETE
-    uri: https://foreman.example.org/katello/api/content_views/31
+    uri: https://foreman.example.org/katello/api/content_views/4
   response:
     body:
-      string: '  {"id":"8f3a3c07-2e46-48ff-9faa-75d2a0a70269","label":"Actions::Katello::ContentView::Destroy","pending":true,"action":"Delete
-        content view ''Test Content View''; organization ''Test Organization''","username":"admin","started_at":"2020-09-14
-        10:20:10 UTC","ended_at":null,"state":"planned","result":"pending","progress":0.0,"input":{"content_view":{"id":31,"name":"Test
-        Content View","label":"Test_Content_View"},"organization":{"id":14,"name":"Test
-        Organization","label":"Test_Organization"},"services_checked":["pulp3","pulp","pulp_auth"],"remote_user":"admin","remote_cp_user":"admin","current_request_id":null,"current_timezone":"UTC","current_user_id":4,"current_organization_id":null,"current_location_id":null},"output":{},"humanized":{"action":"Delete","input":[["content_view",{"text":"content
-        view ''Test Content View''","link":"/content_views/31/versions"}],["organization",{"text":"organization
-        ''Test Organization''","link":"/organizations/14/edit"}]],"output":"","errors":[]},"cli_example":null,"start_at":"2020-09-14
-        10:20:10 UTC","available_actions":{"cancellable":false,"resumable":false}}
+      string: '  {"id":"16a5e456-92f7-4f34-b166-6339bee69df1","label":"Actions::Katello::ContentView::Destroy","pending":true,"action":"Delete
+        content view ''Test Content View''; organization ''Test Organization''","username":"admin","started_at":"2025-07-11
+        15:22:52 UTC","ended_at":null,"state":"planned","result":"pending","progress":0.0,"input":{"content_view":{"id":4,"name":"Test
+        Content View","label":"Test_Content_View"},"organization":{"id":3,"name":"Test
+        Organization","label":"Test_Organization"},"services_checked":["pulp3"],"remote_user":"admin","remote_cp_user":"admin","current_request_id":"d5db2a94-c0c3-412c-ab5a-ca0e791e639a","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{},"humanized":{"action":"Delete","input":[["content_view",{"text":"content
+        view ''Test Content View''","link":"/content_views/4/versions"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/3/edit"}]],"output":"","errors":[]},"cli_example":null,"start_at":"2025-07-11
+        15:22:52 UTC","available_actions":{"cancellable":false,"resumable":false}}
 
         '
     headers:
@@ -407,10 +412,6 @@ interactions:
       - no-cache
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -420,23 +421,29 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=94
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
       Transfer-Encoding:
       - chunked
-      X-Content-Type-Options:
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
+      - max-age=631139040; includeSubdomains
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
+      x-xss-protection:
+      - '0'
     status:
       code: 202
       message: Accepted
@@ -452,26 +459,24 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/foreman_tasks/api/tasks/8f3a3c07-2e46-48ff-9faa-75d2a0a70269
+    uri: https://foreman.example.org/foreman_tasks/api/tasks/16a5e456-92f7-4f34-b166-6339bee69df1
   response:
     body:
-      string: '{"id":"8f3a3c07-2e46-48ff-9faa-75d2a0a70269","label":"Actions::Katello::ContentView::Destroy","pending":false,"action":"Delete
-        content view ''Test Content View''; organization ''Test Organization''","username":"admin","started_at":"2020-09-14
-        10:20:10 UTC","ended_at":"2020-09-14 10:20:12 UTC","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":31,"name":"Test
-        Content View","label":"Test_Content_View"},"organization":{"id":14,"name":"Test
-        Organization","label":"Test_Organization"},"services_checked":["pulp3","pulp","pulp_auth"],"remote_user":"admin","remote_cp_user":"admin","current_request_id":null,"current_timezone":"UTC","current_user_id":4,"current_organization_id":null,"current_location_id":null},"output":{},"humanized":{"action":"Delete","input":[["content_view",{"text":"content
-        view ''Test Content View''","link":"/content_views/31/versions"}],["organization",{"text":"organization
-        ''Test Organization''","link":"/organizations/14/edit"}]],"output":"","errors":[]},"cli_example":null,"start_at":"2020-09-14
-        10:20:10 UTC","available_actions":{"cancellable":false,"resumable":false}}'
+      string: '{"id":"16a5e456-92f7-4f34-b166-6339bee69df1","label":"Actions::Katello::ContentView::Destroy","pending":false,"action":"Delete
+        content view ''Test Content View''; organization ''Test Organization''","username":"admin","started_at":"2025-07-11
+        15:22:52 UTC","ended_at":"2025-07-11 15:22:54 UTC","duration":"2.093612","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":4,"name":"Test
+        Content View","label":"Test_Content_View"},"organization":{"id":3,"name":"Test
+        Organization","label":"Test_Organization"},"services_checked":["pulp3"],"remote_user":"admin","remote_cp_user":"admin","current_request_id":"d5db2a94-c0c3-412c-ab5a-ca0e791e639a","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{},"humanized":{"action":"Delete","input":[["content_view",{"text":"content
+        view ''Test Content View''","link":"/content_views/4/versions"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/3/edit"}]],"output":"","errors":[]},"cli_example":null,"start_at":"2025-07-11
+        15:22:52 UTC","available_actions":{"cancellable":false,"resumable":false}}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '1153'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -481,25 +486,27 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=93
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '1120'
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/content_view-19.yml
+++ b/tests/test_playbooks/fixtures/content_view-19.yml
@@ -14,16 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"2.1.2","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.16.0-develop","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '71'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -33,25 +31,27 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=100
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '62'
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
@@ -70,21 +70,18 @@ interactions:
     uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
-        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\"\
-        :\"Test_Organization\",\"created_at\":\"2020-09-14 10:19:21 UTC\",\"updated_at\"\
-        :\"2020-09-14 10:19:21 UTC\",\"id\":14,\"name\":\"Test Organization\",\"title\"\
-        :\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+        4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2025-07-11
+        15:21:41 UTC\",\"updated_at\":\"2025-07-11 15:21:45 UTC\",\"id\":3,\"name\":\"Test
+        Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '388'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -94,25 +91,27 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=99
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '389'
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
@@ -128,10 +127,10 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/14/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/3/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
   response:
     body:
-      string: '{"total":1,"subtotal":0,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+      string: '{"total":1,"subtotal":0,"selectable":0,"page":1,"per_page":4294967296,"error":null,"search":"name=\"Test
         Content View\"","sort":{"by":"name","order":"asc"},"results":[]}
 
         '
@@ -140,10 +139,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '170'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -151,27 +148,29 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 14; Test Organization
+      - 3; Test Organization
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=98
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '157'
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/content_view-2.yml
+++ b/tests/test_playbooks/fixtures/content_view-2.yml
@@ -14,16 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"2.1.2","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.16.0-develop","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '71'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -33,25 +31,27 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=100
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '62'
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
@@ -70,21 +70,18 @@ interactions:
     uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
-        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\"\
-        :\"Test_Organization\",\"created_at\":\"2020-09-14 10:19:21 UTC\",\"updated_at\"\
-        :\"2020-09-14 10:19:21 UTC\",\"id\":14,\"name\":\"Test Organization\",\"title\"\
-        :\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+        4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2025-07-11
+        15:21:41 UTC\",\"updated_at\":\"2025-07-11 15:21:45 UTC\",\"id\":3,\"name\":\"Test
+        Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '388'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -94,25 +91,27 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=99
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '389'
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
@@ -128,15 +127,15 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/14/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/3/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
   response:
     body:
-      string: '{"total":2,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[30],"id":30,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":14,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":14},"created_at":"2020-09-14
-        10:19:35 UTC","updated_at":"2020-09-14 10:19:35 UTC","environments":[],"repositories":[{"id":30,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
+      string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":4294967296,"error":null,"search":"name=\"Test
+        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"rolling":false,"component_ids":[],"duplicate_repositories_to_publish":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"filtered":false,"needs_publish":true,"environment_ids":[],"repository_ids":[1],"id":3,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":3,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":3},"created_at":"2025-07-11
+        15:22:07 UTC","updated_at":"2025-07-11 15:22:07 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":1,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
 
         '
     headers:
@@ -144,10 +143,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '1121'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -155,27 +152,29 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 14; Test Organization
+      - 3; Test Organization
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=98
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '1040'
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
@@ -191,14 +190,14 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/30
+    uri: https://foreman.example.org/katello/api/content_views/3
   response:
     body:
-      string: '  {"content_host_count":0,"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[30],"id":30,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":14,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":14},"created_at":"2020-09-14
-        10:19:35 UTC","updated_at":"2020-09-14 10:19:35 UTC","environments":[],"repositories":[{"id":30,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true},"duplicate_repositories_to_publish":[]}
+      string: '  {"content_host_count":0,"composite":false,"rolling":false,"component_ids":[],"duplicate_repositories_to_publish":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"filtered":false,"needs_publish":true,"environment_ids":[],"repository_ids":[1],"id":3,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":3,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":3},"created_at":"2025-07-11
+        15:22:07 UTC","updated_at":"2025-07-11 15:22:07 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":1,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[],"errors":null}
 
         '
     headers:
@@ -206,10 +205,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '991'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -219,25 +216,27 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=97
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '948'
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
@@ -255,17 +254,17 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: DELETE
-    uri: https://foreman.example.org/katello/api/content_views/30
+    uri: https://foreman.example.org/katello/api/content_views/3
   response:
     body:
-      string: '  {"id":"78ac542c-da51-44e7-bdeb-673a6fad2dc0","label":"Actions::Katello::ContentView::Destroy","pending":true,"action":"Delete
-        content view ''Test Content View''; organization ''Test Organization''","username":"admin","started_at":"2020-09-14
-        10:19:37 UTC","ended_at":null,"state":"planned","result":"pending","progress":0.0,"input":{"content_view":{"id":30,"name":"Test
-        Content View","label":"Test_Content_View"},"organization":{"id":14,"name":"Test
-        Organization","label":"Test_Organization"},"services_checked":["pulp3"],"remote_user":"admin","remote_cp_user":"admin","current_request_id":null,"current_timezone":"UTC","current_user_id":4,"current_organization_id":null,"current_location_id":null},"output":{},"humanized":{"action":"Delete","input":[["content_view",{"text":"content
-        view ''Test Content View''","link":"/content_views/30/versions"}],["organization",{"text":"organization
-        ''Test Organization''","link":"/organizations/14/edit"}]],"output":"","errors":[]},"cli_example":null,"start_at":"2020-09-14
-        10:19:37 UTC","available_actions":{"cancellable":false,"resumable":false}}
+      string: '  {"id":"0544a101-e9ae-4a15-8e99-af6943c379bf","label":"Actions::Katello::ContentView::Destroy","pending":true,"action":"Delete
+        content view ''Test Content View''; organization ''Test Organization''","username":"admin","started_at":"2025-07-11
+        15:22:11 UTC","ended_at":null,"state":"planned","result":"pending","progress":0.0,"input":{"content_view":{"id":3,"name":"Test
+        Content View","label":"Test_Content_View"},"organization":{"id":3,"name":"Test
+        Organization","label":"Test_Organization"},"services_checked":["pulp3"],"remote_user":"admin","remote_cp_user":"admin","current_request_id":"7a8d3171-2c07-4672-8ec7-4e001fcdc233","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{},"humanized":{"action":"Delete","input":[["content_view",{"text":"content
+        view ''Test Content View''","link":"/content_views/3/versions"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/3/edit"}]],"output":"","errors":[]},"cli_example":null,"start_at":"2025-07-11
+        15:22:11 UTC","available_actions":{"cancellable":false,"resumable":false}}
 
         '
     headers:
@@ -273,10 +272,6 @@ interactions:
       - no-cache
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -286,23 +281,29 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=96
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
       Transfer-Encoding:
       - chunked
-      X-Content-Type-Options:
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
+      - max-age=631139040; includeSubdomains
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
+      x-xss-protection:
+      - '0'
     status:
       code: 202
       message: Accepted
@@ -318,26 +319,24 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/foreman_tasks/api/tasks/78ac542c-da51-44e7-bdeb-673a6fad2dc0
+    uri: https://foreman.example.org/foreman_tasks/api/tasks/0544a101-e9ae-4a15-8e99-af6943c379bf
   response:
     body:
-      string: '{"id":"78ac542c-da51-44e7-bdeb-673a6fad2dc0","label":"Actions::Katello::ContentView::Destroy","pending":false,"action":"Delete
-        content view ''Test Content View''; organization ''Test Organization''","username":"admin","started_at":"2020-09-14
-        10:19:37 UTC","ended_at":"2020-09-14 10:19:37 UTC","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":30,"name":"Test
-        Content View","label":"Test_Content_View"},"organization":{"id":14,"name":"Test
-        Organization","label":"Test_Organization"},"services_checked":["pulp3"],"remote_user":"admin","remote_cp_user":"admin","current_request_id":null,"current_timezone":"UTC","current_user_id":4,"current_organization_id":null,"current_location_id":null},"output":{},"humanized":{"action":"Delete","input":[["content_view",{"text":"content
-        view ''Test Content View''","link":"/content_views/30/versions"}],["organization",{"text":"organization
-        ''Test Organization''","link":"/organizations/14/edit"}]],"output":"","errors":[]},"cli_example":null,"start_at":"2020-09-14
-        10:19:37 UTC","available_actions":{"cancellable":false,"resumable":false}}'
+      string: '{"id":"0544a101-e9ae-4a15-8e99-af6943c379bf","label":"Actions::Katello::ContentView::Destroy","pending":false,"action":"Delete
+        content view ''Test Content View''; organization ''Test Organization''","username":"admin","started_at":"2025-07-11
+        15:22:11 UTC","ended_at":"2025-07-11 15:22:11 UTC","duration":"0.385225","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":3,"name":"Test
+        Content View","label":"Test_Content_View"},"organization":{"id":3,"name":"Test
+        Organization","label":"Test_Organization"},"services_checked":["pulp3"],"remote_user":"admin","remote_cp_user":"admin","current_request_id":"7a8d3171-2c07-4672-8ec7-4e001fcdc233","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{},"humanized":{"action":"Delete","input":[["content_view",{"text":"content
+        view ''Test Content View''","link":"/content_views/3/versions"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/3/edit"}]],"output":"","errors":[]},"cli_example":null,"start_at":"2025-07-11
+        15:22:11 UTC","available_actions":{"cancellable":false,"resumable":false}}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '1153'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -347,25 +346,27 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=95
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '1101'
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/content_view-20.yml
+++ b/tests/test_playbooks/fixtures/content_view-20.yml
@@ -72,8 +72,8 @@ interactions:
     body:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2025-06-05
-        07:17:51 UTC\",\"updated_at\":\"2025-06-05 07:17:54 UTC\",\"id\":3,\"name\":\"Test
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2025-07-11
+        15:21:41 UTC\",\"updated_at\":\"2025-07-11 15:21:45 UTC\",\"id\":3,\"name\":\"Test
         Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
@@ -190,7 +190,7 @@ interactions:
   response:
     body:
       string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":4294967296,"error":null,"search":"name=\"Test
-        Product\"","sort":{"by":"name","order":"asc"},"results":[{"id":1,"cp_id":"605901456311","name":"Test
+        Product\"","sort":{"by":"name","order":"asc"},"results":[{"id":1,"cp_id":"624377688211","name":"Test
         Product","label":"Test_Product","description":"A happy little test product","provider_id":3,"sync_plan_id":null,"sync_summary":{},"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"sync_state":null,"last_sync":null,"last_sync_words":null,"organization_id":3,"organization":{"name":"Test
         Organization","label":"Test_Organization","id":3},"sync_plan":null,"repository_count":1}]}
 
@@ -251,11 +251,11 @@ interactions:
   response:
     body:
       string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":4294967296,"error":null,"search":"name=\"Test
-        Repository\"","sort":{"by":"name","order":"asc"},"results":[{"backend_identifier":"bd286c90-c6a6-4e1a-a1c6-05f30b990e9d","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"https://foreman.example.com/pulp/content/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"full_gpg_key_path":null,"version_href":"/pulp/api/v3/repositories/rpm/rpm/01973ef4-2a9e-797e-875d-f04d0f44b7c7/versions/0/","remote_href":null,"publication_href":"/pulp/api/v3/publications/rpm/rpm/01973ef4-2e69-7e69-b1a9-8bb0ee3e2632/","content_counts":{"rpm":0,"erratum":0,"package_group":0,"srpm":0,"module_stream":0},"mirroring_policy":"mirror_content_only","id":1,"name":"Test
+        Repository\"","sort":{"by":"name","order":"asc"},"results":[{"backend_identifier":"f5cc71fb-3e1f-48d2-8db4-68349096758f","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"https://foreman.example.com/pulp/content/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"full_gpg_key_path":null,"version_href":"/pulp/api/v3/repositories/rpm/rpm/0197fa14-1de9-7a8c-ac85-fff97edefbdd/versions/0/","remote_href":null,"publication_href":"/pulp/api/v3/publications/rpm/rpm/0197fa14-239a-7acb-a6b3-ba44220d968c/","content_counts":{"rpm":0,"erratum":0,"package_group":0,"srpm":0,"module_stream":0},"mirroring_policy":"mirror_content_only","id":1,"name":"Test
         Repository","label":"Test_Repository","description":null,"organization_id":3,"organization":{"name":"Test
         Organization","label":"Test_Organization","id":3},"content_view_versions":[],"filters":[],"last_sync":null,"content_view":{"id":2,"name":"Default
         Organization View"},"content_view_version":{"id":2,"name":"Default Organization
-        View 1.0","content_view_id":2},"kt_environment":{"id":2,"name":"Library"},"content_type":"yum","url":null,"docker_upstream_name":null,"arch":"noarch","os_versions":[],"content_id":"1749107878842","generic_remote_options":null,"major":null,"minor":null,"product":{"id":1,"cp_id":"605901456311","name":"Test
+        View 1.0","content_view_id":2},"kt_environment":{"id":2,"name":"Library"},"content_type":"yum","url":null,"docker_upstream_name":null,"arch":"noarch","os_versions":[],"content_id":"1752247312252","generic_remote_options":null,"major":null,"minor":null,"product":{"id":1,"cp_id":"624377688211","name":"Test
         Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","last_sync_words":null}],"org_repository_count":2}
 
         '
@@ -300,8 +300,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"name": "Test Content View", "composite": false, "rolling": true, "repository_ids":
-      [1], "auto_publish": false}'
+    body: null
     headers:
       Accept:
       - application/json;version=2
@@ -309,24 +308,15 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Content-Length:
-      - '112'
-      Content-Type:
-      - application/json
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
-    method: POST
-    uri: https://foreman.example.org/katello/api/organizations/3/content_views
+    method: GET
+    uri: https://foreman.example.org/katello/api/environments?search=name%3D%22QA%22&per_page=4294967296
   response:
     body:
-      string: '  {"content_host_count":0,"composite":false,"rolling":true,"component_ids":[],"duplicate_repositories_to_publish":[],"default":false,"version_count":1,"latest_version":"1.0","latest_version_id":4,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"filtered":false,"needs_publish":false,"repository_ids":[1],"id":6,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":3,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":3},"created_at":"2025-06-05
-        07:18:55 UTC","updated_at":"2025-06-05 07:18:55 UTC","last_task":null,"latest_version_environments":[{"id":2,"name":"Library","label":"Library"}],"repositories":[{"id":1,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"versions":[{"id":4,"version":"1.0","published":"2025-06-05
-        07:18:55 UTC","description":null,"environment_ids":[2],"filters_applied":null,"published_at_words":"less
-        than a minute"}],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"2.0","last_published":"2025-06-05
-        07:18:55 UTC","environments":[{"id":2,"label":"Library","name":"Library","activation_keys":[],"hosts":[],"permissions":{"readable":true}}],"errors":null}
+      string: '{"total":5,"subtotal":1,"selectable":1,"page":1,"per_page":4294967296,"error":null,"search":"name=\"QA\"","sort":{"by":"name","order":"asc"},"results":[{"library":false,"registry_name_pattern":null,"registry_unauthenticated_pull":false,"id":4,"name":"QA","label":"qa","description":null,"organization_id":3,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":3},"created_at":"2025-07-11
+        15:22:01 UTC","updated_at":"2025-07-11 15:22:01 UTC","prior":{"name":"Test","id":3},"successor":{"name":"Prod","id":5},"counts":{"content_hosts":0,"content_views":0},"permissions":{"create_lifecycle_environments":true,"view_lifecycle_environments":true,"edit_lifecycle_environments":true,"destroy_lifecycle_environments":true,"promote_or_remove_content_views_to_environments":true},"content_views":[],"capsules":[{"id":1,"name":"foreman.example.com","lifecycle_environments":[{"id":1},{"id":2},{"id":3},{"id":4},{"id":5}]}]}]}
 
         '
     headers:
@@ -335,7 +325,197 @@ interactions:
       Connection:
       - Keep-Alive
       Content-Length:
-      - '1307'
+      - '938'
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.16.0-develop
+      Keep-Alive:
+      - timeout=15, max=95
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
+      - max-age=631139040; includeSubdomains
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - sameorigin
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/katello/api/environments?search=name%3D%22Test%22&per_page=4294967296
+  response:
+    body:
+      string: '{"total":5,"subtotal":1,"selectable":1,"page":1,"per_page":4294967296,"error":null,"search":"name=\"Test\"","sort":{"by":"name","order":"asc"},"results":[{"library":false,"registry_name_pattern":null,"registry_unauthenticated_pull":false,"id":3,"name":"Test","label":"test","description":null,"organization_id":3,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":3},"created_at":"2025-07-11
+        15:22:00 UTC","updated_at":"2025-07-11 15:22:00 UTC","prior":{"name":"Library","id":2},"successor":{"name":"QA","id":4},"counts":{"content_hosts":0,"content_views":0},"permissions":{"create_lifecycle_environments":true,"view_lifecycle_environments":true,"edit_lifecycle_environments":true,"destroy_lifecycle_environments":true,"promote_or_remove_content_views_to_environments":true},"content_views":[],"capsules":[{"id":1,"name":"foreman.example.com","lifecycle_environments":[{"id":1},{"id":2},{"id":3},{"id":4},{"id":5}]}]}]}
+
+        '
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Length:
+      - '945'
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.16.0-develop
+      Keep-Alive:
+      - timeout=15, max=94
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
+      - max-age=631139040; includeSubdomains
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - sameorigin
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/katello/api/environments?search=name%3D%22Prod%22&per_page=4294967296
+  response:
+    body:
+      string: '{"total":5,"subtotal":1,"selectable":1,"page":1,"per_page":4294967296,"error":null,"search":"name=\"Prod\"","sort":{"by":"name","order":"asc"},"results":[{"library":false,"registry_name_pattern":null,"registry_unauthenticated_pull":false,"id":5,"name":"Prod","label":"prod","description":null,"organization_id":3,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":3},"created_at":"2025-07-11
+        15:22:02 UTC","updated_at":"2025-07-11 15:22:02 UTC","prior":{"name":"QA","id":4},"successor":null,"counts":{"content_hosts":0,"content_views":0},"permissions":{"create_lifecycle_environments":true,"view_lifecycle_environments":true,"edit_lifecycle_environments":true,"destroy_lifecycle_environments":true,"promote_or_remove_content_views_to_environments":true},"content_views":[],"capsules":[{"id":1,"name":"foreman.example.com","lifecycle_environments":[{"id":1},{"id":2},{"id":3},{"id":4},{"id":5}]}]}]}
+
+        '
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Length:
+      - '924'
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.16.0-develop
+      Keep-Alive:
+      - timeout=15, max=93
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
+      - max-age=631139040; includeSubdomains
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - sameorigin
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"name": "Test Content View", "composite": false, "rolling": true, "repository_ids":
+      [1], "environment_ids": [3, 4, 5], "auto_publish": false}'
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '142'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: POST
+    uri: https://foreman.example.org/katello/api/organizations/3/content_views
+  response:
+    body:
+      string: '  {"content_host_count":0,"composite":false,"rolling":true,"component_ids":[],"duplicate_repositories_to_publish":[],"default":false,"version_count":1,"latest_version":"1.0","latest_version_id":4,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"filtered":false,"needs_publish":false,"environment_ids":[3,4,5],"repository_ids":[1],"id":6,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":3,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":3},"created_at":"2025-07-11
+        15:23:00 UTC","updated_at":"2025-07-11 15:23:00 UTC","last_task":null,"latest_version_environments":[{"id":3,"name":"Test","label":"test"},{"id":4,"name":"QA","label":"qa"},{"id":5,"name":"Prod","label":"prod"}],"repositories":[{"id":1,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"versions":[{"id":4,"version":"1.0","published":"2025-07-11
+        15:23:00 UTC","description":null,"environment_ids":[3,4,5],"filters_applied":null,"published_at_words":"less
+        than a minute"}],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"2.0","last_published":"2025-07-11
+        15:23:00 UTC","environments":[{"id":3,"label":"test","name":"Test","activation_keys":[],"hosts":[],"permissions":{"readable":true}},{"id":4,"label":"qa","name":"QA","activation_keys":[],"hosts":[],"permissions":{"readable":true}},{"id":5,"label":"prod","name":"Prod","activation_keys":[],"hosts":[],"permissions":{"readable":true}}],"errors":null}
+
+        '
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Length:
+      - '1597'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -347,7 +527,7 @@ interactions:
       Foreman_version:
       - 3.16.0-develop
       Keep-Alive:
-      - timeout=15, max=95
+      - timeout=15, max=92
       Referrer-Policy:
       - strict-origin-when-cross-origin
       content-security-policy:

--- a/tests/test_playbooks/fixtures/content_view-21.yml
+++ b/tests/test_playbooks/fixtures/content_view-21.yml
@@ -72,8 +72,8 @@ interactions:
     body:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2025-06-05
-        07:17:51 UTC\",\"updated_at\":\"2025-06-05 07:17:54 UTC\",\"id\":3,\"name\":\"Test
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2025-07-11
+        15:21:41 UTC\",\"updated_at\":\"2025-07-11 15:21:45 UTC\",\"id\":3,\"name\":\"Test
         Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
@@ -131,14 +131,14 @@ interactions:
   response:
     body:
       string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":4294967296,"error":null,"search":"name=\"Test
-        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"rolling":true,"component_ids":[],"duplicate_repositories_to_publish":[],"default":false,"version_count":1,"latest_version":"1.0","latest_version_id":4,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"filtered":false,"needs_publish":false,"repository_ids":[1],"id":6,"name":"Test
+        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"rolling":true,"component_ids":[],"duplicate_repositories_to_publish":[],"default":false,"version_count":1,"latest_version":"1.0","latest_version_id":4,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"filtered":false,"needs_publish":false,"environment_ids":[3,4,5],"repository_ids":[1],"id":6,"name":"Test
         Content View","label":"Test_Content_View","description":null,"organization_id":3,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":3},"created_at":"2025-06-05
-        07:18:55 UTC","updated_at":"2025-06-05 07:18:55 UTC","last_task":null,"latest_version_environments":[{"id":2,"name":"Library","label":"Library"}],"repositories":[{"id":1,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"versions":[{"id":4,"version":"1.0","published":"2025-06-05
-        07:18:55 UTC","description":null,"environment_ids":[2],"filters_applied":null,"published_at_words":"less
-        than a minute"}],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"2.0","last_published":"2025-06-05
-        07:18:55 UTC","environments":[{"id":2,"label":"Library","name":"Library","activation_keys":[],"hosts":[],"permissions":{"readable":true}}]}]}
+        Organization","label":"Test_Organization","id":3},"created_at":"2025-07-11
+        15:23:00 UTC","updated_at":"2025-07-11 15:23:00 UTC","last_task":null,"latest_version_environments":[{"id":3,"name":"Test","label":"test"},{"id":4,"name":"QA","label":"qa"},{"id":5,"name":"Prod","label":"prod"}],"repositories":[{"id":1,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"versions":[{"id":4,"version":"1.0","published":"2025-07-11
+        15:23:00 UTC","description":null,"environment_ids":[3,4,5],"filters_applied":null,"published_at_words":"less
+        than a minute"}],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"2.0","last_published":"2025-07-11
+        15:23:00 UTC","environments":[{"id":3,"label":"test","name":"Test","activation_keys":[],"hosts":[],"permissions":{"readable":true}},{"id":4,"label":"qa","name":"QA","activation_keys":[],"hosts":[],"permissions":{"readable":true}},{"id":5,"label":"prod","name":"Prod","activation_keys":[],"hosts":[],"permissions":{"readable":true}}]}]}
 
         '
     headers:
@@ -147,7 +147,7 @@ interactions:
       Connection:
       - Keep-Alive
       Content-Length:
-      - '1437'
+      - '1727'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -196,14 +196,14 @@ interactions:
     uri: https://foreman.example.org/katello/api/content_views/6
   response:
     body:
-      string: '  {"content_host_count":0,"composite":false,"rolling":true,"component_ids":[],"duplicate_repositories_to_publish":[],"default":false,"version_count":1,"latest_version":"1.0","latest_version_id":4,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"filtered":false,"needs_publish":false,"repository_ids":[1],"id":6,"name":"Test
+      string: '  {"content_host_count":0,"composite":false,"rolling":true,"component_ids":[],"duplicate_repositories_to_publish":[],"default":false,"version_count":1,"latest_version":"1.0","latest_version_id":4,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"filtered":false,"needs_publish":false,"environment_ids":[3,4,5],"repository_ids":[1],"id":6,"name":"Test
         Content View","label":"Test_Content_View","description":null,"organization_id":3,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":3},"created_at":"2025-06-05
-        07:18:55 UTC","updated_at":"2025-06-05 07:18:55 UTC","last_task":null,"latest_version_environments":[{"id":2,"name":"Library","label":"Library"}],"repositories":[{"id":1,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"versions":[{"id":4,"version":"1.0","published":"2025-06-05
-        07:18:55 UTC","description":null,"environment_ids":[2],"filters_applied":null,"published_at_words":"less
-        than a minute"}],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"2.0","last_published":"2025-06-05
-        07:18:55 UTC","environments":[{"id":2,"label":"Library","name":"Library","activation_keys":[],"hosts":[],"permissions":{"readable":true}}],"errors":null}
+        Organization","label":"Test_Organization","id":3},"created_at":"2025-07-11
+        15:23:00 UTC","updated_at":"2025-07-11 15:23:00 UTC","last_task":null,"latest_version_environments":[{"id":3,"name":"Test","label":"test"},{"id":4,"name":"QA","label":"qa"},{"id":5,"name":"Prod","label":"prod"}],"repositories":[{"id":1,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"versions":[{"id":4,"version":"1.0","published":"2025-07-11
+        15:23:00 UTC","description":null,"environment_ids":[3,4,5],"filters_applied":null,"published_at_words":"less
+        than a minute"}],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"2.0","last_published":"2025-07-11
+        15:23:00 UTC","environments":[{"id":3,"label":"test","name":"Test","activation_keys":[],"hosts":[],"permissions":{"readable":true}},{"id":4,"label":"qa","name":"QA","activation_keys":[],"hosts":[],"permissions":{"readable":true}},{"id":5,"label":"prod","name":"Prod","activation_keys":[],"hosts":[],"permissions":{"readable":true}}],"errors":null}
 
         '
     headers:
@@ -212,7 +212,7 @@ interactions:
       Connection:
       - Keep-Alive
       Content-Length:
-      - '1307'
+      - '1597'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -262,7 +262,7 @@ interactions:
   response:
     body:
       string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":4294967296,"error":null,"search":"name=\"Test
-        Product\"","sort":{"by":"name","order":"asc"},"results":[{"id":1,"cp_id":"605901456311","name":"Test
+        Product\"","sort":{"by":"name","order":"asc"},"results":[{"id":1,"cp_id":"624377688211","name":"Test
         Product","label":"Test_Product","description":"A happy little test product","provider_id":3,"sync_plan_id":null,"sync_summary":{},"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"sync_state":null,"last_sync":null,"last_sync_words":null,"organization_id":3,"organization":{"name":"Test
         Organization","label":"Test_Organization","id":3},"sync_plan":null,"repository_count":1}]}
 
@@ -323,13 +323,13 @@ interactions:
   response:
     body:
       string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":4294967296,"error":null,"search":"name=\"Test
-        Repository\"","sort":{"by":"name","order":"asc"},"results":[{"backend_identifier":"bd286c90-c6a6-4e1a-a1c6-05f30b990e9d","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"https://foreman.example.com/pulp/content/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"full_gpg_key_path":null,"version_href":"/pulp/api/v3/repositories/rpm/rpm/01973ef4-2a9e-797e-875d-f04d0f44b7c7/versions/0/","remote_href":null,"publication_href":"/pulp/api/v3/publications/rpm/rpm/01973ef4-2e69-7e69-b1a9-8bb0ee3e2632/","content_counts":{"rpm":0,"erratum":0,"package_group":0,"srpm":0,"module_stream":0},"mirroring_policy":"mirror_content_only","id":1,"name":"Test
+        Repository\"","sort":{"by":"name","order":"asc"},"results":[{"backend_identifier":"f5cc71fb-3e1f-48d2-8db4-68349096758f","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"https://foreman.example.com/pulp/content/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"full_gpg_key_path":null,"version_href":"/pulp/api/v3/repositories/rpm/rpm/0197fa14-1de9-7a8c-ac85-fff97edefbdd/versions/0/","remote_href":null,"publication_href":"/pulp/api/v3/publications/rpm/rpm/0197fa14-239a-7acb-a6b3-ba44220d968c/","content_counts":{"rpm":0,"erratum":0,"package_group":0,"srpm":0,"module_stream":0},"mirroring_policy":"mirror_content_only","id":1,"name":"Test
         Repository","label":"Test_Repository","description":null,"organization_id":3,"organization":{"name":"Test
         Organization","label":"Test_Organization","id":3},"content_view_versions":[{"id":4,"version":"1.0","content_view_id":6,"content_view_name":"Test
         Content View"}],"filters":[],"last_sync":null,"content_view":{"id":2,"name":"Default
         Organization View"},"content_view_version":{"id":2,"name":"Default Organization
-        View 1.0","content_view_id":2},"kt_environment":{"id":2,"name":"Library"},"content_type":"yum","url":null,"docker_upstream_name":null,"arch":"noarch","os_versions":[],"content_id":"1749107878842","generic_remote_options":null,"major":null,"minor":null,"product":{"id":1,"cp_id":"605901456311","name":"Test
-        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","last_sync_words":null}],"org_repository_count":3}
+        View 1.0","content_view_id":2},"kt_environment":{"id":2,"name":"Library"},"content_type":"yum","url":null,"docker_upstream_name":null,"arch":"noarch","os_versions":[],"content_id":"1752247312252","generic_remote_options":null,"major":null,"minor":null,"product":{"id":1,"cp_id":"624377688211","name":"Test
+        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","last_sync_words":null}],"org_repository_count":5}
 
         '
     headers:
@@ -351,6 +351,189 @@ interactions:
       - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=95
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
+      - max-age=631139040; includeSubdomains
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - sameorigin
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/katello/api/environments?search=name%3D%22QA%22&per_page=4294967296
+  response:
+    body:
+      string: '{"total":5,"subtotal":1,"selectable":1,"page":1,"per_page":4294967296,"error":null,"search":"name=\"QA\"","sort":{"by":"name","order":"asc"},"results":[{"library":false,"registry_name_pattern":null,"registry_unauthenticated_pull":false,"id":4,"name":"QA","label":"qa","description":null,"organization_id":3,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":3},"created_at":"2025-07-11
+        15:22:01 UTC","updated_at":"2025-07-11 15:22:01 UTC","prior":{"name":"Test","id":3},"successor":{"name":"Prod","id":5},"counts":{"content_hosts":0,"content_views":1},"permissions":{"create_lifecycle_environments":true,"view_lifecycle_environments":true,"edit_lifecycle_environments":true,"destroy_lifecycle_environments":true,"promote_or_remove_content_views_to_environments":true},"content_views":[{"name":"Test
+        Content View","id":6}],"capsules":[{"id":1,"name":"foreman.example.com","lifecycle_environments":[{"id":1},{"id":2},{"id":3},{"id":4},{"id":5}]}]}]}
+
+        '
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Length:
+      - '973'
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.16.0-develop
+      Keep-Alive:
+      - timeout=15, max=94
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
+      - max-age=631139040; includeSubdomains
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - sameorigin
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/katello/api/environments?search=name%3D%22Prod%22&per_page=4294967296
+  response:
+    body:
+      string: '{"total":5,"subtotal":1,"selectable":1,"page":1,"per_page":4294967296,"error":null,"search":"name=\"Prod\"","sort":{"by":"name","order":"asc"},"results":[{"library":false,"registry_name_pattern":null,"registry_unauthenticated_pull":false,"id":5,"name":"Prod","label":"prod","description":null,"organization_id":3,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":3},"created_at":"2025-07-11
+        15:22:02 UTC","updated_at":"2025-07-11 15:22:02 UTC","prior":{"name":"QA","id":4},"successor":null,"counts":{"content_hosts":0,"content_views":1},"permissions":{"create_lifecycle_environments":true,"view_lifecycle_environments":true,"edit_lifecycle_environments":true,"destroy_lifecycle_environments":true,"promote_or_remove_content_views_to_environments":true},"content_views":[{"name":"Test
+        Content View","id":6}],"capsules":[{"id":1,"name":"foreman.example.com","lifecycle_environments":[{"id":1},{"id":2},{"id":3},{"id":4},{"id":5}]}]}]}
+
+        '
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Length:
+      - '959'
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.16.0-develop
+      Keep-Alive:
+      - timeout=15, max=93
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
+      - max-age=631139040; includeSubdomains
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - sameorigin
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/katello/api/environments?search=name%3D%22Test%22&per_page=4294967296
+  response:
+    body:
+      string: '{"total":5,"subtotal":1,"selectable":1,"page":1,"per_page":4294967296,"error":null,"search":"name=\"Test\"","sort":{"by":"name","order":"asc"},"results":[{"library":false,"registry_name_pattern":null,"registry_unauthenticated_pull":false,"id":3,"name":"Test","label":"test","description":null,"organization_id":3,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":3},"created_at":"2025-07-11
+        15:22:00 UTC","updated_at":"2025-07-11 15:22:00 UTC","prior":{"name":"Library","id":2},"successor":{"name":"QA","id":4},"counts":{"content_hosts":0,"content_views":1},"permissions":{"create_lifecycle_environments":true,"view_lifecycle_environments":true,"edit_lifecycle_environments":true,"destroy_lifecycle_environments":true,"promote_or_remove_content_views_to_environments":true},"content_views":[{"name":"Test
+        Content View","id":6}],"capsules":[{"id":1,"name":"foreman.example.com","lifecycle_environments":[{"id":1},{"id":2},{"id":3},{"id":4},{"id":5}]}]}]}
+
+        '
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Length:
+      - '980'
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.16.0-develop
+      Keep-Alive:
+      - timeout=15, max=92
       Referrer-Policy:
       - strict-origin-when-cross-origin
       content-security-policy:

--- a/tests/test_playbooks/fixtures/content_view-22.yml
+++ b/tests/test_playbooks/fixtures/content_view-22.yml
@@ -72,8 +72,8 @@ interactions:
     body:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2025-06-05
-        07:17:51 UTC\",\"updated_at\":\"2025-06-05 07:17:54 UTC\",\"id\":3,\"name\":\"Test
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2025-07-11
+        15:21:41 UTC\",\"updated_at\":\"2025-07-11 15:21:45 UTC\",\"id\":3,\"name\":\"Test
         Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
@@ -131,14 +131,14 @@ interactions:
   response:
     body:
       string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":4294967296,"error":null,"search":"name=\"Test
-        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"rolling":true,"component_ids":[],"duplicate_repositories_to_publish":[],"default":false,"version_count":1,"latest_version":"1.0","latest_version_id":4,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"filtered":false,"needs_publish":false,"repository_ids":[1],"id":6,"name":"Test
+        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"rolling":true,"component_ids":[],"duplicate_repositories_to_publish":[],"default":false,"version_count":1,"latest_version":"1.0","latest_version_id":4,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"filtered":false,"needs_publish":false,"environment_ids":[3,4,5],"repository_ids":[1],"id":6,"name":"Test
         Content View","label":"Test_Content_View","description":null,"organization_id":3,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":3},"created_at":"2025-06-05
-        07:18:55 UTC","updated_at":"2025-06-05 07:18:55 UTC","last_task":null,"latest_version_environments":[{"id":2,"name":"Library","label":"Library"}],"repositories":[{"id":1,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"versions":[{"id":4,"version":"1.0","published":"2025-06-05
-        07:18:55 UTC","description":null,"environment_ids":[2],"filters_applied":null,"published_at_words":"less
-        than a minute"}],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"2.0","last_published":"2025-06-05
-        07:18:55 UTC","environments":[{"id":2,"label":"Library","name":"Library","activation_keys":[],"hosts":[],"permissions":{"readable":true}}]}]}
+        Organization","label":"Test_Organization","id":3},"created_at":"2025-07-11
+        15:23:00 UTC","updated_at":"2025-07-11 15:23:00 UTC","last_task":null,"latest_version_environments":[{"id":3,"name":"Test","label":"test"},{"id":4,"name":"QA","label":"qa"},{"id":5,"name":"Prod","label":"prod"}],"repositories":[{"id":1,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"versions":[{"id":4,"version":"1.0","published":"2025-07-11
+        15:23:00 UTC","description":null,"environment_ids":[3,4,5],"filters_applied":null,"published_at_words":"less
+        than a minute"}],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"2.0","last_published":"2025-07-11
+        15:23:00 UTC","environments":[{"id":3,"label":"test","name":"Test","activation_keys":[],"hosts":[],"permissions":{"readable":true}},{"id":4,"label":"qa","name":"QA","activation_keys":[],"hosts":[],"permissions":{"readable":true}},{"id":5,"label":"prod","name":"Prod","activation_keys":[],"hosts":[],"permissions":{"readable":true}}]}]}
 
         '
     headers:
@@ -147,7 +147,7 @@ interactions:
       Connection:
       - Keep-Alive
       Content-Length:
-      - '1437'
+      - '1727'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -196,14 +196,14 @@ interactions:
     uri: https://foreman.example.org/katello/api/content_views/6
   response:
     body:
-      string: '  {"content_host_count":0,"composite":false,"rolling":true,"component_ids":[],"duplicate_repositories_to_publish":[],"default":false,"version_count":1,"latest_version":"1.0","latest_version_id":4,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"filtered":false,"needs_publish":false,"repository_ids":[1],"id":6,"name":"Test
+      string: '  {"content_host_count":0,"composite":false,"rolling":true,"component_ids":[],"duplicate_repositories_to_publish":[],"default":false,"version_count":1,"latest_version":"1.0","latest_version_id":4,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"filtered":false,"needs_publish":false,"environment_ids":[3,4,5],"repository_ids":[1],"id":6,"name":"Test
         Content View","label":"Test_Content_View","description":null,"organization_id":3,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":3},"created_at":"2025-06-05
-        07:18:55 UTC","updated_at":"2025-06-05 07:18:55 UTC","last_task":null,"latest_version_environments":[{"id":2,"name":"Library","label":"Library"}],"repositories":[{"id":1,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"versions":[{"id":4,"version":"1.0","published":"2025-06-05
-        07:18:55 UTC","description":null,"environment_ids":[2],"filters_applied":null,"published_at_words":"less
-        than a minute"}],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"2.0","last_published":"2025-06-05
-        07:18:55 UTC","environments":[{"id":2,"label":"Library","name":"Library","activation_keys":[],"hosts":[],"permissions":{"readable":true}}],"errors":null}
+        Organization","label":"Test_Organization","id":3},"created_at":"2025-07-11
+        15:23:00 UTC","updated_at":"2025-07-11 15:23:00 UTC","last_task":null,"latest_version_environments":[{"id":3,"name":"Test","label":"test"},{"id":4,"name":"QA","label":"qa"},{"id":5,"name":"Prod","label":"prod"}],"repositories":[{"id":1,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"versions":[{"id":4,"version":"1.0","published":"2025-07-11
+        15:23:00 UTC","description":null,"environment_ids":[3,4,5],"filters_applied":null,"published_at_words":"less
+        than a minute"}],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"2.0","last_published":"2025-07-11
+        15:23:00 UTC","environments":[{"id":3,"label":"test","name":"Test","activation_keys":[],"hosts":[],"permissions":{"readable":true}},{"id":4,"label":"qa","name":"QA","activation_keys":[],"hosts":[],"permissions":{"readable":true}},{"id":5,"label":"prod","name":"Prod","activation_keys":[],"hosts":[],"permissions":{"readable":true}}],"errors":null}
 
         '
     headers:
@@ -212,7 +212,7 @@ interactions:
       Connection:
       - Keep-Alive
       Content-Length:
-      - '1307'
+      - '1597'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -260,18 +260,18 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: DELETE
-    uri: https://foreman.example.org/katello/api/content_views/6/environments/2
+    uri: https://foreman.example.org/katello/api/content_views/6/environments/3
   response:
     body:
-      string: '  {"id":"e883e581-d1bd-42c7-86a0-bb0f85b8bfcb","label":"Actions::Katello::ContentView::RemoveFromEnvironment","pending":true,"action":"Remove
-        from Environment content view ''Test Content View''; organization ''Test Organization''","username":"admin","started_at":"2025-06-05
-        07:19:00 UTC","ended_at":null,"state":"planned","result":"pending","progress":0.0,"input":{"content_view":{"id":6,"name":"Test
+      string: '  {"id":"cd663cc0-a98a-49b1-a06f-7f89a8172788","label":"Actions::Katello::ContentView::RemoveFromEnvironment","pending":true,"action":"Remove
+        from Environment content view ''Test Content View''; organization ''Test Organization''","username":"admin","started_at":"2025-07-11
+        15:23:08 UTC","ended_at":null,"state":"planned","result":"pending","progress":0.0,"input":{"content_view":{"id":6,"name":"Test
         Content View","label":"Test_Content_View"},"organization":{"id":3,"name":"Test
-        Organization","label":"Test_Organization"},"services_checked":["pulp3","candlepin","candlepin_auth"],"history_id":3,"current_request_id":"61e6cdfd-6d7b-45ee-8732-3d98c4c0013d","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{},"humanized":{"action":"Remove
+        Organization","label":"Test_Organization"},"services_checked":["pulp3","candlepin","candlepin_auth"],"history_id":3,"current_request_id":"fd083ec9-effd-40ff-a04b-aaf016aa2999","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{},"humanized":{"action":"Remove
         from Environment","input":[["content_view",{"text":"content view ''Test Content
         View''","link":"/content_views/6/versions"}],["organization",{"text":"organization
-        ''Test Organization''","link":"/organizations/3/edit"}]],"output":"","errors":[]},"cli_example":null,"start_at":"2025-06-05
-        07:19:00 UTC","available_actions":{"cancellable":false,"resumable":false}}
+        ''Test Organization''","link":"/organizations/3/edit"}]],"output":"","errors":[]},"cli_example":null,"start_at":"2025-07-11
+        15:23:08 UTC","available_actions":{"cancellable":false,"resumable":false}}
 
         '
     headers:
@@ -326,25 +326,25 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/foreman_tasks/api/tasks/e883e581-d1bd-42c7-86a0-bb0f85b8bfcb
+    uri: https://foreman.example.org/foreman_tasks/api/tasks/cd663cc0-a98a-49b1-a06f-7f89a8172788
   response:
     body:
-      string: '{"id":"e883e581-d1bd-42c7-86a0-bb0f85b8bfcb","label":"Actions::Katello::ContentView::RemoveFromEnvironment","pending":false,"action":"Remove
-        from Environment content view ''Test Content View''; organization ''Test Organization''","username":"admin","started_at":"2025-06-05
-        07:19:00 UTC","ended_at":"2025-06-05 07:19:01 UTC","duration":"0.923435","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":6,"name":"Test
+      string: '{"id":"cd663cc0-a98a-49b1-a06f-7f89a8172788","label":"Actions::Katello::ContentView::RemoveFromEnvironment","pending":false,"action":"Remove
+        from Environment content view ''Test Content View''; organization ''Test Organization''","username":"admin","started_at":"2025-07-11
+        15:23:08 UTC","ended_at":"2025-07-11 15:23:09 UTC","duration":"1.07755","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":6,"name":"Test
         Content View","label":"Test_Content_View"},"organization":{"id":3,"name":"Test
-        Organization","label":"Test_Organization"},"services_checked":["pulp3","candlepin","candlepin_auth"],"history_id":3,"current_request_id":"61e6cdfd-6d7b-45ee-8732-3d98c4c0013d","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{},"humanized":{"action":"Remove
+        Organization","label":"Test_Organization"},"services_checked":["pulp3","candlepin","candlepin_auth"],"history_id":3,"current_request_id":"fd083ec9-effd-40ff-a04b-aaf016aa2999","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{},"humanized":{"action":"Remove
         from Environment","input":[["content_view",{"text":"content view ''Test Content
         View''","link":"/content_views/6/versions"}],["organization",{"text":"organization
-        ''Test Organization''","link":"/organizations/3/edit"}]],"output":"","errors":[]},"cli_example":null,"start_at":"2025-06-05
-        07:19:00 UTC","available_actions":{"cancellable":false,"resumable":false}}'
+        ''Test Organization''","link":"/organizations/3/edit"}]],"output":"","errors":[]},"cli_example":null,"start_at":"2025-07-11
+        15:23:08 UTC","available_actions":{"cancellable":false,"resumable":false}}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
       Content-Length:
-      - '1198'
+      - '1197'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -392,17 +392,18 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: DELETE
-    uri: https://foreman.example.org/katello/api/content_views/6
+    uri: https://foreman.example.org/katello/api/content_views/6/environments/4
   response:
     body:
-      string: '  {"id":"0787b01d-e1cf-4fec-8f62-75e14ff722b4","label":"Actions::Katello::ContentView::Destroy","pending":true,"action":"Delete
-        content view ''Test Content View''; organization ''Test Organization''","username":"admin","started_at":"2025-06-05
-        07:19:05 UTC","ended_at":null,"state":"planned","result":"pending","progress":0.0,"input":{"content_view":{"id":6,"name":"Test
+      string: '  {"id":"a78d67b4-9508-414d-ab97-4c5821119778","label":"Actions::Katello::ContentView::RemoveFromEnvironment","pending":true,"action":"Remove
+        from Environment content view ''Test Content View''; organization ''Test Organization''","username":"admin","started_at":"2025-07-11
+        15:23:13 UTC","ended_at":null,"state":"planned","result":"pending","progress":0.0,"input":{"content_view":{"id":6,"name":"Test
         Content View","label":"Test_Content_View"},"organization":{"id":3,"name":"Test
-        Organization","label":"Test_Organization"},"services_checked":["pulp3"],"remote_user":"admin","remote_cp_user":"admin","current_request_id":"caa112ba-c1d9-4b7e-84b5-a0c3676735a0","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{},"humanized":{"action":"Delete","input":[["content_view",{"text":"content
-        view ''Test Content View''","link":"/content_views/6/versions"}],["organization",{"text":"organization
-        ''Test Organization''","link":"/organizations/3/edit"}]],"output":"","errors":[]},"cli_example":null,"start_at":"2025-06-05
-        07:19:05 UTC","available_actions":{"cancellable":false,"resumable":false}}
+        Organization","label":"Test_Organization"},"services_checked":["pulp3","candlepin","candlepin_auth"],"history_id":4,"current_request_id":"ce706199-9fe6-433e-ae77-d2a7400e2c9e","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{},"humanized":{"action":"Remove
+        from Environment","input":[["content_view",{"text":"content view ''Test Content
+        View''","link":"/content_views/6/versions"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/3/edit"}]],"output":"","errors":[]},"cli_example":null,"start_at":"2025-07-11
+        15:23:13 UTC","available_actions":{"cancellable":false,"resumable":false}}
 
         '
     headers:
@@ -457,17 +458,280 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/foreman_tasks/api/tasks/0787b01d-e1cf-4fec-8f62-75e14ff722b4
+    uri: https://foreman.example.org/foreman_tasks/api/tasks/a78d67b4-9508-414d-ab97-4c5821119778
   response:
     body:
-      string: '{"id":"0787b01d-e1cf-4fec-8f62-75e14ff722b4","label":"Actions::Katello::ContentView::Destroy","pending":false,"action":"Delete
-        content view ''Test Content View''; organization ''Test Organization''","username":"admin","started_at":"2025-06-05
-        07:19:05 UTC","ended_at":"2025-06-05 07:19:05 UTC","duration":"0.421077","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":6,"name":"Test
+      string: '{"id":"a78d67b4-9508-414d-ab97-4c5821119778","label":"Actions::Katello::ContentView::RemoveFromEnvironment","pending":false,"action":"Remove
+        from Environment content view ''Test Content View''; organization ''Test Organization''","username":"admin","started_at":"2025-07-11
+        15:23:13 UTC","ended_at":"2025-07-11 15:23:14 UTC","duration":"1.040576","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":6,"name":"Test
         Content View","label":"Test_Content_View"},"organization":{"id":3,"name":"Test
-        Organization","label":"Test_Organization"},"services_checked":["pulp3"],"remote_user":"admin","remote_cp_user":"admin","current_request_id":"caa112ba-c1d9-4b7e-84b5-a0c3676735a0","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{},"humanized":{"action":"Delete","input":[["content_view",{"text":"content
+        Organization","label":"Test_Organization"},"services_checked":["pulp3","candlepin","candlepin_auth"],"history_id":4,"current_request_id":"ce706199-9fe6-433e-ae77-d2a7400e2c9e","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{},"humanized":{"action":"Remove
+        from Environment","input":[["content_view",{"text":"content view ''Test Content
+        View''","link":"/content_views/6/versions"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/3/edit"}]],"output":"","errors":[]},"cli_example":null,"start_at":"2025-07-11
+        15:23:13 UTC","available_actions":{"cancellable":false,"resumable":false}}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Length:
+      - '1198'
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.16.0-develop
+      Keep-Alive:
+      - timeout=15, max=93
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
+      - max-age=631139040; includeSubdomains
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - sameorigin
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: DELETE
+    uri: https://foreman.example.org/katello/api/content_views/6/environments/5
+  response:
+    body:
+      string: '  {"id":"9785559f-88d1-41ce-9ee8-1cb051c4c9eb","label":"Actions::Katello::ContentView::RemoveFromEnvironment","pending":true,"action":"Remove
+        from Environment content view ''Test Content View''; organization ''Test Organization''","username":"admin","started_at":"2025-07-11
+        15:23:18 UTC","ended_at":null,"state":"planned","result":"pending","progress":0.0,"input":{"content_view":{"id":6,"name":"Test
+        Content View","label":"Test_Content_View"},"organization":{"id":3,"name":"Test
+        Organization","label":"Test_Organization"},"services_checked":["pulp3","candlepin","candlepin_auth"],"history_id":5,"current_request_id":"c1133ee7-8d6f-4cda-8c2d-e2944428fba9","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{},"humanized":{"action":"Remove
+        from Environment","input":[["content_view",{"text":"content view ''Test Content
+        View''","link":"/content_views/6/versions"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/3/edit"}]],"output":"","errors":[]},"cli_example":null,"start_at":"2025-07-11
+        15:23:17 UTC","available_actions":{"cancellable":false,"resumable":false}}
+
+        '
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - Keep-Alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.16.0-develop
+      Keep-Alive:
+      - timeout=15, max=92
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Transfer-Encoding:
+      - chunked
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
+      - max-age=631139040; includeSubdomains
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - sameorigin
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - '0'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/foreman_tasks/api/tasks/9785559f-88d1-41ce-9ee8-1cb051c4c9eb
+  response:
+    body:
+      string: '{"id":"9785559f-88d1-41ce-9ee8-1cb051c4c9eb","label":"Actions::Katello::ContentView::RemoveFromEnvironment","pending":false,"action":"Remove
+        from Environment content view ''Test Content View''; organization ''Test Organization''","username":"admin","started_at":"2025-07-11
+        15:23:18 UTC","ended_at":"2025-07-11 15:23:18 UTC","duration":"0.831891","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":6,"name":"Test
+        Content View","label":"Test_Content_View"},"organization":{"id":3,"name":"Test
+        Organization","label":"Test_Organization"},"services_checked":["pulp3","candlepin","candlepin_auth"],"history_id":5,"current_request_id":"c1133ee7-8d6f-4cda-8c2d-e2944428fba9","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{},"humanized":{"action":"Remove
+        from Environment","input":[["content_view",{"text":"content view ''Test Content
+        View''","link":"/content_views/6/versions"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/3/edit"}]],"output":"","errors":[]},"cli_example":null,"start_at":"2025-07-11
+        15:23:17 UTC","available_actions":{"cancellable":false,"resumable":false}}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Length:
+      - '1198'
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.16.0-develop
+      Keep-Alive:
+      - timeout=15, max=91
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
+      - max-age=631139040; includeSubdomains
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - sameorigin
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: DELETE
+    uri: https://foreman.example.org/katello/api/content_views/6
+  response:
+    body:
+      string: '  {"id":"678add80-e64e-4789-a873-7437dfce828a","label":"Actions::Katello::ContentView::Destroy","pending":true,"action":"Delete
+        content view ''Test Content View''; organization ''Test Organization''","username":"admin","started_at":"2025-07-11
+        15:23:22 UTC","ended_at":null,"state":"planned","result":"pending","progress":0.0,"input":{"content_view":{"id":6,"name":"Test
+        Content View","label":"Test_Content_View"},"organization":{"id":3,"name":"Test
+        Organization","label":"Test_Organization"},"services_checked":["pulp3"],"remote_user":"admin","remote_cp_user":"admin","current_request_id":"ddf00b30-762a-4b07-95a2-431b930079bd","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{},"humanized":{"action":"Delete","input":[["content_view",{"text":"content
         view ''Test Content View''","link":"/content_views/6/versions"}],["organization",{"text":"organization
-        ''Test Organization''","link":"/organizations/3/edit"}]],"output":"","errors":[]},"cli_example":null,"start_at":"2025-06-05
-        07:19:05 UTC","available_actions":{"cancellable":false,"resumable":false}}'
+        ''Test Organization''","link":"/organizations/3/edit"}]],"output":"","errors":[]},"cli_example":null,"start_at":"2025-07-11
+        15:23:22 UTC","available_actions":{"cancellable":false,"resumable":false}}
+
+        '
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - Keep-Alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.16.0-develop
+      Keep-Alive:
+      - timeout=15, max=90
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Transfer-Encoding:
+      - chunked
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
+      - max-age=631139040; includeSubdomains
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - sameorigin
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - '0'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/foreman_tasks/api/tasks/678add80-e64e-4789-a873-7437dfce828a
+  response:
+    body:
+      string: '{"id":"678add80-e64e-4789-a873-7437dfce828a","label":"Actions::Katello::ContentView::Destroy","pending":false,"action":"Delete
+        content view ''Test Content View''; organization ''Test Organization''","username":"admin","started_at":"2025-07-11
+        15:23:22 UTC","ended_at":"2025-07-11 15:23:22 UTC","duration":"0.375412","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":6,"name":"Test
+        Content View","label":"Test_Content_View"},"organization":{"id":3,"name":"Test
+        Organization","label":"Test_Organization"},"services_checked":["pulp3"],"remote_user":"admin","remote_cp_user":"admin","current_request_id":"ddf00b30-762a-4b07-95a2-431b930079bd","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{},"humanized":{"action":"Delete","input":[["content_view",{"text":"content
+        view ''Test Content View''","link":"/content_views/6/versions"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/3/edit"}]],"output":"","errors":[]},"cli_example":null,"start_at":"2025-07-11
+        15:23:22 UTC","available_actions":{"cancellable":false,"resumable":false}}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
@@ -486,7 +750,7 @@ interactions:
       Foreman_version:
       - 3.16.0-develop
       Keep-Alive:
-      - timeout=15, max=93
+      - timeout=15, max=89
       Referrer-Policy:
       - strict-origin-when-cross-origin
       content-security-policy:

--- a/tests/test_playbooks/fixtures/content_view-23.yml
+++ b/tests/test_playbooks/fixtures/content_view-23.yml
@@ -72,8 +72,8 @@ interactions:
     body:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2025-06-05
-        07:17:51 UTC\",\"updated_at\":\"2025-06-05 07:17:54 UTC\",\"id\":3,\"name\":\"Test
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2025-07-11
+        15:21:41 UTC\",\"updated_at\":\"2025-07-11 15:21:45 UTC\",\"id\":3,\"name\":\"Test
         Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:

--- a/tests/test_playbooks/fixtures/content_view-3.yml
+++ b/tests/test_playbooks/fixtures/content_view-3.yml
@@ -14,16 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"2.1.2","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.16.0-develop","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '71'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -33,25 +31,27 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=100
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '62'
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
@@ -70,21 +70,18 @@ interactions:
     uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
-        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\"\
-        :\"Test_Organization\",\"created_at\":\"2020-09-14 10:19:21 UTC\",\"updated_at\"\
-        :\"2020-09-14 10:19:21 UTC\",\"id\":14,\"name\":\"Test Organization\",\"title\"\
-        :\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+        4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2025-07-11
+        15:21:41 UTC\",\"updated_at\":\"2025-07-11 15:21:45 UTC\",\"id\":3,\"name\":\"Test
+        Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '388'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -94,25 +91,27 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=99
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '389'
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
@@ -128,10 +127,10 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/14/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/3/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
   response:
     body:
-      string: '{"total":1,"subtotal":0,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+      string: '{"total":1,"subtotal":0,"selectable":0,"page":1,"per_page":4294967296,"error":null,"search":"name=\"Test
         Content View\"","sort":{"by":"name","order":"asc"},"results":[]}
 
         '
@@ -140,10 +139,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '170'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -151,27 +148,29 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 14; Test Organization
+      - 3; Test Organization
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=98
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '157'
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/content_view-4.yml
+++ b/tests/test_playbooks/fixtures/content_view-4.yml
@@ -14,16 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"2.1.2","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.16.0-develop","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '71'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -33,25 +31,27 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=100
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '62'
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
@@ -70,21 +70,18 @@ interactions:
     uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
-        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\"\
-        :\"Test_Organization\",\"created_at\":\"2020-09-14 10:19:21 UTC\",\"updated_at\"\
-        :\"2020-09-14 10:19:21 UTC\",\"id\":14,\"name\":\"Test Organization\",\"title\"\
-        :\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+        4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2025-07-11
+        15:21:41 UTC\",\"updated_at\":\"2025-07-11 15:21:45 UTC\",\"id\":3,\"name\":\"Test
+        Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '388'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -94,25 +91,27 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=99
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '389'
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
@@ -128,10 +127,10 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/14/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/3/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
   response:
     body:
-      string: '{"total":1,"subtotal":0,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+      string: '{"total":1,"subtotal":0,"selectable":0,"page":1,"per_page":4294967296,"error":null,"search":"name=\"Test
         Content View\"","sort":{"by":"name","order":"asc"},"results":[]}
 
         '
@@ -140,10 +139,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '170'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -151,27 +148,29 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 14; Test Organization
+      - 3; Test Organization
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=98
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '157'
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
@@ -187,14 +186,13 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/14/products?search=name%3D%22Test+Product%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/3/products?search=name%3D%22Test+Product%22&per_page=4294967296
   response:
     body:
-      string: '{"total":2,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Product\"","sort":{"by":"name","order":"asc"},"results":[{"id":18,"cp_id":"956117903760","name":"Test
-        Product","label":"Test_Product","description":"A happy little test product","provider_id":25,"sync_plan_id":null,"sync_summary":{},"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"sync_state":null,"last_sync":"2020-09-14
-        10:19:27 UTC","last_sync_words":"less than a minute","organization_id":14,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":14},"sync_plan":null,"repository_count":1}]}
+      string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":4294967296,"error":null,"search":"name=\"Test
+        Product\"","sort":{"by":"name","order":"asc"},"results":[{"id":1,"cp_id":"624377688211","name":"Test
+        Product","label":"Test_Product","description":"A happy little test product","provider_id":3,"sync_plan_id":null,"sync_summary":{},"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"sync_state":null,"last_sync":null,"last_sync_words":null,"organization_id":3,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":3},"sync_plan":null,"repository_count":1}]}
 
         '
     headers:
@@ -202,10 +200,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '625'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -213,27 +209,29 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 14; Test Organization
+      - 3; Test Organization
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=97
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '653'
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
@@ -249,15 +247,16 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/products/18/repositories?search=name%3D%22Test+Repository%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/products/1/repositories?search=name%3D%22Test+Repository%22&per_page=4294967296
   response:
     body:
-      string: '{"total":1,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Repository\"","sort":{"by":"name","order":"asc"},"results":[{"backend_identifier":"1819fd9f-8231-43ee-9132-a87a073ba3d7","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"http://centos7-katello-3-16.yatsu.example.com/pulp/repos/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"id":30,"name":"Test
-        Repository","label":"Test_Repository","description":null,"last_sync":null,"content_view":{"id":29,"name":"Default
-        Organization View"},"content_view_version":{"id":18,"name":"Default Organization
-        View 1.0","content_view_id":29},"kt_environment":{"id":13,"name":"Library"},"content_type":"yum","url":null,"arch":"noarch","content_id":"1600078766677","major":null,"minor":null,"product":{"id":18,"cp_id":"956117903760","name":"Test
-        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","content_counts":{"ostree_branch":0,"docker_manifest":0,"docker_manifest_list":0,"docker_tag":0,"rpm":0,"srpm":0,"package":0,"package_group":0,"erratum":0,"puppet_module":0,"file":0,"deb":0,"module_stream":0,"ansible_collection":0},"last_sync_words":null}]}
+      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":4294967296,"error":null,"search":"name=\"Test
+        Repository\"","sort":{"by":"name","order":"asc"},"results":[{"backend_identifier":"f5cc71fb-3e1f-48d2-8db4-68349096758f","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"https://foreman.example.com/pulp/content/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"full_gpg_key_path":null,"version_href":"/pulp/api/v3/repositories/rpm/rpm/0197fa14-1de9-7a8c-ac85-fff97edefbdd/versions/0/","remote_href":null,"publication_href":"/pulp/api/v3/publications/rpm/rpm/0197fa14-239a-7acb-a6b3-ba44220d968c/","content_counts":{"rpm":0,"erratum":0,"package_group":0,"srpm":0,"module_stream":0},"mirroring_policy":"mirror_content_only","id":1,"name":"Test
+        Repository","label":"Test_Repository","description":null,"organization_id":3,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":3},"content_view_versions":[],"filters":[],"last_sync":null,"content_view":{"id":2,"name":"Default
+        Organization View"},"content_view_version":{"id":2,"name":"Default Organization
+        View 1.0","content_view_id":2},"kt_environment":{"id":2,"name":"Library"},"content_type":"yum","url":null,"docker_upstream_name":null,"arch":"noarch","os_versions":[],"content_id":"1752247312252","generic_remote_options":null,"major":null,"minor":null,"product":{"id":1,"cp_id":"624377688211","name":"Test
+        Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","last_sync_words":null}],"org_repository_count":2}
 
         '
     headers:
@@ -265,10 +264,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '1679'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -278,30 +275,32 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=96
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '1319'
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"name": "Test Content View", "composite": false, "repository_ids": [30],
+    body: '{"name": "Test Content View", "composite": false, "repository_ids": [1],
       "auto_publish": false}'
     headers:
       Accept:
@@ -311,20 +310,20 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '96'
+      - '95'
       Content-Type:
       - application/json
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: POST
-    uri: https://foreman.example.org/katello/api/organizations/14/content_views
+    uri: https://foreman.example.org/katello/api/organizations/3/content_views
   response:
     body:
-      string: '  {"content_host_count":0,"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[30],"id":31,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":14,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":14},"created_at":"2020-09-14
-        10:19:43 UTC","updated_at":"2020-09-14 10:19:43 UTC","environments":[],"repositories":[{"id":30,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true},"duplicate_repositories_to_publish":[]}
+      string: '  {"content_host_count":0,"composite":false,"rolling":false,"component_ids":[],"duplicate_repositories_to_publish":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"filtered":false,"needs_publish":true,"environment_ids":[],"repository_ids":[1],"id":4,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":3,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":3},"created_at":"2025-07-11
+        15:22:18 UTC","updated_at":"2025-07-11 15:22:18 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":1,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[],"errors":null}
 
         '
     headers:
@@ -332,10 +331,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '991'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -343,25 +340,29 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 14; Test Organization
+      - 3; Test Organization
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=95
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
+      x-xss-protection:
+      - '0'
     status:
       code: 201
       message: Created

--- a/tests/test_playbooks/fixtures/content_view-5.yml
+++ b/tests/test_playbooks/fixtures/content_view-5.yml
@@ -14,16 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"2.1.2","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.16.0-develop","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '71'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -33,25 +31,27 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=100
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '62'
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
@@ -70,21 +70,18 @@ interactions:
     uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
-        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\"\
-        :\"Test_Organization\",\"created_at\":\"2020-09-14 10:19:21 UTC\",\"updated_at\"\
-        :\"2020-09-14 10:19:21 UTC\",\"id\":14,\"name\":\"Test Organization\",\"title\"\
-        :\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+        4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2025-07-11
+        15:21:41 UTC\",\"updated_at\":\"2025-07-11 15:21:45 UTC\",\"id\":3,\"name\":\"Test
+        Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '388'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -94,25 +91,27 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=99
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '389'
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
@@ -128,15 +127,15 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/14/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/3/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
   response:
     body:
-      string: '{"total":2,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[30],"id":31,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":14,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":14},"created_at":"2020-09-14
-        10:19:43 UTC","updated_at":"2020-09-14 10:19:43 UTC","environments":[],"repositories":[{"id":30,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
+      string: '{"total":2,"subtotal":1,"selectable":1,"page":1,"per_page":4294967296,"error":null,"search":"name=\"Test
+        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"rolling":false,"component_ids":[],"duplicate_repositories_to_publish":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"filtered":false,"needs_publish":true,"environment_ids":[],"repository_ids":[1],"id":4,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":3,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":3},"created_at":"2025-07-11
+        15:22:18 UTC","updated_at":"2025-07-11 15:22:18 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":1,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
 
         '
     headers:
@@ -144,10 +143,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '1121'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -155,27 +152,29 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 14; Test Organization
+      - 3; Test Organization
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=98
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '1040'
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
@@ -191,10 +190,10 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_view_versions?search=content_view_id%3D31%2Cversion%3D1.0&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_view_versions?search=content_view_id%3D4%2Cversion%3D1.0&per_page=4294967296
   response:
     body:
-      string: '{"total":3,"subtotal":0,"page":1,"per_page":"4294967296","error":null,"search":"content_view_id=31,version=1.0","sort":{"by":"version","order":"desc"},"results":[]}
+      string: '{"total":2,"subtotal":0,"selectable":0,"page":1,"per_page":4294967296,"error":null,"search":"content_view_id=4,version=1.0","sort":{"by":"version","order":"desc"},"results":[]}
 
         '
     headers:
@@ -202,10 +201,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '177'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -215,25 +212,27 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=97
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '165'
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
@@ -249,12 +248,12 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/14/environments?search=name%3D%22Library%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/3/environments?search=name%3D%22Library%22&per_page=4294967296
   response:
     body:
-      string: '{"total":1,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Library\"","sort":{"by":"name","order":"asc"},"results":[{"library":true,"registry_name_pattern":null,"registry_unauthenticated_pull":false,"id":13,"name":"Library","label":"Library","description":null,"organization_id":14,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":14},"created_at":"2020-09-14
-        10:19:22 UTC","updated_at":"2020-09-14 10:19:22 UTC","prior":null,"successor":null,"counts":{"content_hosts":0,"content_views":0,"packages":0,"puppet_modules":0,"module_streams":0,"errata":{"security":null,"bugfix":0,"enhancement":0,"total":null},"yum_repositories":2,"docker_repositories":0,"ostree_repositories":0,"products":2},"permissions":{"create_lifecycle_environments":true,"view_lifecycle_environments":true,"edit_lifecycle_environments":true,"destroy_lifecycle_environments":false,"promote_or_remove_content_views_to_environments":true}}]}
+      string: '{"total":4,"subtotal":1,"selectable":1,"page":1,"per_page":4294967296,"error":null,"search":"name=\"Library\"","sort":{"by":"name","order":"asc"},"results":[{"library":true,"registry_name_pattern":null,"registry_unauthenticated_pull":false,"id":2,"name":"Library","label":"Library","description":null,"organization_id":3,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":3},"created_at":"2025-07-11
+        15:21:43 UTC","updated_at":"2025-07-11 15:21:43 UTC","prior":null,"successor":null,"counts":{"content_hosts":0,"content_views":0,"packages":0,"module_streams":0,"errata":{"security":0,"bugfix":0,"enhancement":0,"total":0},"yum_repositories":2,"docker_repositories":0,"ostree_repositories":0,"products":2,"debs":0,"deb_repositories":0},"permissions":{"create_lifecycle_environments":true,"view_lifecycle_environments":true,"edit_lifecycle_environments":true,"destroy_lifecycle_environments":false,"promote_or_remove_content_views_to_environments":true},"content_views":[],"capsules":[{"id":1,"name":"foreman.example.com","lifecycle_environments":[{"id":1},{"id":2},{"id":3},{"id":4},{"id":5}]}]}]}
 
         '
     headers:
@@ -262,10 +261,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '1122'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -273,27 +270,29 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 14; Test Organization
+      - 3; Test Organization
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=96
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '965'
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
@@ -313,18 +312,18 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: POST
-    uri: https://foreman.example.org/katello/api/content_views/31/publish
+    uri: https://foreman.example.org/katello/api/content_views/4/publish
   response:
     body:
-      string: '  {"id":"dce95aeb-7d0d-49d1-829f-8c263c4bbc47","label":"Actions::Katello::ContentView::Publish","pending":true,"action":"Publish
-        content view ''Test Content View''; organization ''Test Organization''","username":"admin","started_at":"2020-09-14
-        10:19:44 UTC","ended_at":null,"state":"planned","result":"pending","progress":0.0,"input":{"content_view":{"id":31,"name":"Test
-        Content View","label":"Test_Content_View"},"organization":{"id":14,"name":"Test
-        Organization","label":"Test_Organization"},"services_checked":["candlepin","candlepin_auth","pulp3","pulp","pulp_auth"],"history_id":24,"content_view_id":31,"auto_publish_composite_ids":[],"content_view_version_name":"Test
-        Content View 1.0","content_view_version_id":19,"environment_id":13,"user_id":4,"skip_promotion":null,"current_request_id":null,"current_timezone":"UTC","current_user_id":4,"current_organization_id":null,"current_location_id":null},"output":{},"humanized":{"action":"Publish","input":[["content_view",{"text":"content
-        view ''Test Content View''","link":"/content_views/31/versions"}],["organization",{"text":"organization
-        ''Test Organization''","link":"/organizations/14/edit"}]],"output":"","errors":[]},"cli_example":null,"start_at":"2020-09-14
-        10:19:44 UTC","available_actions":{"cancellable":false,"resumable":false}}
+      string: '  {"id":"6f661932-5bdd-4f8f-a521-f5875e5339f4","label":"Actions::Katello::ContentView::Publish","pending":true,"action":"Publish
+        content view ''Test Content View''; organization ''Test Organization''","username":"admin","started_at":"2025-07-11
+        15:22:19 UTC","ended_at":null,"state":"planned","result":"pending","progress":0.0,"input":{"content_view":{"id":4,"name":"Test
+        Content View","label":"Test_Content_View"},"organization":{"id":3,"name":"Test
+        Organization","label":"Test_Organization"},"services_checked":["pulp3","candlepin","candlepin_auth"],"history_id":1,"content_view_id":4,"auto_publish_composite_ids":[],"content_view_version_name":"Test
+        Content View 1.0","content_view_version_id":3,"environment_id":2,"user_id":4,"skip_promotion":null,"current_request_id":"5d8b36e2-b73a-497e-a358-9fc98cabdad2","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{},"humanized":{"action":"Publish","input":[["content_view",{"text":"content
+        view ''Test Content View''","link":"/content_views/4/versions"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/3/edit"}]],"output":"","errors":[]},"cli_example":null,"start_at":"2025-07-11
+        15:22:19 UTC","available_actions":{"cancellable":false,"resumable":false}}
 
         '
     headers:
@@ -332,10 +331,6 @@ interactions:
       - no-cache
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -345,23 +340,29 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=95
-      Strict-Transport-Security:
-      - max-age=631139040; includeSubdomains
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
       Transfer-Encoding:
       - chunked
-      X-Content-Type-Options:
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
+      - max-age=631139040; includeSubdomains
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
+      x-xss-protection:
+      - '0'
     status:
       code: 202
       message: Accepted
@@ -377,27 +378,25 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/foreman_tasks/api/tasks/dce95aeb-7d0d-49d1-829f-8c263c4bbc47
+    uri: https://foreman.example.org/foreman_tasks/api/tasks/6f661932-5bdd-4f8f-a521-f5875e5339f4
   response:
     body:
-      string: '{"id":"dce95aeb-7d0d-49d1-829f-8c263c4bbc47","label":"Actions::Katello::ContentView::Publish","pending":false,"action":"Publish
-        content view ''Test Content View''; organization ''Test Organization''","username":"admin","started_at":"2020-09-14
-        10:19:44 UTC","ended_at":"2020-09-14 10:19:47 UTC","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":31,"name":"Test
-        Content View","label":"Test_Content_View"},"organization":{"id":14,"name":"Test
-        Organization","label":"Test_Organization"},"services_checked":["candlepin","candlepin_auth","pulp3","pulp","pulp_auth"],"history_id":24,"content_view_id":31,"auto_publish_composite_ids":[],"content_view_version_name":"Test
-        Content View 1.0","content_view_version_id":19,"environment_id":13,"user_id":4,"skip_promotion":null,"current_request_id":null,"current_timezone":"UTC","current_user_id":4,"current_organization_id":null,"current_location_id":null},"output":{"content_view_id":31,"content_view_version_id":19,"skip_promotion":null},"humanized":{"action":"Publish","input":[["content_view",{"text":"content
-        view ''Test Content View''","link":"/content_views/31/versions"}],["organization",{"text":"organization
-        ''Test Organization''","link":"/organizations/14/edit"}]],"output":"","errors":[]},"cli_example":null,"start_at":"2020-09-14
-        10:19:44 UTC","available_actions":{"cancellable":false,"resumable":false}}'
+      string: '{"id":"6f661932-5bdd-4f8f-a521-f5875e5339f4","label":"Actions::Katello::ContentView::Publish","pending":false,"action":"Publish
+        content view ''Test Content View''; organization ''Test Organization''","username":"admin","started_at":"2025-07-11
+        15:22:19 UTC","ended_at":"2025-07-11 15:22:23 UTC","duration":"3.865006","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":4,"name":"Test
+        Content View","label":"Test_Content_View"},"organization":{"id":3,"name":"Test
+        Organization","label":"Test_Organization"},"services_checked":["pulp3","candlepin","candlepin_auth"],"history_id":1,"content_view_id":4,"auto_publish_composite_ids":[],"content_view_version_name":"Test
+        Content View 1.0","content_view_version_id":3,"environment_id":2,"user_id":4,"skip_promotion":null,"current_request_id":"5d8b36e2-b73a-497e-a358-9fc98cabdad2","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{"content_view_id":4,"content_view_version_id":3,"skip_promotion":null,"history_id":1},"humanized":{"action":"Publish","input":[["content_view",{"text":"content
+        view ''Test Content View''","link":"/content_views/4/versions"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/3/edit"}]],"output":"","errors":[]},"cli_example":null,"start_at":"2025-07-11
+        15:22:19 UTC","available_actions":{"cancellable":false,"resumable":false}}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '1421'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -407,25 +406,27 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=94
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '1379'
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
@@ -441,22 +442,23 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_view_versions/19
+    uri: https://foreman.example.org/katello/api/content_view_versions/3
   response:
     body:
-      string: '  {"version":"1.0","major":1,"minor":0,"composite_content_view_ids":[],"published_in_composite_content_view_ids":[],"content_view_id":31,"default":false,"description":null,"id":19,"name":"Test
-        Content View 1.0","created_at":"2020-09-14 10:19:44 UTC","updated_at":"2020-09-14
-        10:19:47 UTC","content_view":{"id":31,"name":"Test Content View","label":"Test_Content_View"},"composite_content_views":[],"composite_content_view_versions":[],"published_in_composite_content_views":[],"environments":[{"id":13,"name":"Library","label":"Library","puppet_environment_id":null,"permissions":{"readable":true,"promotable_or_removable":true,"all_hosts_editable":true,"all_keys_editable":true},"host_count":0,"activation_key_count":0}],"repositories":[{"id":32,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum","library_instance_id":30}],"last_event":{"user":"admin","status":"successful","description":null,"action":"publish","created_at":"2020-09-14
-        10:19:44 UTC","updated_at":"2020-09-14 10:19:47 UTC","environment":null,"task":{"id":"dce95aeb-7d0d-49d1-829f-8c263c4bbc47","label":"Actions::Katello::ContentView::Publish","pending":false,"action":"Publish
-        content view ''Test Content View''; organization ''Test Organization''","username":"admin","started_at":"2020-09-14
-        10:19:44 UTC","ended_at":"2020-09-14 10:19:47 UTC","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":31,"name":"Test
-        Content View","label":"Test_Content_View"},"organization":{"id":14,"name":"Test
-        Organization","label":"Test_Organization"},"services_checked":["candlepin","candlepin_auth","pulp3","pulp","pulp_auth"],"history_id":24,"content_view_id":31,"auto_publish_composite_ids":[],"content_view_version_name":"Test
-        Content View 1.0","content_view_version_id":19,"environment_id":13,"user_id":4,"skip_promotion":null,"current_request_id":null,"current_timezone":"UTC","current_user_id":4,"current_organization_id":null,"current_location_id":null},"output":{"content_view_id":31,"content_view_version_id":19,"skip_promotion":null},"humanized":{"action":"Publish","input":[["content_view",{"text":"content
-        view ''Test Content View''","link":"/content_views/31/versions"}],["organization",{"text":"organization
-        ''Test Organization''","link":"/organizations/14/edit"}]],"output":"","errors":[]},"cli_example":null,"start_at":"2020-09-14
-        10:19:44 UTC","available_actions":{"cancellable":false,"resumable":false}},"version":"1.0","publish":true,"version_id":19,"triggered_by":null,"triggered_by_id":null},"active_history":[],"deb_count":0,"docker_manifest_count":0,"docker_manifest_list_count":0,"docker_tag_count":0,"file_count":0,"puppet_module_count":0,"rpm_count":0,"modulemd_count":0,"erratum_count":0,"package_group_count":0,"srpm_count":0,"module_stream_count":0,"package_count":0,"ostree_branch_count":null,"errata_counts":{"security":null,"bugfix":0,"enhancement":0,"total":null},"permissions":{"deletable":true},"puppet_modules":[]}
+      string: '  {"version":"1.0","major":1,"minor":0,"composite_content_view_ids":[],"published_in_composite_content_view_ids":[],"content_view_id":4,"default":false,"description":null,"id":3,"name":"Test
+        Content View 1.0","created_at":"2025-07-11 15:22:20 UTC","updated_at":"2025-07-11
+        15:22:23 UTC","content_view":{"id":4,"name":"Test Content View","label":"Test_Content_View","generated_for":"none"},"composite_content_views":[],"composite_content_view_versions":[],"published_in_composite_content_views":[],"content_view_environments":[{"label":"Library/Test_Content_View","environment_id":2,"environment_name":"Library"}],"environments":[{"id":2,"name":"Library","label":"Library","publish_date":"less
+        than a minute","permissions":{"readable":true,"promotable_or_removable":true,"all_hosts_editable":true,"all_keys_editable":true},"host_count":0,"multi_env_host_count":0,"activation_key_count":0,"multi_env_ak_count":0}],"repositories":[{"id":3,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum","library_instance_id":1,"mirroring_policy":"mirror_content_only"}],"last_event":{"user":"admin","status":"successful","description":null,"action":"publish","created_at":"2025-07-11
+        15:22:20 UTC","updated_at":"2025-07-11 15:22:23 UTC","environment":null,"task":{"id":"6f661932-5bdd-4f8f-a521-f5875e5339f4","label":"Actions::Katello::ContentView::Publish","pending":false,"action":"Publish
+        content view ''Test Content View''; organization ''Test Organization''","username":"admin","started_at":"2025-07-11
+        15:22:19 UTC","ended_at":"2025-07-11 15:22:23 UTC","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":4,"name":"Test
+        Content View","label":"Test_Content_View"},"organization":{"id":3,"name":"Test
+        Organization","label":"Test_Organization"},"services_checked":["pulp3","candlepin","candlepin_auth"],"history_id":1,"content_view_id":4,"auto_publish_composite_ids":[],"content_view_version_name":"Test
+        Content View 1.0","content_view_version_id":3,"environment_id":2,"user_id":4,"skip_promotion":null,"current_request_id":"5d8b36e2-b73a-497e-a358-9fc98cabdad2","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{"content_view_id":4,"content_view_version_id":3,"skip_promotion":null,"history_id":1},"humanized":{"action":"Publish","input":[["content_view",{"text":"content
+        view ''Test Content View''","link":"/content_views/4/versions"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/3/edit"}]],"output":"","errors":[]},"cli_example":null,"start_at":"2025-07-11
+        15:22:19 UTC","available_actions":{"cancellable":false,"resumable":false}},"version":"1.0","publish":true,"version_id":3,"triggered_by":null,"triggered_by_id":null},"active_history":[],"rpm_count":0,"modulemd_count":0,"erratum_count":0,"package_group_count":0,"srpm_count":0,"ansible_collection_count":0,"deb_count":0,"docker_manifest_count":0,"docker_manifest_list_count":0,"docker_tag_count":0,"file_count":0,"python_package_count":0,"module_stream_count":0,"package_count":0,"component_view_count":0,"ansible_collection_repository_count":0,"deb_repository_count":0,"docker_repository_count":0,"file_repository_count":0,"python_repository_count":0,"yum_repository_count":1,"errata_counts":{"security":0,"bugfix":0,"enhancement":0,"total":0},"permissions":{"deletable":true},"filters_applied":false}
 
         '
     headers:
@@ -464,10 +466,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '3394'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -477,25 +477,27 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=93
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '2948'
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/content_view-6.yml
+++ b/tests/test_playbooks/fixtures/content_view-6.yml
@@ -14,16 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"2.1.2","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.16.0-develop","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '71'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -33,25 +31,27 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=100
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '62'
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
@@ -70,21 +70,18 @@ interactions:
     uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
-        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\"\
-        :\"Test_Organization\",\"created_at\":\"2020-09-14 10:19:21 UTC\",\"updated_at\"\
-        :\"2020-09-14 10:19:21 UTC\",\"id\":14,\"name\":\"Test Organization\",\"title\"\
-        :\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+        4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2025-07-11
+        15:21:41 UTC\",\"updated_at\":\"2025-07-11 15:21:45 UTC\",\"id\":3,\"name\":\"Test
+        Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '388'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -94,25 +91,27 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=99
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '389'
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
@@ -128,10 +127,10 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/14/content_views?search=name%3D%22Test+Composite+Content+View%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/3/content_views?search=name%3D%22Test+Composite+Content+View%22&per_page=4294967296
   response:
     body:
-      string: '{"total":2,"subtotal":0,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+      string: '{"total":2,"subtotal":0,"selectable":0,"page":1,"per_page":4294967296,"error":null,"search":"name=\"Test
         Composite Content View\"","sort":{"by":"name","order":"asc"},"results":[]}
 
         '
@@ -140,10 +139,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '180'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -151,27 +148,29 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 14; Test Organization
+      - 3; Test Organization
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=98
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '167'
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
@@ -192,13 +191,13 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: POST
-    uri: https://foreman.example.org/katello/api/organizations/14/content_views
+    uri: https://foreman.example.org/katello/api/organizations/3/content_views
   response:
     body:
-      string: '  {"content_host_count":0,"composite":true,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[],"id":32,"name":"Test
-        Composite Content View","label":"Test_Composite_Content_View","description":null,"organization_id":14,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":14},"created_at":"2020-09-14
-        10:19:50 UTC","updated_at":"2020-09-14 10:19:50 UTC","environments":[],"repositories":[],"puppet_modules":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true},"duplicate_repositories_to_publish":[]}
+      string: '  {"content_host_count":0,"composite":true,"rolling":false,"component_ids":[],"duplicate_repositories_to_publish":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"filtered":false,"needs_publish":true,"environment_ids":[],"repository_ids":[],"id":5,"name":"Test
+        Composite Content View","label":"Test_Composite_Content_View","description":null,"organization_id":3,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":3},"created_at":"2025-07-11
+        15:22:26 UTC","updated_at":"2025-07-11 15:22:26 UTC","last_task":null,"latest_version_environments":[],"repositories":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[],"errors":null}
 
         '
     headers:
@@ -206,10 +205,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '929'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -217,25 +214,29 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 14; Test Organization
+      - 3; Test Organization
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=97
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Transfer-Encoding:
-      - chunked
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
+      x-xss-protection:
+      - '0'
     status:
       code: 201
       message: Created
@@ -251,17 +252,19 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/14/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/3/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
   response:
     body:
-      string: '{"total":3,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":1,"latest_version":"1.0","auto_publish":false,"solve_dependencies":false,"repository_ids":[30],"id":31,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":14,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":14},"created_at":"2020-09-14
-        10:19:43 UTC","updated_at":"2020-09-14 10:19:44 UTC","environments":[{"id":13,"name":"Library","label":"Library","permissions":{"readable":true}}],"repositories":[{"id":30,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[{"id":19,"version":"1.0","published":"2020-09-14
-        10:19:44 UTC","environment_ids":[13]}],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"2.0","last_published":"2020-09-14
-        10:19:44 UTC","permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
+      string: '{"total":3,"subtotal":1,"selectable":1,"page":1,"per_page":4294967296,"error":null,"search":"name=\"Test
+        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"rolling":false,"component_ids":[],"duplicate_repositories_to_publish":[],"default":false,"version_count":1,"latest_version":"1.0","latest_version_id":3,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"filtered":false,"needs_publish":false,"environment_ids":[2],"repository_ids":[1],"id":4,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":3,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":3},"created_at":"2025-07-11
+        15:22:18 UTC","updated_at":"2025-07-11 15:22:20 UTC","last_task":{"id":"6f661932-5bdd-4f8f-a521-f5875e5339f4","started_at":"2025-07-11
+        15:22:19 UTC","result":"success","last_sync_words":"less than a minute"},"latest_version_environments":[{"id":2,"name":"Library","label":"Library"}],"repositories":[{"id":1,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"versions":[{"id":3,"version":"1.0","published":"2025-07-11
+        15:22:20 UTC","description":null,"environment_ids":[2],"filters_applied":false,"published_at_words":"less
+        than a minute"}],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"2.0","last_published":"2025-07-11
+        15:22:20 UTC","environments":[{"id":2,"label":"Library","name":"Library","activation_keys":[],"hosts":[],"permissions":{"readable":true}}]}]}
 
         '
     headers:
@@ -269,10 +272,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '1599'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -280,27 +281,29 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 14; Test Organization
+      - 3; Test Organization
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=96
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '1224'
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
@@ -316,16 +319,18 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/31
+    uri: https://foreman.example.org/katello/api/content_views/4
   response:
     body:
-      string: '  {"content_host_count":0,"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":1,"latest_version":"1.0","auto_publish":false,"solve_dependencies":false,"repository_ids":[30],"id":31,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":14,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":14},"created_at":"2020-09-14
-        10:19:43 UTC","updated_at":"2020-09-14 10:19:44 UTC","environments":[{"id":13,"name":"Library","label":"Library","permissions":{"readable":true}}],"repositories":[{"id":30,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[{"id":19,"version":"1.0","published":"2020-09-14
-        10:19:44 UTC","environment_ids":[13]}],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"2.0","last_published":"2020-09-14
-        10:19:44 UTC","permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true},"duplicate_repositories_to_publish":[]}
+      string: '  {"content_host_count":0,"composite":false,"rolling":false,"component_ids":[],"duplicate_repositories_to_publish":[],"default":false,"version_count":1,"latest_version":"1.0","latest_version_id":3,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"filtered":false,"needs_publish":false,"environment_ids":[2],"repository_ids":[1],"id":4,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":3,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":3},"created_at":"2025-07-11
+        15:22:18 UTC","updated_at":"2025-07-11 15:22:20 UTC","last_task":{"id":"6f661932-5bdd-4f8f-a521-f5875e5339f4","started_at":"2025-07-11
+        15:22:19 UTC","result":"success","last_sync_words":"less than a minute"},"latest_version_environments":[{"id":2,"name":"Library","label":"Library"}],"repositories":[{"id":1,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"versions":[{"id":3,"version":"1.0","published":"2025-07-11
+        15:22:20 UTC","description":null,"environment_ids":[2],"filters_applied":false,"published_at_words":"less
+        than a minute"}],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"2.0","last_published":"2025-07-11
+        15:22:20 UTC","environments":[{"id":2,"label":"Library","name":"Library","activation_keys":[],"hosts":[],"permissions":{"readable":true}}],"errors":null}
 
         '
     headers:
@@ -333,10 +338,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '1469'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -346,25 +349,27 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=95
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '1132'
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
@@ -380,22 +385,23 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_view_versions?search=content_view_id%3D31%2Cversion%3D1.0&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_view_versions?search=content_view_id%3D4%2Cversion%3D1.0&per_page=4294967296
   response:
     body:
-      string: '{"total":4,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"content_view_id=31,version=1.0","sort":{"by":"version","order":"desc"},"results":[{"version":"1.0","major":1,"minor":0,"composite_content_view_ids":[],"published_in_composite_content_view_ids":[],"content_view_id":31,"default":false,"description":null,"id":19,"name":"Test
-        Content View 1.0","created_at":"2020-09-14 10:19:44 UTC","updated_at":"2020-09-14
-        10:19:47 UTC","content_view":{"id":31,"name":"Test Content View","label":"Test_Content_View"},"composite_content_views":[],"composite_content_view_versions":[],"published_in_composite_content_views":[],"environments":[{"id":13,"name":"Library","label":"Library","puppet_environment_id":null,"permissions":{"readable":true,"promotable_or_removable":true,"all_hosts_editable":true,"all_keys_editable":true},"host_count":0,"activation_key_count":0}],"repositories":[{"id":32,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum","library_instance_id":30}],"last_event":{"user":"admin","status":"successful","description":null,"action":"publish","created_at":"2020-09-14
-        10:19:44 UTC","updated_at":"2020-09-14 10:19:47 UTC","environment":null,"task":{"id":"dce95aeb-7d0d-49d1-829f-8c263c4bbc47","label":"Actions::Katello::ContentView::Publish","pending":false,"action":"Publish
-        content view ''Test Content View''; organization ''Test Organization''","username":"admin","started_at":"2020-09-14
-        10:19:44 UTC","ended_at":"2020-09-14 10:19:47 UTC","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":31,"name":"Test
-        Content View","label":"Test_Content_View"},"organization":{"id":14,"name":"Test
-        Organization","label":"Test_Organization"},"services_checked":["candlepin","candlepin_auth","pulp3","pulp","pulp_auth"],"history_id":24,"content_view_id":31,"auto_publish_composite_ids":[],"content_view_version_name":"Test
-        Content View 1.0","content_view_version_id":19,"environment_id":13,"user_id":4,"skip_promotion":null,"current_request_id":null,"current_timezone":"UTC","current_user_id":4,"current_organization_id":null,"current_location_id":null},"output":{"content_view_id":31,"content_view_version_id":19,"skip_promotion":null},"humanized":{"action":"Publish","input":[["content_view",{"text":"content
-        view ''Test Content View''","link":"/content_views/31/versions"}],["organization",{"text":"organization
-        ''Test Organization''","link":"/organizations/14/edit"}]],"output":"","errors":[]},"cli_example":null,"start_at":"2020-09-14
-        10:19:44 UTC","available_actions":{"cancellable":false,"resumable":false}},"version":"1.0","publish":true,"version_id":19,"triggered_by":null,"triggered_by_id":null},"active_history":[],"deb_count":0,"docker_manifest_count":0,"docker_manifest_list_count":0,"docker_tag_count":0,"file_count":0,"puppet_module_count":0,"rpm_count":0,"modulemd_count":0,"erratum_count":0,"package_group_count":0,"srpm_count":0,"module_stream_count":0,"package_count":0,"ostree_branch_count":null,"errata_counts":{"security":null,"bugfix":0,"enhancement":0,"total":null},"permissions":{"deletable":true}}]}
+      string: '{"total":3,"subtotal":1,"selectable":1,"page":1,"per_page":4294967296,"error":null,"search":"content_view_id=4,version=1.0","sort":{"by":"version","order":"desc"},"results":[{"version":"1.0","major":1,"minor":0,"composite_content_view_ids":[],"published_in_composite_content_view_ids":[],"content_view_id":4,"default":false,"description":null,"id":3,"name":"Test
+        Content View 1.0","created_at":"2025-07-11 15:22:20 UTC","updated_at":"2025-07-11
+        15:22:23 UTC","content_view":{"id":4,"name":"Test Content View","label":"Test_Content_View","generated_for":"none"},"composite_content_views":[],"composite_content_view_versions":[],"published_in_composite_content_views":[],"content_view_environments":[{"label":"Library/Test_Content_View","environment_id":2,"environment_name":"Library"}],"environments":[{"id":2,"name":"Library","label":"Library","publish_date":"less
+        than a minute","permissions":{"readable":true,"promotable_or_removable":true,"all_hosts_editable":true,"all_keys_editable":true},"host_count":0,"multi_env_host_count":0,"activation_key_count":0,"multi_env_ak_count":0}],"repositories":[{"id":3,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum","library_instance_id":1,"mirroring_policy":"mirror_content_only"}],"last_event":{"user":"admin","status":"successful","description":null,"action":"publish","created_at":"2025-07-11
+        15:22:20 UTC","updated_at":"2025-07-11 15:22:23 UTC","environment":null,"task":{"id":"6f661932-5bdd-4f8f-a521-f5875e5339f4","label":"Actions::Katello::ContentView::Publish","pending":false,"action":"Publish
+        content view ''Test Content View''; organization ''Test Organization''","username":"admin","started_at":"2025-07-11
+        15:22:19 UTC","ended_at":"2025-07-11 15:22:23 UTC","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":4,"name":"Test
+        Content View","label":"Test_Content_View"},"organization":{"id":3,"name":"Test
+        Organization","label":"Test_Organization"},"services_checked":["pulp3","candlepin","candlepin_auth"],"history_id":1,"content_view_id":4,"auto_publish_composite_ids":[],"content_view_version_name":"Test
+        Content View 1.0","content_view_version_id":3,"environment_id":2,"user_id":4,"skip_promotion":null,"current_request_id":"5d8b36e2-b73a-497e-a358-9fc98cabdad2","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{"content_view_id":4,"content_view_version_id":3,"skip_promotion":null,"history_id":1},"humanized":{"action":"Publish","input":[["content_view",{"text":"content
+        view ''Test Content View''","link":"/content_views/4/versions"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/3/edit"}]],"output":"","errors":[]},"cli_example":null,"start_at":"2025-07-11
+        15:22:19 UTC","available_actions":{"cancellable":false,"resumable":false}},"version":"1.0","publish":true,"version_id":3,"triggered_by":null,"triggered_by_id":null},"active_history":[],"rpm_count":0,"modulemd_count":0,"erratum_count":0,"package_group_count":0,"srpm_count":0,"ansible_collection_count":0,"deb_count":0,"docker_manifest_count":0,"docker_manifest_list_count":0,"docker_tag_count":0,"file_count":0,"python_package_count":0,"module_stream_count":0,"package_count":0,"component_view_count":0,"ansible_collection_repository_count":0,"deb_repository_count":0,"docker_repository_count":0,"file_repository_count":0,"python_repository_count":0,"yum_repository_count":1,"errata_counts":{"security":0,"bugfix":0,"enhancement":0,"total":0},"permissions":{"deletable":true},"filters_applied":false}]}
 
         '
     headers:
@@ -403,10 +409,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '3568'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -416,31 +420,33 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=94
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '3090'
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"components": [{"latest": false, "content_view_id": 31, "content_view_version_id":
-      19}]}'
+    body: '{"components": [{"latest": false, "content_view_id": 4, "content_view_version_id":
+      3}]}'
     headers:
       Accept:
       - application/json;version=2
@@ -449,22 +455,23 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '89'
+      - '87'
       Content-Type:
       - application/json
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: PUT
-    uri: https://foreman.example.org/katello/api/content_views/32/content_view_components/add
+    uri: https://foreman.example.org/katello/api/content_views/5/content_view_components/add
   response:
     body:
-      string: '{"total":1,"subtotal":1,"page":null,"per_page":null,"error":null,"search":null,"sort":{"by":null,"order":null},"results":[{"latest":false,"id":6,"created_at":"2020-09-14
-        10:19:50 UTC","updated_at":"2020-09-14 10:19:50 UTC","composite_content_view":{"id":32,"name":"Test
-        Composite Content View","label":"Test_Composite_Content_View","description":null,"next_version":1,"latest_version":null,"version_count":0},"content_view":{"id":31,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0","version_count":1},"content_view_version":{"id":19,"name":"Test
-        Content View 1.0","content_view_id":31,"version":"1.0","content_view":{"id":31,"name":"Test
-        Content View","label":"Test_Content_View","description":null},"environments":[{"id":13,"name":"Library","label":"Library"}],"repositories":[{"id":32,"name":"Test
-        Repository","label":"Test_Repository","description":null}]}}]}
+      string: '{"total":1,"subtotal":1,"selectable":1,"page":null,"per_page":null,"error":null,"search":null,"sort":{"by":null,"order":null},"results":[{"latest":false,"id":1,"created_at":"2025-07-11
+        15:22:27 UTC","updated_at":"2025-07-11 15:22:27 UTC","composite_content_view":{"id":5,"name":"Test
+        Composite Content View","label":"Test_Composite_Content_View","description":null,"next_version":1,"latest_version":null,"version_count":0},"content_view":{"id":4,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0","version_count":1},"content_view_version":{"id":3,"name":"Test
+        Content View 1.0","content_view_id":4,"version":"1.0","content_view":{"id":4,"name":"Test
+        Content View","label":"Test_Content_View","description":null},"environments":[{"id":2,"name":"Library","label":"Library"}],"repositories":[{"id":3,"name":"Test
+        Repository","label":"Test_Repository","description":null}]},"component_content_view_versions":[{"id":3,"version":"1.0","description":null,"published_at_words":"less
+        than a minute"}]}]}
 
         '
     headers:
@@ -472,10 +479,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '1058'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -485,25 +490,27 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=93
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '928'
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/content_view-7.yml
+++ b/tests/test_playbooks/fixtures/content_view-7.yml
@@ -14,16 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"2.1.2","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.16.0-develop","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '71'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -33,25 +31,27 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=100
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '62'
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
@@ -70,21 +70,18 @@ interactions:
     uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
-        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\"\
-        :\"Test_Organization\",\"created_at\":\"2020-09-14 10:19:21 UTC\",\"updated_at\"\
-        :\"2020-09-14 10:19:21 UTC\",\"id\":14,\"name\":\"Test Organization\",\"title\"\
-        :\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+        4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2025-07-11
+        15:21:41 UTC\",\"updated_at\":\"2025-07-11 15:21:45 UTC\",\"id\":3,\"name\":\"Test
+        Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '388'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -94,25 +91,27 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=99
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '389'
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
@@ -128,24 +127,25 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/14/content_views?search=name%3D%22Test+Composite+Content+View%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/3/content_views?search=name%3D%22Test+Composite+Content+View%22&per_page=4294967296
   response:
     body:
-      string: '{"total":3,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Composite Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":true,"component_ids":[19],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[32],"id":32,"name":"Test
-        Composite Content View","label":"Test_Composite_Content_View","description":null,"organization_id":14,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":14},"created_at":"2020-09-14
-        10:19:50 UTC","updated_at":"2020-09-14 10:19:50 UTC","environments":[],"repositories":[{"id":32,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[{"id":19,"name":"Test
-        Content View 1.0","content_view_id":31,"version":"1.0","environments":[{"id":13,"name":"Library","label":"Library"}],"content_view":{"id":31,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0"},"repositories":[{"id":32,"name":"Test
-        Repository","label":"Test_Repository","description":null}]}],"content_view_components":[{"latest":false,"id":6,"created_at":"2020-09-14
-        10:19:50 UTC","updated_at":"2020-09-14 10:19:50 UTC","composite_content_view":{"id":32,"name":"Test
-        Composite Content View","label":"Test_Composite_Content_View","description":null,"next_version":1,"latest_version":null,"version_count":0},"content_view":{"id":31,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0","version_count":1},"content_view_version":{"id":19,"name":"Test
-        Content View 1.0","content_view_id":31,"version":"1.0","content_view":{"id":31,"name":"Test
-        Content View","label":"Test_Content_View","description":null},"environments":[{"id":13,"name":"Library","label":"Library"}],"repositories":[{"id":32,"name":"Test
-        Repository","label":"Test_Repository","description":null}]}}],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
+      string: '{"total":3,"subtotal":1,"selectable":1,"page":1,"per_page":4294967296,"error":null,"search":"name=\"Test
+        Composite Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":true,"rolling":false,"component_ids":[3],"duplicate_repositories_to_publish":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":1,"related_composite_cvs":[],"filtered":false,"needs_publish":true,"environment_ids":[],"repository_ids":[3],"id":5,"name":"Test
+        Composite Content View","label":"Test_Composite_Content_View","description":null,"organization_id":3,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":3},"created_at":"2025-07-11
+        15:22:26 UTC","updated_at":"2025-07-11 15:22:26 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":3,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"versions":[],"components":[{"id":3,"name":"Test
+        Content View 1.0","content_view_id":4,"version":"1.0","environments":[{"id":2,"name":"Library","label":"Library"}],"content_view":{"id":4,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0"},"repositories":[{"id":3,"name":"Test
+        Repository","label":"Test_Repository","description":null}]}],"content_view_components":[{"latest":false,"id":1,"created_at":"2025-07-11
+        15:22:27 UTC","updated_at":"2025-07-11 15:22:27 UTC","composite_content_view":{"id":5,"name":"Test
+        Composite Content View","label":"Test_Composite_Content_View","description":null,"next_version":1,"latest_version":null,"version_count":0},"content_view":{"id":4,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0","version_count":1},"content_view_version":{"id":3,"name":"Test
+        Content View 1.0","content_view_id":4,"version":"1.0","content_view":{"id":4,"name":"Test
+        Content View","label":"Test_Content_View","description":null},"environments":[{"id":2,"name":"Library","label":"Library"}],"repositories":[{"id":3,"name":"Test
+        Repository","label":"Test_Repository","description":null}]},"component_content_view_versions":[{"id":3,"version":"1.0","description":null,"published_at_words":"less
+        than a minute"}]}],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
 
         '
     headers:
@@ -153,10 +153,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '2439'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -164,27 +162,29 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 14; Test Organization
+      - 3; Test Organization
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=98
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '2249'
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
@@ -200,23 +200,24 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/32
+    uri: https://foreman.example.org/katello/api/content_views/5
   response:
     body:
-      string: '  {"content_host_count":0,"composite":true,"component_ids":[19],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[32],"id":32,"name":"Test
-        Composite Content View","label":"Test_Composite_Content_View","description":null,"organization_id":14,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":14},"created_at":"2020-09-14
-        10:19:50 UTC","updated_at":"2020-09-14 10:19:50 UTC","environments":[],"repositories":[{"id":32,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[{"id":19,"name":"Test
-        Content View 1.0","content_view_id":31,"version":"1.0","environments":[{"id":13,"name":"Library","label":"Library"}],"content_view":{"id":31,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0"},"repositories":[{"id":32,"name":"Test
-        Repository","label":"Test_Repository","description":null}]}],"content_view_components":[{"latest":false,"id":6,"created_at":"2020-09-14
-        10:19:50 UTC","updated_at":"2020-09-14 10:19:50 UTC","composite_content_view":{"id":32,"name":"Test
-        Composite Content View","label":"Test_Composite_Content_View","description":null,"next_version":1,"latest_version":null,"version_count":0},"content_view":{"id":31,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0","version_count":1},"content_view_version":{"id":19,"name":"Test
-        Content View 1.0","content_view_id":31,"version":"1.0","content_view":{"id":31,"name":"Test
-        Content View","label":"Test_Content_View","description":null},"environments":[{"id":13,"name":"Library","label":"Library"}],"repositories":[{"id":32,"name":"Test
-        Repository","label":"Test_Repository","description":null}]}}],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true},"duplicate_repositories_to_publish":[]}
+      string: '  {"content_host_count":0,"composite":true,"rolling":false,"component_ids":[3],"duplicate_repositories_to_publish":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":1,"related_composite_cvs":[],"filtered":false,"needs_publish":true,"environment_ids":[],"repository_ids":[3],"id":5,"name":"Test
+        Composite Content View","label":"Test_Composite_Content_View","description":null,"organization_id":3,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":3},"created_at":"2025-07-11
+        15:22:26 UTC","updated_at":"2025-07-11 15:22:26 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":3,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"versions":[],"components":[{"id":3,"name":"Test
+        Content View 1.0","content_view_id":4,"version":"1.0","environments":[{"id":2,"name":"Library","label":"Library"}],"content_view":{"id":4,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0"},"repositories":[{"id":3,"name":"Test
+        Repository","label":"Test_Repository","description":null}]}],"content_view_components":[{"latest":false,"id":1,"created_at":"2025-07-11
+        15:22:27 UTC","updated_at":"2025-07-11 15:22:27 UTC","composite_content_view":{"id":5,"name":"Test
+        Composite Content View","label":"Test_Composite_Content_View","description":null,"next_version":1,"latest_version":null,"version_count":0},"content_view":{"id":4,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0","version_count":1},"content_view_version":{"id":3,"name":"Test
+        Content View 1.0","content_view_id":4,"version":"1.0","content_view":{"id":4,"name":"Test
+        Content View","label":"Test_Content_View","description":null},"environments":[{"id":2,"name":"Library","label":"Library"}],"repositories":[{"id":3,"name":"Test
+        Repository","label":"Test_Repository","description":null}]},"component_content_view_versions":[{"id":3,"version":"1.0","description":null,"published_at_words":"less
+        than a minute"}]}],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[],"errors":null}
 
         '
     headers:
@@ -224,10 +225,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '2299'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -237,25 +236,27 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=97
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '2147'
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
@@ -271,17 +272,20 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/14/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/3/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
   response:
     body:
-      string: '{"total":3,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":1,"latest_version":"1.0","auto_publish":false,"solve_dependencies":false,"repository_ids":[30],"id":31,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":14,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":14},"created_at":"2020-09-14
-        10:19:43 UTC","updated_at":"2020-09-14 10:19:44 UTC","environments":[{"id":13,"name":"Library","label":"Library","permissions":{"readable":true}}],"repositories":[{"id":30,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[{"id":19,"version":"1.0","published":"2020-09-14
-        10:19:44 UTC","environment_ids":[13]}],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"2.0","last_published":"2020-09-14
-        10:19:44 UTC","permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
+      string: '{"total":3,"subtotal":1,"selectable":1,"page":1,"per_page":4294967296,"error":null,"search":"name=\"Test
+        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"rolling":false,"component_ids":[],"duplicate_repositories_to_publish":[],"default":false,"version_count":1,"latest_version":"1.0","latest_version_id":3,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":1,"related_composite_cvs":[{"id":5,"name":"Test
+        Composite Content View"}],"filtered":false,"needs_publish":false,"environment_ids":[2],"repository_ids":[1],"id":4,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":3,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":3},"created_at":"2025-07-11
+        15:22:18 UTC","updated_at":"2025-07-11 15:22:20 UTC","last_task":{"id":"6f661932-5bdd-4f8f-a521-f5875e5339f4","started_at":"2025-07-11
+        15:22:19 UTC","result":"success","last_sync_words":"less than a minute"},"latest_version_environments":[{"id":2,"name":"Library","label":"Library"}],"repositories":[{"id":1,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"versions":[{"id":3,"version":"1.0","published":"2025-07-11
+        15:22:20 UTC","description":null,"environment_ids":[2],"filters_applied":false,"published_at_words":"less
+        than a minute"}],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"2.0","last_published":"2025-07-11
+        15:22:20 UTC","environments":[{"id":2,"label":"Library","name":"Library","activation_keys":[],"hosts":[],"permissions":{"readable":true}}]}]}
 
         '
     headers:
@@ -289,10 +293,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '1644'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -300,27 +302,29 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 14; Test Organization
+      - 3; Test Organization
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=96
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '1224'
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
@@ -336,16 +340,19 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/31
+    uri: https://foreman.example.org/katello/api/content_views/4
   response:
     body:
-      string: '  {"content_host_count":0,"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":1,"latest_version":"1.0","auto_publish":false,"solve_dependencies":false,"repository_ids":[30],"id":31,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":14,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":14},"created_at":"2020-09-14
-        10:19:43 UTC","updated_at":"2020-09-14 10:19:44 UTC","environments":[{"id":13,"name":"Library","label":"Library","permissions":{"readable":true}}],"repositories":[{"id":30,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[{"id":19,"version":"1.0","published":"2020-09-14
-        10:19:44 UTC","environment_ids":[13]}],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"2.0","last_published":"2020-09-14
-        10:19:44 UTC","permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true},"duplicate_repositories_to_publish":[]}
+      string: '  {"content_host_count":0,"composite":false,"rolling":false,"component_ids":[],"duplicate_repositories_to_publish":[],"default":false,"version_count":1,"latest_version":"1.0","latest_version_id":3,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":1,"related_composite_cvs":[{"id":5,"name":"Test
+        Composite Content View"}],"filtered":false,"needs_publish":false,"environment_ids":[2],"repository_ids":[1],"id":4,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":3,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":3},"created_at":"2025-07-11
+        15:22:18 UTC","updated_at":"2025-07-11 15:22:20 UTC","last_task":{"id":"6f661932-5bdd-4f8f-a521-f5875e5339f4","started_at":"2025-07-11
+        15:22:19 UTC","result":"success","last_sync_words":"less than a minute"},"latest_version_environments":[{"id":2,"name":"Library","label":"Library"}],"repositories":[{"id":1,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"versions":[{"id":3,"version":"1.0","published":"2025-07-11
+        15:22:20 UTC","description":null,"environment_ids":[2],"filters_applied":false,"published_at_words":"less
+        than a minute"}],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"2.0","last_published":"2025-07-11
+        15:22:20 UTC","environments":[{"id":2,"label":"Library","name":"Library","activation_keys":[],"hosts":[],"permissions":{"readable":true}}],"errors":null}
 
         '
     headers:
@@ -353,10 +360,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '1514'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -366,25 +371,27 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=95
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '1132'
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
@@ -400,23 +407,24 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_view_versions?search=content_view_id%3D31%2Cversion%3D1.0&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_view_versions?search=content_view_id%3D4%2Cversion%3D1.0&per_page=4294967296
   response:
     body:
-      string: '{"total":4,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"content_view_id=31,version=1.0","sort":{"by":"version","order":"desc"},"results":[{"version":"1.0","major":1,"minor":0,"composite_content_view_ids":[32],"published_in_composite_content_view_ids":[],"content_view_id":31,"default":false,"description":null,"id":19,"name":"Test
-        Content View 1.0","created_at":"2020-09-14 10:19:44 UTC","updated_at":"2020-09-14
-        10:19:47 UTC","content_view":{"id":31,"name":"Test Content View","label":"Test_Content_View"},"composite_content_views":[{"id":32,"name":"Test
-        Composite Content View","label":"Test_Composite_Content_View"}],"composite_content_view_versions":[],"published_in_composite_content_views":[],"environments":[{"id":13,"name":"Library","label":"Library","puppet_environment_id":null,"permissions":{"readable":true,"promotable_or_removable":true,"all_hosts_editable":true,"all_keys_editable":true},"host_count":0,"activation_key_count":0}],"repositories":[{"id":32,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum","library_instance_id":30}],"last_event":{"user":"admin","status":"successful","description":null,"action":"publish","created_at":"2020-09-14
-        10:19:44 UTC","updated_at":"2020-09-14 10:19:47 UTC","environment":null,"task":{"id":"dce95aeb-7d0d-49d1-829f-8c263c4bbc47","label":"Actions::Katello::ContentView::Publish","pending":false,"action":"Publish
-        content view ''Test Content View''; organization ''Test Organization''","username":"admin","started_at":"2020-09-14
-        10:19:44 UTC","ended_at":"2020-09-14 10:19:47 UTC","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":31,"name":"Test
-        Content View","label":"Test_Content_View"},"organization":{"id":14,"name":"Test
-        Organization","label":"Test_Organization"},"services_checked":["candlepin","candlepin_auth","pulp3","pulp","pulp_auth"],"history_id":24,"content_view_id":31,"auto_publish_composite_ids":[],"content_view_version_name":"Test
-        Content View 1.0","content_view_version_id":19,"environment_id":13,"user_id":4,"skip_promotion":null,"current_request_id":null,"current_timezone":"UTC","current_user_id":4,"current_organization_id":null,"current_location_id":null},"output":{"content_view_id":31,"content_view_version_id":19,"skip_promotion":null},"humanized":{"action":"Publish","input":[["content_view",{"text":"content
-        view ''Test Content View''","link":"/content_views/31/versions"}],["organization",{"text":"organization
-        ''Test Organization''","link":"/organizations/14/edit"}]],"output":"","errors":[]},"cli_example":null,"start_at":"2020-09-14
-        10:19:44 UTC","available_actions":{"cancellable":false,"resumable":false}},"version":"1.0","publish":true,"version_id":19,"triggered_by":null,"triggered_by_id":null},"active_history":[],"deb_count":0,"docker_manifest_count":0,"docker_manifest_list_count":0,"docker_tag_count":0,"file_count":0,"puppet_module_count":0,"rpm_count":0,"modulemd_count":0,"erratum_count":0,"package_group_count":0,"srpm_count":0,"module_stream_count":0,"package_count":0,"ostree_branch_count":null,"errata_counts":{"security":null,"bugfix":0,"enhancement":0,"total":null},"permissions":{"deletable":true}}]}
+      string: '{"total":3,"subtotal":1,"selectable":1,"page":1,"per_page":4294967296,"error":null,"search":"content_view_id=4,version=1.0","sort":{"by":"version","order":"desc"},"results":[{"version":"1.0","major":1,"minor":0,"composite_content_view_ids":[5],"published_in_composite_content_view_ids":[],"content_view_id":4,"default":false,"description":null,"id":3,"name":"Test
+        Content View 1.0","created_at":"2025-07-11 15:22:20 UTC","updated_at":"2025-07-11
+        15:22:23 UTC","content_view":{"id":4,"name":"Test Content View","label":"Test_Content_View","generated_for":"none"},"composite_content_views":[{"id":5,"name":"Test
+        Composite Content View","label":"Test_Composite_Content_View"}],"composite_content_view_versions":[],"published_in_composite_content_views":[],"content_view_environments":[{"label":"Library/Test_Content_View","environment_id":2,"environment_name":"Library"}],"environments":[{"id":2,"name":"Library","label":"Library","publish_date":"less
+        than a minute","permissions":{"readable":true,"promotable_or_removable":true,"all_hosts_editable":true,"all_keys_editable":true},"host_count":0,"multi_env_host_count":0,"activation_key_count":0,"multi_env_ak_count":0}],"repositories":[{"id":3,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum","library_instance_id":1,"mirroring_policy":"mirror_content_only"}],"last_event":{"user":"admin","status":"successful","description":null,"action":"publish","created_at":"2025-07-11
+        15:22:20 UTC","updated_at":"2025-07-11 15:22:23 UTC","environment":null,"task":{"id":"6f661932-5bdd-4f8f-a521-f5875e5339f4","label":"Actions::Katello::ContentView::Publish","pending":false,"action":"Publish
+        content view ''Test Content View''; organization ''Test Organization''","username":"admin","started_at":"2025-07-11
+        15:22:19 UTC","ended_at":"2025-07-11 15:22:23 UTC","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":4,"name":"Test
+        Content View","label":"Test_Content_View"},"organization":{"id":3,"name":"Test
+        Organization","label":"Test_Organization"},"services_checked":["pulp3","candlepin","candlepin_auth"],"history_id":1,"content_view_id":4,"auto_publish_composite_ids":[],"content_view_version_name":"Test
+        Content View 1.0","content_view_version_id":3,"environment_id":2,"user_id":4,"skip_promotion":null,"current_request_id":"5d8b36e2-b73a-497e-a358-9fc98cabdad2","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{"content_view_id":4,"content_view_version_id":3,"skip_promotion":null,"history_id":1},"humanized":{"action":"Publish","input":[["content_view",{"text":"content
+        view ''Test Content View''","link":"/content_views/4/versions"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/3/edit"}]],"output":"","errors":[]},"cli_example":null,"start_at":"2025-07-11
+        15:22:19 UTC","available_actions":{"cancellable":false,"resumable":false}},"version":"1.0","publish":true,"version_id":3,"triggered_by":null,"triggered_by_id":null},"active_history":[],"rpm_count":0,"modulemd_count":0,"erratum_count":0,"package_group_count":0,"srpm_count":0,"ansible_collection_count":0,"deb_count":0,"docker_manifest_count":0,"docker_manifest_list_count":0,"docker_tag_count":0,"file_count":0,"python_package_count":0,"module_stream_count":0,"package_count":0,"component_view_count":0,"ansible_collection_repository_count":0,"deb_repository_count":0,"docker_repository_count":0,"file_repository_count":0,"python_repository_count":0,"yum_repository_count":1,"errata_counts":{"security":0,"bugfix":0,"enhancement":0,"total":0},"permissions":{"deletable":true},"filters_applied":false}]}
 
         '
     headers:
@@ -424,10 +432,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '3652'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -437,25 +443,27 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=94
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '3176'
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/content_view-8.yml
+++ b/tests/test_playbooks/fixtures/content_view-8.yml
@@ -14,16 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"2.1.2","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.16.0-develop","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '71'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -33,25 +31,27 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=100
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '62'
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
@@ -70,21 +70,18 @@ interactions:
     uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
-        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\"\
-        :\"Test_Organization\",\"created_at\":\"2020-09-14 10:19:21 UTC\",\"updated_at\"\
-        :\"2020-09-14 10:19:21 UTC\",\"id\":14,\"name\":\"Test Organization\",\"title\"\
-        :\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+        4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2025-07-11
+        15:21:41 UTC\",\"updated_at\":\"2025-07-11 15:21:45 UTC\",\"id\":3,\"name\":\"Test
+        Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '388'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -94,25 +91,27 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=99
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '389'
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
@@ -128,24 +127,25 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/14/content_views?search=name%3D%22Test+Composite+Content+View%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/3/content_views?search=name%3D%22Test+Composite+Content+View%22&per_page=4294967296
   response:
     body:
-      string: '{"total":3,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Composite Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":true,"component_ids":[19],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[32],"id":32,"name":"Test
-        Composite Content View","label":"Test_Composite_Content_View","description":null,"organization_id":14,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":14},"created_at":"2020-09-14
-        10:19:50 UTC","updated_at":"2020-09-14 10:19:50 UTC","environments":[],"repositories":[{"id":32,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[{"id":19,"name":"Test
-        Content View 1.0","content_view_id":31,"version":"1.0","environments":[{"id":13,"name":"Library","label":"Library"}],"content_view":{"id":31,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0"},"repositories":[{"id":32,"name":"Test
-        Repository","label":"Test_Repository","description":null}]}],"content_view_components":[{"latest":false,"id":6,"created_at":"2020-09-14
-        10:19:50 UTC","updated_at":"2020-09-14 10:19:50 UTC","composite_content_view":{"id":32,"name":"Test
-        Composite Content View","label":"Test_Composite_Content_View","description":null,"next_version":1,"latest_version":null,"version_count":0},"content_view":{"id":31,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0","version_count":1},"content_view_version":{"id":19,"name":"Test
-        Content View 1.0","content_view_id":31,"version":"1.0","content_view":{"id":31,"name":"Test
-        Content View","label":"Test_Content_View","description":null},"environments":[{"id":13,"name":"Library","label":"Library"}],"repositories":[{"id":32,"name":"Test
-        Repository","label":"Test_Repository","description":null}]}}],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
+      string: '{"total":3,"subtotal":1,"selectable":1,"page":1,"per_page":4294967296,"error":null,"search":"name=\"Test
+        Composite Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":true,"rolling":false,"component_ids":[3],"duplicate_repositories_to_publish":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":1,"related_composite_cvs":[],"filtered":false,"needs_publish":true,"environment_ids":[],"repository_ids":[3],"id":5,"name":"Test
+        Composite Content View","label":"Test_Composite_Content_View","description":null,"organization_id":3,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":3},"created_at":"2025-07-11
+        15:22:26 UTC","updated_at":"2025-07-11 15:22:26 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":3,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"versions":[],"components":[{"id":3,"name":"Test
+        Content View 1.0","content_view_id":4,"version":"1.0","environments":[{"id":2,"name":"Library","label":"Library"}],"content_view":{"id":4,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0"},"repositories":[{"id":3,"name":"Test
+        Repository","label":"Test_Repository","description":null}]}],"content_view_components":[{"latest":false,"id":1,"created_at":"2025-07-11
+        15:22:27 UTC","updated_at":"2025-07-11 15:22:27 UTC","composite_content_view":{"id":5,"name":"Test
+        Composite Content View","label":"Test_Composite_Content_View","description":null,"next_version":1,"latest_version":null,"version_count":0},"content_view":{"id":4,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0","version_count":1},"content_view_version":{"id":3,"name":"Test
+        Content View 1.0","content_view_id":4,"version":"1.0","content_view":{"id":4,"name":"Test
+        Content View","label":"Test_Content_View","description":null},"environments":[{"id":2,"name":"Library","label":"Library"}],"repositories":[{"id":3,"name":"Test
+        Repository","label":"Test_Repository","description":null}]},"component_content_view_versions":[{"id":3,"version":"1.0","description":null,"published_at_words":"less
+        than a minute"}]}],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
 
         '
     headers:
@@ -153,10 +153,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '2439'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -164,27 +162,29 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 14; Test Organization
+      - 3; Test Organization
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=98
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '2249'
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
@@ -200,23 +200,24 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/32
+    uri: https://foreman.example.org/katello/api/content_views/5
   response:
     body:
-      string: '  {"content_host_count":0,"composite":true,"component_ids":[19],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":false,"solve_dependencies":false,"repository_ids":[32],"id":32,"name":"Test
-        Composite Content View","label":"Test_Composite_Content_View","description":null,"organization_id":14,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":14},"created_at":"2020-09-14
-        10:19:50 UTC","updated_at":"2020-09-14 10:19:50 UTC","environments":[],"repositories":[{"id":32,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[{"id":19,"name":"Test
-        Content View 1.0","content_view_id":31,"version":"1.0","environments":[{"id":13,"name":"Library","label":"Library"}],"content_view":{"id":31,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0"},"repositories":[{"id":32,"name":"Test
-        Repository","label":"Test_Repository","description":null}]}],"content_view_components":[{"latest":false,"id":6,"created_at":"2020-09-14
-        10:19:50 UTC","updated_at":"2020-09-14 10:19:50 UTC","composite_content_view":{"id":32,"name":"Test
-        Composite Content View","label":"Test_Composite_Content_View","description":null,"next_version":1,"latest_version":null,"version_count":0},"content_view":{"id":31,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0","version_count":1},"content_view_version":{"id":19,"name":"Test
-        Content View 1.0","content_view_id":31,"version":"1.0","content_view":{"id":31,"name":"Test
-        Content View","label":"Test_Content_View","description":null},"environments":[{"id":13,"name":"Library","label":"Library"}],"repositories":[{"id":32,"name":"Test
-        Repository","label":"Test_Repository","description":null}]}}],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true},"duplicate_repositories_to_publish":[]}
+      string: '  {"content_host_count":0,"composite":true,"rolling":false,"component_ids":[3],"duplicate_repositories_to_publish":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":1,"related_composite_cvs":[],"filtered":false,"needs_publish":true,"environment_ids":[],"repository_ids":[3],"id":5,"name":"Test
+        Composite Content View","label":"Test_Composite_Content_View","description":null,"organization_id":3,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":3},"created_at":"2025-07-11
+        15:22:26 UTC","updated_at":"2025-07-11 15:22:26 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":3,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"versions":[],"components":[{"id":3,"name":"Test
+        Content View 1.0","content_view_id":4,"version":"1.0","environments":[{"id":2,"name":"Library","label":"Library"}],"content_view":{"id":4,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0"},"repositories":[{"id":3,"name":"Test
+        Repository","label":"Test_Repository","description":null}]}],"content_view_components":[{"latest":false,"id":1,"created_at":"2025-07-11
+        15:22:27 UTC","updated_at":"2025-07-11 15:22:27 UTC","composite_content_view":{"id":5,"name":"Test
+        Composite Content View","label":"Test_Composite_Content_View","description":null,"next_version":1,"latest_version":null,"version_count":0},"content_view":{"id":4,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0","version_count":1},"content_view_version":{"id":3,"name":"Test
+        Content View 1.0","content_view_id":4,"version":"1.0","content_view":{"id":4,"name":"Test
+        Content View","label":"Test_Content_View","description":null},"environments":[{"id":2,"name":"Library","label":"Library"}],"repositories":[{"id":3,"name":"Test
+        Repository","label":"Test_Repository","description":null}]},"component_content_view_versions":[{"id":3,"version":"1.0","description":null,"published_at_words":"less
+        than a minute"}]}],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[],"errors":null}
 
         '
     headers:
@@ -224,10 +225,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '2299'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -237,25 +236,27 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=97
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '2147'
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
@@ -275,23 +276,24 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: PUT
-    uri: https://foreman.example.org/katello/api/content_views/32
+    uri: https://foreman.example.org/katello/api/content_views/5
   response:
     body:
-      string: '  {"content_host_count":0,"composite":true,"component_ids":[19],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":true,"solve_dependencies":false,"repository_ids":[32],"id":32,"name":"Test
-        Composite Content View","label":"Test_Composite_Content_View","description":null,"organization_id":14,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":14},"created_at":"2020-09-14
-        10:19:50 UTC","updated_at":"2020-09-14 10:19:53 UTC","environments":[],"repositories":[{"id":32,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[{"id":19,"name":"Test
-        Content View 1.0","content_view_id":31,"version":"1.0","environments":[{"id":13,"name":"Library","label":"Library"}],"content_view":{"id":31,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0"},"repositories":[{"id":32,"name":"Test
-        Repository","label":"Test_Repository","description":null}]}],"content_view_components":[{"latest":false,"id":6,"created_at":"2020-09-14
-        10:19:50 UTC","updated_at":"2020-09-14 10:19:50 UTC","composite_content_view":{"id":32,"name":"Test
-        Composite Content View","label":"Test_Composite_Content_View","description":null,"next_version":1,"latest_version":null,"version_count":0},"content_view":{"id":31,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0","version_count":1},"content_view_version":{"id":19,"name":"Test
-        Content View 1.0","content_view_id":31,"version":"1.0","content_view":{"id":31,"name":"Test
-        Content View","label":"Test_Content_View","description":null},"environments":[{"id":13,"name":"Library","label":"Library"}],"repositories":[{"id":32,"name":"Test
-        Repository","label":"Test_Repository","description":null}]}}],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true},"duplicate_repositories_to_publish":[]}
+      string: '  {"content_host_count":0,"composite":true,"rolling":false,"component_ids":[3],"duplicate_repositories_to_publish":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":true,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":1,"related_composite_cvs":[],"filtered":false,"needs_publish":true,"environment_ids":[],"repository_ids":[3],"id":5,"name":"Test
+        Composite Content View","label":"Test_Composite_Content_View","description":null,"organization_id":3,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":3},"created_at":"2025-07-11
+        15:22:26 UTC","updated_at":"2025-07-11 15:22:30 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":3,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"versions":[],"components":[{"id":3,"name":"Test
+        Content View 1.0","content_view_id":4,"version":"1.0","environments":[{"id":2,"name":"Library","label":"Library"}],"content_view":{"id":4,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0"},"repositories":[{"id":3,"name":"Test
+        Repository","label":"Test_Repository","description":null}]}],"content_view_components":[{"latest":false,"id":1,"created_at":"2025-07-11
+        15:22:27 UTC","updated_at":"2025-07-11 15:22:27 UTC","composite_content_view":{"id":5,"name":"Test
+        Composite Content View","label":"Test_Composite_Content_View","description":null,"next_version":1,"latest_version":null,"version_count":0},"content_view":{"id":4,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0","version_count":1},"content_view_version":{"id":3,"name":"Test
+        Content View 1.0","content_view_id":4,"version":"1.0","content_view":{"id":4,"name":"Test
+        Content View","label":"Test_Content_View","description":null},"environments":[{"id":2,"name":"Library","label":"Library"}],"repositories":[{"id":3,"name":"Test
+        Repository","label":"Test_Repository","description":null}]},"component_content_view_versions":[{"id":3,"version":"1.0","description":null,"published_at_words":"less
+        than a minute"}]}],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[],"errors":null}
 
         '
     headers:
@@ -299,10 +301,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '2298'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -312,25 +312,27 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=96
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '2146'
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
@@ -346,17 +348,20 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/14/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/3/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
   response:
     body:
-      string: '{"total":3,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":1,"latest_version":"1.0","auto_publish":false,"solve_dependencies":false,"repository_ids":[30],"id":31,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":14,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":14},"created_at":"2020-09-14
-        10:19:43 UTC","updated_at":"2020-09-14 10:19:44 UTC","environments":[{"id":13,"name":"Library","label":"Library","permissions":{"readable":true}}],"repositories":[{"id":30,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[{"id":19,"version":"1.0","published":"2020-09-14
-        10:19:44 UTC","environment_ids":[13]}],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"2.0","last_published":"2020-09-14
-        10:19:44 UTC","permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
+      string: '{"total":3,"subtotal":1,"selectable":1,"page":1,"per_page":4294967296,"error":null,"search":"name=\"Test
+        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"rolling":false,"component_ids":[],"duplicate_repositories_to_publish":[],"default":false,"version_count":1,"latest_version":"1.0","latest_version_id":3,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":1,"related_composite_cvs":[{"id":5,"name":"Test
+        Composite Content View"}],"filtered":false,"needs_publish":false,"environment_ids":[2],"repository_ids":[1],"id":4,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":3,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":3},"created_at":"2025-07-11
+        15:22:18 UTC","updated_at":"2025-07-11 15:22:20 UTC","last_task":{"id":"6f661932-5bdd-4f8f-a521-f5875e5339f4","started_at":"2025-07-11
+        15:22:19 UTC","result":"success","last_sync_words":"less than a minute"},"latest_version_environments":[{"id":2,"name":"Library","label":"Library"}],"repositories":[{"id":1,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"versions":[{"id":3,"version":"1.0","published":"2025-07-11
+        15:22:20 UTC","description":null,"environment_ids":[2],"filters_applied":false,"published_at_words":"less
+        than a minute"}],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"2.0","last_published":"2025-07-11
+        15:22:20 UTC","environments":[{"id":2,"label":"Library","name":"Library","activation_keys":[],"hosts":[],"permissions":{"readable":true}}]}]}
 
         '
     headers:
@@ -364,10 +369,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '1644'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -375,27 +378,29 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 14; Test Organization
+      - 3; Test Organization
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=95
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '1224'
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
@@ -411,16 +416,19 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/31
+    uri: https://foreman.example.org/katello/api/content_views/4
   response:
     body:
-      string: '  {"content_host_count":0,"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":1,"latest_version":"1.0","auto_publish":false,"solve_dependencies":false,"repository_ids":[30],"id":31,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":14,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":14},"created_at":"2020-09-14
-        10:19:43 UTC","updated_at":"2020-09-14 10:19:44 UTC","environments":[{"id":13,"name":"Library","label":"Library","permissions":{"readable":true}}],"repositories":[{"id":30,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[{"id":19,"version":"1.0","published":"2020-09-14
-        10:19:44 UTC","environment_ids":[13]}],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"2.0","last_published":"2020-09-14
-        10:19:44 UTC","permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true},"duplicate_repositories_to_publish":[]}
+      string: '  {"content_host_count":0,"composite":false,"rolling":false,"component_ids":[],"duplicate_repositories_to_publish":[],"default":false,"version_count":1,"latest_version":"1.0","latest_version_id":3,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":1,"related_composite_cvs":[{"id":5,"name":"Test
+        Composite Content View"}],"filtered":false,"needs_publish":false,"environment_ids":[2],"repository_ids":[1],"id":4,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":3,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":3},"created_at":"2025-07-11
+        15:22:18 UTC","updated_at":"2025-07-11 15:22:20 UTC","last_task":{"id":"6f661932-5bdd-4f8f-a521-f5875e5339f4","started_at":"2025-07-11
+        15:22:19 UTC","result":"success","last_sync_words":"less than a minute"},"latest_version_environments":[{"id":2,"name":"Library","label":"Library"}],"repositories":[{"id":1,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"versions":[{"id":3,"version":"1.0","published":"2025-07-11
+        15:22:20 UTC","description":null,"environment_ids":[2],"filters_applied":false,"published_at_words":"less
+        than a minute"}],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"2.0","last_published":"2025-07-11
+        15:22:20 UTC","environments":[{"id":2,"label":"Library","name":"Library","activation_keys":[],"hosts":[],"permissions":{"readable":true}}],"errors":null}
 
         '
     headers:
@@ -428,10 +436,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '1514'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -441,25 +447,27 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=94
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '1132'
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
@@ -475,23 +483,24 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_view_versions?search=content_view_id%3D31%2Cversion%3D1.0&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_view_versions?search=content_view_id%3D4%2Cversion%3D1.0&per_page=4294967296
   response:
     body:
-      string: '{"total":4,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"content_view_id=31,version=1.0","sort":{"by":"version","order":"desc"},"results":[{"version":"1.0","major":1,"minor":0,"composite_content_view_ids":[32],"published_in_composite_content_view_ids":[],"content_view_id":31,"default":false,"description":null,"id":19,"name":"Test
-        Content View 1.0","created_at":"2020-09-14 10:19:44 UTC","updated_at":"2020-09-14
-        10:19:47 UTC","content_view":{"id":31,"name":"Test Content View","label":"Test_Content_View"},"composite_content_views":[{"id":32,"name":"Test
-        Composite Content View","label":"Test_Composite_Content_View"}],"composite_content_view_versions":[],"published_in_composite_content_views":[],"environments":[{"id":13,"name":"Library","label":"Library","puppet_environment_id":null,"permissions":{"readable":true,"promotable_or_removable":true,"all_hosts_editable":true,"all_keys_editable":true},"host_count":0,"activation_key_count":0}],"repositories":[{"id":32,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum","library_instance_id":30}],"last_event":{"user":"admin","status":"successful","description":null,"action":"publish","created_at":"2020-09-14
-        10:19:44 UTC","updated_at":"2020-09-14 10:19:47 UTC","environment":null,"task":{"id":"dce95aeb-7d0d-49d1-829f-8c263c4bbc47","label":"Actions::Katello::ContentView::Publish","pending":false,"action":"Publish
-        content view ''Test Content View''; organization ''Test Organization''","username":"admin","started_at":"2020-09-14
-        10:19:44 UTC","ended_at":"2020-09-14 10:19:47 UTC","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":31,"name":"Test
-        Content View","label":"Test_Content_View"},"organization":{"id":14,"name":"Test
-        Organization","label":"Test_Organization"},"services_checked":["candlepin","candlepin_auth","pulp3","pulp","pulp_auth"],"history_id":24,"content_view_id":31,"auto_publish_composite_ids":[],"content_view_version_name":"Test
-        Content View 1.0","content_view_version_id":19,"environment_id":13,"user_id":4,"skip_promotion":null,"current_request_id":null,"current_timezone":"UTC","current_user_id":4,"current_organization_id":null,"current_location_id":null},"output":{"content_view_id":31,"content_view_version_id":19,"skip_promotion":null},"humanized":{"action":"Publish","input":[["content_view",{"text":"content
-        view ''Test Content View''","link":"/content_views/31/versions"}],["organization",{"text":"organization
-        ''Test Organization''","link":"/organizations/14/edit"}]],"output":"","errors":[]},"cli_example":null,"start_at":"2020-09-14
-        10:19:44 UTC","available_actions":{"cancellable":false,"resumable":false}},"version":"1.0","publish":true,"version_id":19,"triggered_by":null,"triggered_by_id":null},"active_history":[],"deb_count":0,"docker_manifest_count":0,"docker_manifest_list_count":0,"docker_tag_count":0,"file_count":0,"puppet_module_count":0,"rpm_count":0,"modulemd_count":0,"erratum_count":0,"package_group_count":0,"srpm_count":0,"module_stream_count":0,"package_count":0,"ostree_branch_count":null,"errata_counts":{"security":null,"bugfix":0,"enhancement":0,"total":null},"permissions":{"deletable":true}}]}
+      string: '{"total":3,"subtotal":1,"selectable":1,"page":1,"per_page":4294967296,"error":null,"search":"content_view_id=4,version=1.0","sort":{"by":"version","order":"desc"},"results":[{"version":"1.0","major":1,"minor":0,"composite_content_view_ids":[5],"published_in_composite_content_view_ids":[],"content_view_id":4,"default":false,"description":null,"id":3,"name":"Test
+        Content View 1.0","created_at":"2025-07-11 15:22:20 UTC","updated_at":"2025-07-11
+        15:22:23 UTC","content_view":{"id":4,"name":"Test Content View","label":"Test_Content_View","generated_for":"none"},"composite_content_views":[{"id":5,"name":"Test
+        Composite Content View","label":"Test_Composite_Content_View"}],"composite_content_view_versions":[],"published_in_composite_content_views":[],"content_view_environments":[{"label":"Library/Test_Content_View","environment_id":2,"environment_name":"Library"}],"environments":[{"id":2,"name":"Library","label":"Library","publish_date":"less
+        than a minute","permissions":{"readable":true,"promotable_or_removable":true,"all_hosts_editable":true,"all_keys_editable":true},"host_count":0,"multi_env_host_count":0,"activation_key_count":0,"multi_env_ak_count":0}],"repositories":[{"id":3,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum","library_instance_id":1,"mirroring_policy":"mirror_content_only"}],"last_event":{"user":"admin","status":"successful","description":null,"action":"publish","created_at":"2025-07-11
+        15:22:20 UTC","updated_at":"2025-07-11 15:22:23 UTC","environment":null,"task":{"id":"6f661932-5bdd-4f8f-a521-f5875e5339f4","label":"Actions::Katello::ContentView::Publish","pending":false,"action":"Publish
+        content view ''Test Content View''; organization ''Test Organization''","username":"admin","started_at":"2025-07-11
+        15:22:19 UTC","ended_at":"2025-07-11 15:22:23 UTC","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":4,"name":"Test
+        Content View","label":"Test_Content_View"},"organization":{"id":3,"name":"Test
+        Organization","label":"Test_Organization"},"services_checked":["pulp3","candlepin","candlepin_auth"],"history_id":1,"content_view_id":4,"auto_publish_composite_ids":[],"content_view_version_name":"Test
+        Content View 1.0","content_view_version_id":3,"environment_id":2,"user_id":4,"skip_promotion":null,"current_request_id":"5d8b36e2-b73a-497e-a358-9fc98cabdad2","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{"content_view_id":4,"content_view_version_id":3,"skip_promotion":null,"history_id":1},"humanized":{"action":"Publish","input":[["content_view",{"text":"content
+        view ''Test Content View''","link":"/content_views/4/versions"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/3/edit"}]],"output":"","errors":[]},"cli_example":null,"start_at":"2025-07-11
+        15:22:19 UTC","available_actions":{"cancellable":false,"resumable":false}},"version":"1.0","publish":true,"version_id":3,"triggered_by":null,"triggered_by_id":null},"active_history":[],"rpm_count":0,"modulemd_count":0,"erratum_count":0,"package_group_count":0,"srpm_count":0,"ansible_collection_count":0,"deb_count":0,"docker_manifest_count":0,"docker_manifest_list_count":0,"docker_tag_count":0,"file_count":0,"python_package_count":0,"module_stream_count":0,"package_count":0,"component_view_count":0,"ansible_collection_repository_count":0,"deb_repository_count":0,"docker_repository_count":0,"file_repository_count":0,"python_repository_count":0,"yum_repository_count":1,"errata_counts":{"security":0,"bugfix":0,"enhancement":0,"total":0},"permissions":{"deletable":true},"filters_applied":false}]}
 
         '
     headers:
@@ -499,10 +508,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '3652'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -512,25 +519,27 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=93
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '3176'
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/content_view-9.yml
+++ b/tests/test_playbooks/fixtures/content_view-9.yml
@@ -14,16 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"2.1.2","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.16.0-develop","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '71'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -33,25 +31,27 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=100
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '62'
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
@@ -70,21 +70,18 @@ interactions:
     uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
   response:
     body:
-      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\"\
-        : 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\"\
-        : {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\"\
-        :\"Test_Organization\",\"created_at\":\"2020-09-14 10:19:21 UTC\",\"updated_at\"\
-        :\"2020-09-14 10:19:21 UTC\",\"id\":14,\"name\":\"Test Organization\",\"title\"\
-        :\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
+        4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2025-07-11
+        15:21:41 UTC\",\"updated_at\":\"2025-07-11 15:21:45 UTC\",\"id\":3,\"name\":\"Test
+        Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '388'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -94,25 +91,27 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=99
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '389'
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
@@ -128,24 +127,25 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/14/content_views?search=name%3D%22Test+Composite+Content+View%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/3/content_views?search=name%3D%22Test+Composite+Content+View%22&per_page=4294967296
   response:
     body:
-      string: '{"total":3,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Composite Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":true,"component_ids":[19],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":true,"solve_dependencies":false,"repository_ids":[32],"id":32,"name":"Test
-        Composite Content View","label":"Test_Composite_Content_View","description":null,"organization_id":14,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":14},"created_at":"2020-09-14
-        10:19:50 UTC","updated_at":"2020-09-14 10:19:53 UTC","environments":[],"repositories":[{"id":32,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[{"id":19,"name":"Test
-        Content View 1.0","content_view_id":31,"version":"1.0","environments":[{"id":13,"name":"Library","label":"Library"}],"content_view":{"id":31,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0"},"repositories":[{"id":32,"name":"Test
-        Repository","label":"Test_Repository","description":null}]}],"content_view_components":[{"latest":false,"id":6,"created_at":"2020-09-14
-        10:19:50 UTC","updated_at":"2020-09-14 10:19:50 UTC","composite_content_view":{"id":32,"name":"Test
-        Composite Content View","label":"Test_Composite_Content_View","description":null,"next_version":1,"latest_version":null,"version_count":0},"content_view":{"id":31,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0","version_count":1},"content_view_version":{"id":19,"name":"Test
-        Content View 1.0","content_view_id":31,"version":"1.0","content_view":{"id":31,"name":"Test
-        Content View","label":"Test_Content_View","description":null},"environments":[{"id":13,"name":"Library","label":"Library"}],"repositories":[{"id":32,"name":"Test
-        Repository","label":"Test_Repository","description":null}]}}],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
+      string: '{"total":3,"subtotal":1,"selectable":1,"page":1,"per_page":4294967296,"error":null,"search":"name=\"Test
+        Composite Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":true,"rolling":false,"component_ids":[3],"duplicate_repositories_to_publish":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":true,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":1,"related_composite_cvs":[],"filtered":false,"needs_publish":true,"environment_ids":[],"repository_ids":[3],"id":5,"name":"Test
+        Composite Content View","label":"Test_Composite_Content_View","description":null,"organization_id":3,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":3},"created_at":"2025-07-11
+        15:22:26 UTC","updated_at":"2025-07-11 15:22:30 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":3,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"versions":[],"components":[{"id":3,"name":"Test
+        Content View 1.0","content_view_id":4,"version":"1.0","environments":[{"id":2,"name":"Library","label":"Library"}],"content_view":{"id":4,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0"},"repositories":[{"id":3,"name":"Test
+        Repository","label":"Test_Repository","description":null}]}],"content_view_components":[{"latest":false,"id":1,"created_at":"2025-07-11
+        15:22:27 UTC","updated_at":"2025-07-11 15:22:27 UTC","composite_content_view":{"id":5,"name":"Test
+        Composite Content View","label":"Test_Composite_Content_View","description":null,"next_version":1,"latest_version":null,"version_count":0},"content_view":{"id":4,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0","version_count":1},"content_view_version":{"id":3,"name":"Test
+        Content View 1.0","content_view_id":4,"version":"1.0","content_view":{"id":4,"name":"Test
+        Content View","label":"Test_Content_View","description":null},"environments":[{"id":2,"name":"Library","label":"Library"}],"repositories":[{"id":3,"name":"Test
+        Repository","label":"Test_Repository","description":null}]},"component_content_view_versions":[{"id":3,"version":"1.0","description":null,"published_at_words":"less
+        than a minute"}]}],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
 
         '
     headers:
@@ -153,10 +153,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '2438'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -164,27 +162,29 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 14; Test Organization
+      - 3; Test Organization
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=98
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '2248'
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
@@ -200,23 +200,24 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/32
+    uri: https://foreman.example.org/katello/api/content_views/5
   response:
     body:
-      string: '  {"content_host_count":0,"composite":true,"component_ids":[19],"default":false,"force_puppet_environment":false,"version_count":0,"latest_version":null,"auto_publish":true,"solve_dependencies":false,"repository_ids":[32],"id":32,"name":"Test
-        Composite Content View","label":"Test_Composite_Content_View","description":null,"organization_id":14,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":14},"created_at":"2020-09-14
-        10:19:50 UTC","updated_at":"2020-09-14 10:19:53 UTC","environments":[],"repositories":[{"id":32,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[],"components":[{"id":19,"name":"Test
-        Content View 1.0","content_view_id":31,"version":"1.0","environments":[{"id":13,"name":"Library","label":"Library"}],"content_view":{"id":31,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0"},"repositories":[{"id":32,"name":"Test
-        Repository","label":"Test_Repository","description":null}]}],"content_view_components":[{"latest":false,"id":6,"created_at":"2020-09-14
-        10:19:50 UTC","updated_at":"2020-09-14 10:19:50 UTC","composite_content_view":{"id":32,"name":"Test
-        Composite Content View","label":"Test_Composite_Content_View","description":null,"next_version":1,"latest_version":null,"version_count":0},"content_view":{"id":31,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0","version_count":1},"content_view_version":{"id":19,"name":"Test
-        Content View 1.0","content_view_id":31,"version":"1.0","content_view":{"id":31,"name":"Test
-        Content View","label":"Test_Content_View","description":null},"environments":[{"id":13,"name":"Library","label":"Library"}],"repositories":[{"id":32,"name":"Test
-        Repository","label":"Test_Repository","description":null}]}}],"activation_keys":[],"next_version":"1.0","last_published":null,"permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true},"duplicate_repositories_to_publish":[]}
+      string: '  {"content_host_count":0,"composite":true,"rolling":false,"component_ids":[3],"duplicate_repositories_to_publish":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":true,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":1,"related_composite_cvs":[],"filtered":false,"needs_publish":true,"environment_ids":[],"repository_ids":[3],"id":5,"name":"Test
+        Composite Content View","label":"Test_Composite_Content_View","description":null,"organization_id":3,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":3},"created_at":"2025-07-11
+        15:22:26 UTC","updated_at":"2025-07-11 15:22:30 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":3,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"versions":[],"components":[{"id":3,"name":"Test
+        Content View 1.0","content_view_id":4,"version":"1.0","environments":[{"id":2,"name":"Library","label":"Library"}],"content_view":{"id":4,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0"},"repositories":[{"id":3,"name":"Test
+        Repository","label":"Test_Repository","description":null}]}],"content_view_components":[{"latest":false,"id":1,"created_at":"2025-07-11
+        15:22:27 UTC","updated_at":"2025-07-11 15:22:27 UTC","composite_content_view":{"id":5,"name":"Test
+        Composite Content View","label":"Test_Composite_Content_View","description":null,"next_version":1,"latest_version":null,"version_count":0},"content_view":{"id":4,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"next_version":2,"latest_version":"1.0","version_count":1},"content_view_version":{"id":3,"name":"Test
+        Content View 1.0","content_view_id":4,"version":"1.0","content_view":{"id":4,"name":"Test
+        Content View","label":"Test_Content_View","description":null},"environments":[{"id":2,"name":"Library","label":"Library"}],"repositories":[{"id":3,"name":"Test
+        Repository","label":"Test_Repository","description":null}]},"component_content_view_versions":[{"id":3,"version":"1.0","description":null,"published_at_words":"less
+        than a minute"}]}],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[],"errors":null}
 
         '
     headers:
@@ -224,10 +225,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '2298'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -237,25 +236,27 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=97
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '2146'
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
@@ -271,17 +272,20 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/14/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/3/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
   response:
     body:
-      string: '{"total":3,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":1,"latest_version":"1.0","auto_publish":false,"solve_dependencies":false,"repository_ids":[30],"id":31,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":14,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":14},"created_at":"2020-09-14
-        10:19:43 UTC","updated_at":"2020-09-14 10:19:44 UTC","environments":[{"id":13,"name":"Library","label":"Library","permissions":{"readable":true}}],"repositories":[{"id":30,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[{"id":19,"version":"1.0","published":"2020-09-14
-        10:19:44 UTC","environment_ids":[13]}],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"2.0","last_published":"2020-09-14
-        10:19:44 UTC","permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true}}]}
+      string: '{"total":3,"subtotal":1,"selectable":1,"page":1,"per_page":4294967296,"error":null,"search":"name=\"Test
+        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"rolling":false,"component_ids":[],"duplicate_repositories_to_publish":[],"default":false,"version_count":1,"latest_version":"1.0","latest_version_id":3,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":1,"related_composite_cvs":[{"id":5,"name":"Test
+        Composite Content View"}],"filtered":false,"needs_publish":false,"environment_ids":[2],"repository_ids":[1],"id":4,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":3,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":3},"created_at":"2025-07-11
+        15:22:18 UTC","updated_at":"2025-07-11 15:22:20 UTC","last_task":{"id":"6f661932-5bdd-4f8f-a521-f5875e5339f4","started_at":"2025-07-11
+        15:22:19 UTC","result":"success","last_sync_words":"less than a minute"},"latest_version_environments":[{"id":2,"name":"Library","label":"Library"}],"repositories":[{"id":1,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"versions":[{"id":3,"version":"1.0","published":"2025-07-11
+        15:22:20 UTC","description":null,"environment_ids":[2],"filters_applied":false,"published_at_words":"less
+        than a minute"}],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"2.0","last_published":"2025-07-11
+        15:22:20 UTC","environments":[{"id":2,"label":"Library","name":"Library","activation_keys":[],"hosts":[],"permissions":{"readable":true}}]}]}
 
         '
     headers:
@@ -289,10 +293,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '1644'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -300,27 +302,29 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 14; Test Organization
+      - 3; Test Organization
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=96
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '1224'
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
@@ -336,16 +340,19 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/31
+    uri: https://foreman.example.org/katello/api/content_views/4
   response:
     body:
-      string: '  {"content_host_count":0,"composite":false,"component_ids":[],"default":false,"force_puppet_environment":false,"version_count":1,"latest_version":"1.0","auto_publish":false,"solve_dependencies":false,"repository_ids":[30],"id":31,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":14,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":14},"created_at":"2020-09-14
-        10:19:43 UTC","updated_at":"2020-09-14 10:19:44 UTC","environments":[{"id":13,"name":"Library","label":"Library","permissions":{"readable":true}}],"repositories":[{"id":30,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"puppet_modules":[],"versions":[{"id":19,"version":"1.0","published":"2020-09-14
-        10:19:44 UTC","environment_ids":[13]}],"components":[],"content_view_components":[],"activation_keys":[],"next_version":"2.0","last_published":"2020-09-14
-        10:19:44 UTC","permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true},"duplicate_repositories_to_publish":[]}
+      string: '  {"content_host_count":0,"composite":false,"rolling":false,"component_ids":[],"duplicate_repositories_to_publish":[],"default":false,"version_count":1,"latest_version":"1.0","latest_version_id":3,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":1,"related_composite_cvs":[{"id":5,"name":"Test
+        Composite Content View"}],"filtered":false,"needs_publish":false,"environment_ids":[2],"repository_ids":[1],"id":4,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":3,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":3},"created_at":"2025-07-11
+        15:22:18 UTC","updated_at":"2025-07-11 15:22:20 UTC","last_task":{"id":"6f661932-5bdd-4f8f-a521-f5875e5339f4","started_at":"2025-07-11
+        15:22:19 UTC","result":"success","last_sync_words":"less than a minute"},"latest_version_environments":[{"id":2,"name":"Library","label":"Library"}],"repositories":[{"id":1,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"versions":[{"id":3,"version":"1.0","published":"2025-07-11
+        15:22:20 UTC","description":null,"environment_ids":[2],"filters_applied":false,"published_at_words":"less
+        than a minute"}],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"2.0","last_published":"2025-07-11
+        15:22:20 UTC","environments":[{"id":2,"label":"Library","name":"Library","activation_keys":[],"hosts":[],"permissions":{"readable":true}}],"errors":null}
 
         '
     headers:
@@ -353,10 +360,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '1514'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -366,25 +371,27 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=95
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '1132'
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
@@ -400,23 +407,24 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_view_versions?search=content_view_id%3D31%2Cversion%3D1.0&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_view_versions?search=content_view_id%3D4%2Cversion%3D1.0&per_page=4294967296
   response:
     body:
-      string: '{"total":4,"subtotal":1,"page":1,"per_page":"4294967296","error":null,"search":"content_view_id=31,version=1.0","sort":{"by":"version","order":"desc"},"results":[{"version":"1.0","major":1,"minor":0,"composite_content_view_ids":[32],"published_in_composite_content_view_ids":[],"content_view_id":31,"default":false,"description":null,"id":19,"name":"Test
-        Content View 1.0","created_at":"2020-09-14 10:19:44 UTC","updated_at":"2020-09-14
-        10:19:47 UTC","content_view":{"id":31,"name":"Test Content View","label":"Test_Content_View"},"composite_content_views":[{"id":32,"name":"Test
-        Composite Content View","label":"Test_Composite_Content_View"}],"composite_content_view_versions":[],"published_in_composite_content_views":[],"environments":[{"id":13,"name":"Library","label":"Library","puppet_environment_id":null,"permissions":{"readable":true,"promotable_or_removable":true,"all_hosts_editable":true,"all_keys_editable":true},"host_count":0,"activation_key_count":0}],"repositories":[{"id":32,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum","library_instance_id":30}],"last_event":{"user":"admin","status":"successful","description":null,"action":"publish","created_at":"2020-09-14
-        10:19:44 UTC","updated_at":"2020-09-14 10:19:47 UTC","environment":null,"task":{"id":"dce95aeb-7d0d-49d1-829f-8c263c4bbc47","label":"Actions::Katello::ContentView::Publish","pending":false,"action":"Publish
-        content view ''Test Content View''; organization ''Test Organization''","username":"admin","started_at":"2020-09-14
-        10:19:44 UTC","ended_at":"2020-09-14 10:19:47 UTC","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":31,"name":"Test
-        Content View","label":"Test_Content_View"},"organization":{"id":14,"name":"Test
-        Organization","label":"Test_Organization"},"services_checked":["candlepin","candlepin_auth","pulp3","pulp","pulp_auth"],"history_id":24,"content_view_id":31,"auto_publish_composite_ids":[],"content_view_version_name":"Test
-        Content View 1.0","content_view_version_id":19,"environment_id":13,"user_id":4,"skip_promotion":null,"current_request_id":null,"current_timezone":"UTC","current_user_id":4,"current_organization_id":null,"current_location_id":null},"output":{"content_view_id":31,"content_view_version_id":19,"skip_promotion":null},"humanized":{"action":"Publish","input":[["content_view",{"text":"content
-        view ''Test Content View''","link":"/content_views/31/versions"}],["organization",{"text":"organization
-        ''Test Organization''","link":"/organizations/14/edit"}]],"output":"","errors":[]},"cli_example":null,"start_at":"2020-09-14
-        10:19:44 UTC","available_actions":{"cancellable":false,"resumable":false}},"version":"1.0","publish":true,"version_id":19,"triggered_by":null,"triggered_by_id":null},"active_history":[],"deb_count":0,"docker_manifest_count":0,"docker_manifest_list_count":0,"docker_tag_count":0,"file_count":0,"puppet_module_count":0,"rpm_count":0,"modulemd_count":0,"erratum_count":0,"package_group_count":0,"srpm_count":0,"module_stream_count":0,"package_count":0,"ostree_branch_count":null,"errata_counts":{"security":null,"bugfix":0,"enhancement":0,"total":null},"permissions":{"deletable":true}}]}
+      string: '{"total":3,"subtotal":1,"selectable":1,"page":1,"per_page":4294967296,"error":null,"search":"content_view_id=4,version=1.0","sort":{"by":"version","order":"desc"},"results":[{"version":"1.0","major":1,"minor":0,"composite_content_view_ids":[5],"published_in_composite_content_view_ids":[],"content_view_id":4,"default":false,"description":null,"id":3,"name":"Test
+        Content View 1.0","created_at":"2025-07-11 15:22:20 UTC","updated_at":"2025-07-11
+        15:22:23 UTC","content_view":{"id":4,"name":"Test Content View","label":"Test_Content_View","generated_for":"none"},"composite_content_views":[{"id":5,"name":"Test
+        Composite Content View","label":"Test_Composite_Content_View"}],"composite_content_view_versions":[],"published_in_composite_content_views":[],"content_view_environments":[{"label":"Library/Test_Content_View","environment_id":2,"environment_name":"Library"}],"environments":[{"id":2,"name":"Library","label":"Library","publish_date":"less
+        than a minute","permissions":{"readable":true,"promotable_or_removable":true,"all_hosts_editable":true,"all_keys_editable":true},"host_count":0,"multi_env_host_count":0,"activation_key_count":0,"multi_env_ak_count":0}],"repositories":[{"id":3,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum","library_instance_id":1,"mirroring_policy":"mirror_content_only"}],"last_event":{"user":"admin","status":"successful","description":null,"action":"publish","created_at":"2025-07-11
+        15:22:20 UTC","updated_at":"2025-07-11 15:22:23 UTC","environment":null,"task":{"id":"6f661932-5bdd-4f8f-a521-f5875e5339f4","label":"Actions::Katello::ContentView::Publish","pending":false,"action":"Publish
+        content view ''Test Content View''; organization ''Test Organization''","username":"admin","started_at":"2025-07-11
+        15:22:19 UTC","ended_at":"2025-07-11 15:22:23 UTC","state":"stopped","result":"success","progress":1.0,"input":{"content_view":{"id":4,"name":"Test
+        Content View","label":"Test_Content_View"},"organization":{"id":3,"name":"Test
+        Organization","label":"Test_Organization"},"services_checked":["pulp3","candlepin","candlepin_auth"],"history_id":1,"content_view_id":4,"auto_publish_composite_ids":[],"content_view_version_name":"Test
+        Content View 1.0","content_view_version_id":3,"environment_id":2,"user_id":4,"skip_promotion":null,"current_request_id":"5d8b36e2-b73a-497e-a358-9fc98cabdad2","current_timezone":"UTC","current_organization_id":null,"current_location_id":null,"current_user_id":4},"output":{"content_view_id":4,"content_view_version_id":3,"skip_promotion":null,"history_id":1},"humanized":{"action":"Publish","input":[["content_view",{"text":"content
+        view ''Test Content View''","link":"/content_views/4/versions"}],["organization",{"text":"organization
+        ''Test Organization''","link":"/organizations/3/edit"}]],"output":"","errors":[]},"cli_example":null,"start_at":"2025-07-11
+        15:22:19 UTC","available_actions":{"cancellable":false,"resumable":false}},"version":"1.0","publish":true,"version_id":3,"triggered_by":null,"triggered_by_id":null},"active_history":[],"rpm_count":0,"modulemd_count":0,"erratum_count":0,"package_group_count":0,"srpm_count":0,"ansible_collection_count":0,"deb_count":0,"docker_manifest_count":0,"docker_manifest_list_count":0,"docker_tag_count":0,"file_count":0,"python_package_count":0,"module_stream_count":0,"package_count":0,"component_view_count":0,"ansible_collection_repository_count":0,"deb_repository_count":0,"docker_repository_count":0,"file_repository_count":0,"python_repository_count":0,"yum_repository_count":1,"errata_counts":{"security":0,"bugfix":0,"enhancement":0,"total":0},"permissions":{"deletable":true},"filters_applied":false}]}
 
         '
     headers:
@@ -424,10 +432,8 @@ interactions:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      Content-Length:
+      - '3652'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -437,25 +443,27 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 2.1.2
+      - 3.16.0-develop
       Keep-Alive:
       - timeout=15, max=94
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '3176'
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/content_views_role-0.yml
+++ b/tests/test_playbooks/fixtures/content_views_role-0.yml
@@ -14,18 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"3.7.1","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.17.0-develop","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
       Content-Length:
-      - '62'
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      - '71'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -35,21 +31,27 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.7.1
+      - 3.17.0-develop
       Keep-Alive:
       - timeout=15, max=100
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
@@ -70,8 +72,8 @@ interactions:
     body:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-11-15
-        10:37:36 UTC\",\"updated_at\":\"2023-11-15 10:37:38 UTC\",\"id\":6,\"name\":\"Test
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2025-09-10
+        16:29:02 UTC\",\"updated_at\":\"2025-09-10 16:29:07 UTC\",\"id\":3,\"name\":\"Test
         Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
@@ -80,10 +82,6 @@ interactions:
       - Keep-Alive
       Content-Length:
       - '388'
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -93,21 +91,27 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.7.1
+      - 3.17.0-develop
       Keep-Alive:
       - timeout=15, max=99
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
@@ -123,10 +127,10 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/6/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/3/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
   response:
     body:
-      string: '{"total":1,"subtotal":0,"selectable":0,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+      string: '{"total":1,"subtotal":0,"selectable":0,"page":1,"per_page":4294967296,"error":null,"search":"name=\"Test
         Content View\"","sort":{"by":"name","order":"asc"},"results":[]}
 
         '
@@ -136,11 +140,7 @@ interactions:
       Connection:
       - Keep-Alive
       Content-Length:
-      - '172'
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      - '170'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -148,23 +148,29 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 6; Test Organization
+      - 3; Test Organization
       Foreman_version:
-      - 3.7.1
+      - 3.17.0-develop
       Keep-Alive:
       - timeout=15, max=98
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
@@ -180,14 +186,13 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/6/products?search=name%3D%22Test+Product%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/3/products?search=name%3D%22Test+Product%22&per_page=4294967296
   response:
     body:
-      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Product\"","sort":{"by":"name","order":"asc"},"results":[{"id":11,"cp_id":"505037285537","name":"Test
-        Product","label":"Test_Product","description":"A happy little test product","provider_id":9,"sync_plan_id":null,"sync_summary":{},"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"sync_state":null,"last_sync":"2023-11-15
-        10:37:41 UTC","last_sync_words":"less than a minute","organization_id":6,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":6},"sync_plan":null,"repository_count":1}]}
+      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":4294967296,"error":null,"search":"name=\"Test
+        Product\"","sort":{"by":"name","order":"asc"},"results":[{"id":1,"cp_id":"924755210160","name":"Test
+        Product","label":"Test_Product","description":"A happy little test product","provider_id":3,"sync_plan_id":null,"sync_summary":{},"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"sync_state":null,"last_sync":null,"last_sync_words":null,"organization_id":3,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":3},"sync_plan":null,"repository_count":1}]}
 
         '
     headers:
@@ -196,11 +201,7 @@ interactions:
       Connection:
       - Keep-Alive
       Content-Length:
-      - '665'
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      - '625'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -208,23 +209,29 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 6; Test Organization
+      - 3; Test Organization
       Foreman_version:
-      - 3.7.1
+      - 3.17.0-develop
       Keep-Alive:
       - timeout=15, max=97
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
@@ -240,14 +247,15 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/products/11/repositories?search=name%3D%22Test+Repository%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/products/1/repositories?search=name%3D%22Test+Repository%22&per_page=4294967296
   response:
     body:
-      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Repository\"","sort":{"by":"name","order":"asc"},"results":[{"backend_identifier":"09e11185-2b92-425a-b437-018bbd8a82df","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"https://centos8-stream-katello-4-9.tanso.example.com/pulp/content/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"version_href":"/pulp/api/v3/repositories/rpm/rpm/e202e2e5-779d-4b44-adc4-e554320b0b05/versions/0/","remote_href":null,"publication_href":"/pulp/api/v3/publications/rpm/rpm/8d8c3f21-95de-4bc1-90d9-cc98d88fd471/","content_counts":{"rpm":0,"erratum":0,"package_group":0,"srpm":0,"module_stream":0},"mirroring_policy":"mirror_content_only","id":21,"name":"Test
-        Repository","label":"Test_Repository","description":null,"content_view_versions":[],"filters":[],"last_sync":null,"content_view":{"id":11,"name":"Default
-        Organization View"},"content_view_version":{"id":9,"name":"Default Organization
-        View 1.0","content_view_id":11},"kt_environment":{"id":5,"name":"Library"},"content_type":"yum","url":null,"arch":"noarch","os_versions":[],"content_id":"1700044660581","generic_remote_options":null,"major":null,"minor":null,"product":{"id":11,"cp_id":"505037285537","name":"Test
+      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":4294967296,"error":null,"search":"name=\"Test
+        Repository\"","sort":{"by":"name","order":"asc"},"results":[{"backend_identifier":"e8540c22-fe57-4e8d-83dc-f53f9659f5dc","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"https://almalinux9-katello-nightly.example.com/pulp/content/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"full_gpg_key_path":null,"version_href":"/pulp/api/v3/repositories/rpm/rpm/01993475-b64b-7e08-a95e-8b24604fa2aa/versions/0/","remote_href":null,"publication_href":"/pulp/api/v3/publications/rpm/rpm/01993475-bbaf-7725-82b5-62969af3cb19/","content_counts":{"rpm":0,"erratum":0,"package_group":0,"srpm":0,"module_stream":0},"mirroring_policy":"mirror_content_only","id":1,"name":"Test
+        Repository","label":"Test_Repository","description":null,"organization_id":3,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":3},"content_view_versions":[],"filters":[],"last_sync":null,"content_view":{"id":2,"name":"Default
+        Organization View"},"content_view_version":{"id":2,"name":"Default Organization
+        View 1.0","content_view_id":2},"kt_environment":{"id":2,"name":"Library"},"content_type":"yum","url":null,"docker_upstream_name":null,"arch":"noarch","os_versions":[],"content_id":"1757521753961","generic_remote_options":null,"major":null,"minor":null,"product":{"id":1,"cp_id":"924755210160","name":"Test
         Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","last_sync_words":null}],"org_repository_count":1}
 
         '
@@ -257,11 +265,7 @@ interactions:
       Connection:
       - Keep-Alive
       Content-Length:
-      - '1558'
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      - '1698'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -271,27 +275,33 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.7.1
+      - 3.17.0-develop
       Keep-Alive:
       - timeout=15, max=96
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"name": "Test Content View", "composite": false, "repository_ids": [21],
-      "auto_publish": false}'
+    body: '{"name": "Test Content View", "composite": false, "rolling": false, "repository_ids":
+      [1], "auto_publish": false}'
     headers:
       Accept:
       - application/json;version=2
@@ -300,20 +310,20 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '96'
+      - '113'
       Content-Type:
       - application/json
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: POST
-    uri: https://foreman.example.org/katello/api/organizations/6/content_views
+    uri: https://foreman.example.org/katello/api/organizations/3/content_views
   response:
     body:
-      string: '  {"content_host_count":0,"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":false,"repository_ids":[21],"id":12,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":6,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":6},"created_at":"2023-11-15
-        10:37:43 UTC","updated_at":"2023-11-15 10:37:43 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":21,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[],"duplicate_repositories_to_publish":[],"errors":null}
+      string: '  {"content_host_count":0,"composite":false,"rolling":false,"component_ids":[],"duplicate_repositories_to_publish":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"filtered":false,"needs_publish":true,"environment_ids":[],"repository_ids":[1],"id":3,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":3,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":3},"created_at":"2025-09-10
+        16:29:19 UTC","updated_at":"2025-09-10 16:29:19 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":1,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[],"errors":null}
 
         '
     headers:
@@ -322,11 +332,7 @@ interactions:
       Connection:
       - Keep-Alive
       Content-Length:
-      - '957'
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      - '991'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -334,23 +340,29 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 6; Test Organization
+      - 3; Test Organization
       Foreman_version:
-      - 3.7.1
+      - 3.17.0-develop
       Keep-Alive:
       - timeout=15, max=95
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
+      x-xss-protection:
+      - '0'
     status:
       code: 201
       message: Created

--- a/tests/test_playbooks/fixtures/content_views_role-1.yml
+++ b/tests/test_playbooks/fixtures/content_views_role-1.yml
@@ -14,18 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"3.7.1","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.17.0-develop","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
       Content-Length:
-      - '62'
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      - '71'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -35,21 +31,27 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.7.1
+      - 3.17.0-develop
       Keep-Alive:
       - timeout=15, max=100
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
@@ -70,8 +72,8 @@ interactions:
     body:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-11-15
-        10:37:36 UTC\",\"updated_at\":\"2023-11-15 10:37:38 UTC\",\"id\":6,\"name\":\"Test
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2025-09-10
+        16:29:02 UTC\",\"updated_at\":\"2025-09-10 16:29:07 UTC\",\"id\":3,\"name\":\"Test
         Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
@@ -80,10 +82,6 @@ interactions:
       - Keep-Alive
       Content-Length:
       - '388'
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -93,21 +91,27 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.7.1
+      - 3.17.0-develop
       Keep-Alive:
       - timeout=15, max=99
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
@@ -123,10 +127,10 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/6/content_views?search=name%3D%22Test+Composite+Content+View%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/3/content_views?search=name%3D%22Test+Composite+Content+View%22&per_page=4294967296
   response:
     body:
-      string: '{"total":2,"subtotal":0,"selectable":0,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+      string: '{"total":2,"subtotal":0,"selectable":0,"page":1,"per_page":4294967296,"error":null,"search":"name=\"Test
         Composite Content View\"","sort":{"by":"name","order":"asc"},"results":[]}
 
         '
@@ -136,11 +140,7 @@ interactions:
       Connection:
       - Keep-Alive
       Content-Length:
-      - '182'
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      - '180'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -148,29 +148,35 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 6; Test Organization
+      - 3; Test Organization
       Foreman_version:
-      - 3.7.1
+      - 3.17.0-develop
       Keep-Alive:
       - timeout=15, max=98
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"name": "Test Composite Content View", "composite": true, "auto_publish":
-      false}'
+    body: '{"name": "Test Composite Content View", "composite": true, "rolling": false,
+      "auto_publish": false}'
     headers:
       Accept:
       - application/json;version=2
@@ -179,19 +185,19 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '81'
+      - '99'
       Content-Type:
       - application/json
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: POST
-    uri: https://foreman.example.org/katello/api/organizations/6/content_views
+    uri: https://foreman.example.org/katello/api/organizations/3/content_views
   response:
     body:
-      string: '  {"content_host_count":0,"composite":true,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":false,"repository_ids":[],"id":13,"name":"Test
-        Composite Content View","label":"Test_Composite_Content_View","description":null,"organization_id":6,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":6},"created_at":"2023-11-15
-        10:37:43 UTC","updated_at":"2023-11-15 10:37:43 UTC","last_task":null,"latest_version_environments":[],"repositories":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[],"duplicate_repositories_to_publish":[],"errors":null}
+      string: '  {"content_host_count":0,"composite":true,"rolling":false,"component_ids":[],"duplicate_repositories_to_publish":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"filtered":false,"needs_publish":true,"environment_ids":[],"repository_ids":[],"id":4,"name":"Test
+        Composite Content View","label":"Test_Composite_Content_View","description":null,"organization_id":3,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":3},"created_at":"2025-09-10
+        16:29:21 UTC","updated_at":"2025-09-10 16:29:21 UTC","last_task":null,"latest_version_environments":[],"repositories":[],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[],"errors":null}
 
         '
     headers:
@@ -200,11 +206,7 @@ interactions:
       Connection:
       - Keep-Alive
       Content-Length:
-      - '893'
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      - '929'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -212,23 +214,29 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 6; Test Organization
+      - 3; Test Organization
       Foreman_version:
-      - 3.7.1
+      - 3.17.0-develop
       Keep-Alive:
       - timeout=15, max=97
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
+      x-xss-protection:
+      - '0'
     status:
       code: 201
       message: Created
@@ -244,14 +252,14 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/6/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/3/content_views?search=name%3D%22Test+Content+View%22&per_page=4294967296
   response:
     body:
-      string: '{"total":3,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":false,"repository_ids":[21],"id":12,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":6,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":6},"created_at":"2023-11-15
-        10:37:43 UTC","updated_at":"2023-11-15 10:37:43 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":21,"name":"Test
+      string: '{"total":3,"subtotal":1,"selectable":1,"page":1,"per_page":4294967296,"error":null,"search":"name=\"Test
+        Content View\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"rolling":false,"component_ids":[],"duplicate_repositories_to_publish":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"filtered":false,"needs_publish":true,"environment_ids":[],"repository_ids":[1],"id":3,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":3,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":3},"created_at":"2025-09-10
+        16:29:19 UTC","updated_at":"2025-09-10 16:29:19 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":1,"name":"Test
         Repository","label":"Test_Repository","content_type":"yum"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
 
         '
@@ -261,11 +269,7 @@ interactions:
       Connection:
       - Keep-Alive
       Content-Length:
-      - '1050'
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      - '1121'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -273,23 +277,29 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 6; Test Organization
+      - 3; Test Organization
       Foreman_version:
-      - 3.7.1
+      - 3.17.0-develop
       Keep-Alive:
       - timeout=15, max=96
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
@@ -305,14 +315,14 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/12
+    uri: https://foreman.example.org/katello/api/content_views/3
   response:
     body:
-      string: '  {"content_host_count":0,"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":false,"repository_ids":[21],"id":12,"name":"Test
-        Content View","label":"Test_Content_View","description":null,"organization_id":6,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":6},"created_at":"2023-11-15
-        10:37:43 UTC","updated_at":"2023-11-15 10:37:43 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":21,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[],"duplicate_repositories_to_publish":[],"errors":null}
+      string: '  {"content_host_count":0,"composite":false,"rolling":false,"component_ids":[],"duplicate_repositories_to_publish":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"filtered":false,"needs_publish":true,"environment_ids":[],"repository_ids":[1],"id":3,"name":"Test
+        Content View","label":"Test_Content_View","description":null,"organization_id":3,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":3},"created_at":"2025-09-10
+        16:29:19 UTC","updated_at":"2025-09-10 16:29:19 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":1,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[],"errors":null}
 
         '
     headers:
@@ -321,11 +331,7 @@ interactions:
       Connection:
       - Keep-Alive
       Content-Length:
-      - '957'
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      - '991'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -335,26 +341,32 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.7.1
+      - 3.17.0-develop
       Keep-Alive:
       - timeout=15, max=95
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"components": [{"latest": true, "content_view_id": 12}]}'
+    body: '{"components": [{"latest": true, "content_view_id": 3}]}'
     headers:
       Accept:
       - application/json;version=2
@@ -363,18 +375,18 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '57'
+      - '56'
       Content-Type:
       - application/json
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: PUT
-    uri: https://foreman.example.org/katello/api/content_views/13/content_view_components/add
+    uri: https://foreman.example.org/katello/api/content_views/4/content_view_components/add
   response:
     body:
-      string: '{"total":1,"subtotal":1,"selectable":1,"page":null,"per_page":null,"error":null,"search":null,"sort":{"by":null,"order":null},"results":[{"latest":true,"id":1,"created_at":"2023-11-15
-        10:37:43 UTC","updated_at":"2023-11-15 10:37:43 UTC","composite_content_view":{"id":13,"name":"Test
-        Composite Content View","label":"Test_Composite_Content_View","description":null,"next_version":1,"latest_version":null,"version_count":0},"content_view":{"id":12,"name":"Test
+      string: '{"total":1,"subtotal":1,"selectable":1,"page":null,"per_page":null,"error":null,"search":null,"sort":{"by":null,"order":null},"results":[{"latest":true,"id":1,"created_at":"2025-09-10
+        16:29:22 UTC","updated_at":"2025-09-10 16:29:22 UTC","composite_content_view":{"id":4,"name":"Test
+        Composite Content View","label":"Test_Composite_Content_View","description":null,"next_version":1,"latest_version":null,"version_count":0},"content_view":{"id":3,"name":"Test
         Content View","label":"Test_Content_View","description":null,"next_version":1,"latest_version":null,"version_count":0},"content_view_version":null,"component_content_view_versions":[]}]}
 
         '
@@ -384,11 +396,7 @@ interactions:
       Connection:
       - Keep-Alive
       Content-Length:
-      - '647'
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      - '645'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -398,21 +406,27 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.7.1
+      - 3.17.0-develop
       Keep-Alive:
       - timeout=15, max=94
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK

--- a/tests/test_playbooks/fixtures/content_views_role-2.yml
+++ b/tests/test_playbooks/fixtures/content_views_role-2.yml
@@ -14,18 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"3.7.1","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.17.0-develop","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
       Content-Length:
-      - '62'
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      - '71'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -35,21 +31,27 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.7.1
+      - 3.17.0-develop
       Keep-Alive:
       - timeout=15, max=100
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
@@ -70,8 +72,8 @@ interactions:
     body:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-11-15
-        10:37:36 UTC\",\"updated_at\":\"2023-11-15 10:37:38 UTC\",\"id\":6,\"name\":\"Test
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2025-09-10
+        16:29:02 UTC\",\"updated_at\":\"2025-09-10 16:29:07 UTC\",\"id\":3,\"name\":\"Test
         Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
@@ -80,10 +82,6 @@ interactions:
       - Keep-Alive
       Content-Length:
       - '388'
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -93,21 +91,27 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.7.1
+      - 3.17.0-develop
       Keep-Alive:
       - timeout=15, max=99
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
@@ -123,10 +127,10 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/6/content_views?search=name%3D%22Test+Content+View+with+Filter%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/3/content_views?search=name%3D%22Test+Content+View+with+Filter%22&per_page=4294967296
   response:
     body:
-      string: '{"total":3,"subtotal":0,"selectable":0,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+      string: '{"total":3,"subtotal":0,"selectable":0,"page":1,"per_page":4294967296,"error":null,"search":"name=\"Test
         Content View with Filter\"","sort":{"by":"name","order":"asc"},"results":[]}
 
         '
@@ -136,11 +140,7 @@ interactions:
       Connection:
       - Keep-Alive
       Content-Length:
-      - '184'
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      - '182'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -148,23 +148,29 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 6; Test Organization
+      - 3; Test Organization
       Foreman_version:
-      - 3.7.1
+      - 3.17.0-develop
       Keep-Alive:
       - timeout=15, max=98
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
@@ -180,14 +186,13 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/6/products?search=name%3D%22Test+Product%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/3/products?search=name%3D%22Test+Product%22&per_page=4294967296
   response:
     body:
-      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Product\"","sort":{"by":"name","order":"asc"},"results":[{"id":11,"cp_id":"505037285537","name":"Test
-        Product","label":"Test_Product","description":"A happy little test product","provider_id":9,"sync_plan_id":null,"sync_summary":{},"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"sync_state":null,"last_sync":"2023-11-15
-        10:37:41 UTC","last_sync_words":"less than a minute","organization_id":6,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":6},"sync_plan":null,"repository_count":1}]}
+      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":4294967296,"error":null,"search":"name=\"Test
+        Product\"","sort":{"by":"name","order":"asc"},"results":[{"id":1,"cp_id":"924755210160","name":"Test
+        Product","label":"Test_Product","description":"A happy little test product","provider_id":3,"sync_plan_id":null,"sync_summary":{},"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"sync_state":null,"last_sync":null,"last_sync_words":null,"organization_id":3,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":3},"sync_plan":null,"repository_count":1}]}
 
         '
     headers:
@@ -196,11 +201,7 @@ interactions:
       Connection:
       - Keep-Alive
       Content-Length:
-      - '665'
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      - '625'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -208,23 +209,29 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 6; Test Organization
+      - 3; Test Organization
       Foreman_version:
-      - 3.7.1
+      - 3.17.0-develop
       Keep-Alive:
       - timeout=15, max=97
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
@@ -240,14 +247,15 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/products/11/repositories?search=name%3D%22Test+Repository%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/products/1/repositories?search=name%3D%22Test+Repository%22&per_page=4294967296
   response:
     body:
-      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Repository\"","sort":{"by":"name","order":"asc"},"results":[{"backend_identifier":"09e11185-2b92-425a-b437-018bbd8a82df","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"https://centos8-stream-katello-4-9.tanso.example.com/pulp/content/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"version_href":"/pulp/api/v3/repositories/rpm/rpm/e202e2e5-779d-4b44-adc4-e554320b0b05/versions/0/","remote_href":null,"publication_href":"/pulp/api/v3/publications/rpm/rpm/8d8c3f21-95de-4bc1-90d9-cc98d88fd471/","content_counts":{"rpm":0,"erratum":0,"package_group":0,"srpm":0,"module_stream":0},"mirroring_policy":"mirror_content_only","id":21,"name":"Test
-        Repository","label":"Test_Repository","description":null,"content_view_versions":[],"filters":[],"last_sync":null,"content_view":{"id":11,"name":"Default
-        Organization View"},"content_view_version":{"id":9,"name":"Default Organization
-        View 1.0","content_view_id":11},"kt_environment":{"id":5,"name":"Library"},"content_type":"yum","url":null,"arch":"noarch","os_versions":[],"content_id":"1700044660581","generic_remote_options":null,"major":null,"minor":null,"product":{"id":11,"cp_id":"505037285537","name":"Test
+      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":4294967296,"error":null,"search":"name=\"Test
+        Repository\"","sort":{"by":"name","order":"asc"},"results":[{"backend_identifier":"e8540c22-fe57-4e8d-83dc-f53f9659f5dc","relative_path":"Test_Organization/Library/custom/Test_Product/Test_Repository","container_repository_name":null,"full_path":"https://almalinux9-katello-nightly.example.com/pulp/content/Test_Organization/Library/custom/Test_Product/Test_Repository/","library_instance_id":null,"full_gpg_key_path":null,"version_href":"/pulp/api/v3/repositories/rpm/rpm/01993475-b64b-7e08-a95e-8b24604fa2aa/versions/0/","remote_href":null,"publication_href":"/pulp/api/v3/publications/rpm/rpm/01993475-bbaf-7725-82b5-62969af3cb19/","content_counts":{"rpm":0,"erratum":0,"package_group":0,"srpm":0,"module_stream":0},"mirroring_policy":"mirror_content_only","id":1,"name":"Test
+        Repository","label":"Test_Repository","description":null,"organization_id":3,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":3},"content_view_versions":[],"filters":[],"last_sync":null,"content_view":{"id":2,"name":"Default
+        Organization View"},"content_view_version":{"id":2,"name":"Default Organization
+        View 1.0","content_view_id":2},"kt_environment":{"id":2,"name":"Library"},"content_type":"yum","url":null,"docker_upstream_name":null,"arch":"noarch","os_versions":[],"content_id":"1757521753961","generic_remote_options":null,"major":null,"minor":null,"product":{"id":1,"cp_id":"924755210160","name":"Test
         Product","orphaned":false,"redhat":false,"sync_plan":null},"content_label":"Test_Organization_Test_Product_Test_Repository","last_sync_words":null}],"org_repository_count":1}
 
         '
@@ -257,11 +265,7 @@ interactions:
       Connection:
       - Keep-Alive
       Content-Length:
-      - '1558'
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      - '1698'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -271,27 +275,33 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.7.1
+      - 3.17.0-develop
       Keep-Alive:
       - timeout=15, max=96
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"name": "Test Content View with Filter", "composite": false, "repository_ids":
-      [21], "auto_publish": false}'
+    body: '{"name": "Test Content View with Filter", "composite": false, "rolling":
+      false, "repository_ids": [1], "auto_publish": false}'
     headers:
       Accept:
       - application/json;version=2
@@ -300,20 +310,20 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '108'
+      - '125'
       Content-Type:
       - application/json
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: POST
-    uri: https://foreman.example.org/katello/api/organizations/6/content_views
+    uri: https://foreman.example.org/katello/api/organizations/3/content_views
   response:
     body:
-      string: '  {"content_host_count":0,"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":false,"repository_ids":[21],"id":14,"name":"Test
-        Content View with Filter","label":"Test_Content_View_with_Filter","description":null,"organization_id":6,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":6},"created_at":"2023-11-15
-        10:37:44 UTC","updated_at":"2023-11-15 10:37:44 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":21,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[],"duplicate_repositories_to_publish":[],"errors":null}
+      string: '  {"content_host_count":0,"composite":false,"rolling":false,"component_ids":[],"duplicate_repositories_to_publish":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"filtered":false,"needs_publish":true,"environment_ids":[],"repository_ids":[1],"id":5,"name":"Test
+        Content View with Filter","label":"Test_Content_View_with_Filter","description":null,"organization_id":3,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":3},"created_at":"2025-09-10
+        16:29:23 UTC","updated_at":"2025-09-10 16:29:23 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":1,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[],"errors":null}
 
         '
     headers:
@@ -322,11 +332,7 @@ interactions:
       Connection:
       - Keep-Alive
       Content-Length:
-      - '981'
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      - '1015'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -334,23 +340,29 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 6; Test Organization
+      - 3; Test Organization
       Foreman_version:
-      - 3.7.1
+      - 3.17.0-develop
       Keep-Alive:
       - timeout=15, max=95
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
+      x-xss-protection:
+      - '0'
     status:
       code: 201
       message: Created

--- a/tests/test_playbooks/fixtures/content_views_role-3.yml
+++ b/tests/test_playbooks/fixtures/content_views_role-3.yml
@@ -14,18 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"3.7.1","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.17.0-develop","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
       Content-Length:
-      - '62'
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      - '71'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -35,21 +31,27 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.7.1
+      - 3.17.0-develop
       Keep-Alive:
       - timeout=15, max=100
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
@@ -70,8 +72,8 @@ interactions:
     body:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-11-15
-        10:37:36 UTC\",\"updated_at\":\"2023-11-15 10:37:38 UTC\",\"id\":6,\"name\":\"Test
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2025-09-10
+        16:29:02 UTC\",\"updated_at\":\"2025-09-10 16:29:07 UTC\",\"id\":3,\"name\":\"Test
         Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
@@ -80,10 +82,6 @@ interactions:
       - Keep-Alive
       Content-Length:
       - '388'
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -93,21 +91,27 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.7.1
+      - 3.17.0-develop
       Keep-Alive:
       - timeout=15, max=99
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
@@ -123,14 +127,14 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/6/content_views?search=name%3D%22Test+Content+View+with+Filter%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/3/content_views?search=name%3D%22Test+Content+View+with+Filter%22&per_page=4294967296
   response:
     body:
-      string: '{"total":4,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View with Filter\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":false,"repository_ids":[21],"id":14,"name":"Test
-        Content View with Filter","label":"Test_Content_View_with_Filter","description":null,"organization_id":6,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":6},"created_at":"2023-11-15
-        10:37:44 UTC","updated_at":"2023-11-15 10:37:44 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":21,"name":"Test
+      string: '{"total":4,"subtotal":1,"selectable":1,"page":1,"per_page":4294967296,"error":null,"search":"name=\"Test
+        Content View with Filter\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"rolling":false,"component_ids":[],"duplicate_repositories_to_publish":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"filtered":false,"needs_publish":true,"environment_ids":[],"repository_ids":[1],"id":5,"name":"Test
+        Content View with Filter","label":"Test_Content_View_with_Filter","description":null,"organization_id":3,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":3},"created_at":"2025-09-10
+        16:29:23 UTC","updated_at":"2025-09-10 16:29:23 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":1,"name":"Test
         Repository","label":"Test_Repository","content_type":"yum"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
 
         '
@@ -140,11 +144,7 @@ interactions:
       Connection:
       - Keep-Alive
       Content-Length:
-      - '1086'
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      - '1157'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -152,23 +152,29 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 6; Test Organization
+      - 3; Test Organization
       Foreman_version:
-      - 3.7.1
+      - 3.17.0-develop
       Keep-Alive:
       - timeout=15, max=98
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
@@ -184,10 +190,10 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/14/filters?search=name%3D%22Test+Package+Content+View+Filter%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_views/5/filters?search=name%3D%22Test+Package+Content+View+Filter%22&per_page=4294967296
   response:
     body:
-      string: '{"total":0,"subtotal":0,"selectable":0,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
+      string: '{"total":0,"subtotal":0,"selectable":0,"page":1,"per_page":4294967296,"error":null,"search":"name=\"Test
         Package Content View Filter\"","sort":{"by":"name","order":"asc"},"results":[]}
 
         '
@@ -197,11 +203,7 @@ interactions:
       Connection:
       - Keep-Alive
       Content-Length:
-      - '187'
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      - '185'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -211,21 +213,27 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.7.1
+      - 3.17.0-develop
       Keep-Alive:
       - timeout=15, max=97
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
@@ -246,16 +254,16 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: POST
-    uri: https://foreman.example.org/katello/api/content_views/14/filters
+    uri: https://foreman.example.org/katello/api/content_views/5/filters
   response:
     body:
-      string: '  {"inclusion":false,"original_packages":false,"id":15,"name":"Test
-        Package Content View Filter","description":null,"created_at":"2023-11-15 10:37:45
-        UTC","updated_at":"2023-11-15 10:37:45 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[21],"id":14,"name":"Test
-        Content View with Filter","label":"Test_Content_View_with_Filter","description":null,"organization_id":6,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":6},"created_at":"2023-11-15
-        10:37:44 UTC","updated_at":"2023-11-15 10:37:44 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":21,"name":"Test
-        Repository","label":"Test_Repository","content_type":"yum","product":{"id":11,"name":"Test
+      string: '  {"inclusion":false,"original_packages":false,"id":1,"name":"Test
+        Package Content View Filter","description":null,"created_at":"2025-09-10 16:29:25
+        UTC","updated_at":"2025-09-10 16:29:25 UTC","content_view":{"composite":false,"rolling":false,"component_ids":[],"duplicate_repositories_to_publish":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"filtered":true,"needs_publish":true,"environment_ids":[],"repository_ids":[1],"id":5,"name":"Test
+        Content View with Filter","label":"Test_Content_View_with_Filter","description":null,"organization_id":3,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":3},"created_at":"2025-09-10
+        16:29:23 UTC","updated_at":"2025-09-10 16:29:23 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":1,"name":"Test
+        Repository","label":"Test_Repository","content_type":"yum","product":{"id":1,"name":"Test
         Product"},"content_counts":{"docker_manifest":0,"docker_tag":0,"rpm":0,"package":0,"package_group":0,"erratum":0,"module_stream":0}}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"rpm","rules":[]}
 
         '
@@ -265,11 +273,7 @@ interactions:
       Connection:
       - Keep-Alive
       Content-Length:
-      - '1318'
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      - '1389'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -279,21 +283,27 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.7.1
+      - 3.17.0-develop
       Keep-Alive:
       - timeout=15, max=96
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
+      x-xss-protection:
+      - '0'
     status:
       code: 201
       message: Created

--- a/tests/test_playbooks/fixtures/content_views_role-4.yml
+++ b/tests/test_playbooks/fixtures/content_views_role-4.yml
@@ -14,18 +14,14 @@ interactions:
     uri: https://foreman.example.org/api/status
   response:
     body:
-      string: '{"result":"ok","status":200,"version":"3.7.1","api_version":2}'
+      string: '{"result":"ok","status":200,"version":"3.17.0-develop","api_version":2}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - Keep-Alive
       Content-Length:
-      - '62'
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      - '71'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -35,21 +31,27 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.7.1
+      - 3.17.0-develop
       Keep-Alive:
       - timeout=15, max=100
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
@@ -70,8 +72,8 @@ interactions:
     body:
       string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\":
         4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\":
-        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2023-11-15
-        10:37:36 UTC\",\"updated_at\":\"2023-11-15 10:37:38 UTC\",\"id\":6,\"name\":\"Test
+        {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2025-09-10
+        16:29:02 UTC\",\"updated_at\":\"2025-09-10 16:29:07 UTC\",\"id\":3,\"name\":\"Test
         Organization\",\"title\":\"Test Organization\",\"description\":\"A test organization\"}]\n}\n"
     headers:
       Cache-Control:
@@ -80,10 +82,6 @@ interactions:
       - Keep-Alive
       Content-Length:
       - '388'
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -93,21 +91,27 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.7.1
+      - 3.17.0-develop
       Keep-Alive:
       - timeout=15, max=99
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
@@ -123,14 +127,14 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/organizations/6/content_views?search=name%3D%22Test+Content+View+with+Filter%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/3/content_views?search=name%3D%22Test+Content+View+with+Filter%22&per_page=4294967296
   response:
     body:
-      string: '{"total":4,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Content View with Filter\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[21],"id":14,"name":"Test
-        Content View with Filter","label":"Test_Content_View_with_Filter","description":null,"organization_id":6,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":6},"created_at":"2023-11-15
-        10:37:44 UTC","updated_at":"2023-11-15 10:37:44 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":21,"name":"Test
+      string: '{"total":4,"subtotal":1,"selectable":1,"page":1,"per_page":4294967296,"error":null,"search":"name=\"Test
+        Content View with Filter\"","sort":{"by":"name","order":"asc"},"results":[{"composite":false,"rolling":false,"component_ids":[],"duplicate_repositories_to_publish":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"filtered":true,"needs_publish":true,"environment_ids":[],"repository_ids":[1],"id":5,"name":"Test
+        Content View with Filter","label":"Test_Content_View_with_Filter","description":null,"organization_id":3,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":3},"created_at":"2025-09-10
+        16:29:23 UTC","updated_at":"2025-09-10 16:29:23 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":1,"name":"Test
         Repository","label":"Test_Repository","content_type":"yum"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]}]}
 
         '
@@ -140,11 +144,7 @@ interactions:
       Connection:
       - Keep-Alive
       Content-Length:
-      - '1085'
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      - '1156'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -152,23 +152,29 @@ interactions:
       Foreman_current_location:
       - ; ANY
       Foreman_current_organization:
-      - 6; Test Organization
+      - 3; Test Organization
       Foreman_version:
-      - 3.7.1
+      - 3.17.0-develop
       Keep-Alive:
       - timeout=15, max=98
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
@@ -184,16 +190,16 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_views/14/filters?search=name%3D%22Test+Package+Content+View+Filter%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_views/5/filters?search=name%3D%22Test+Package+Content+View+Filter%22&per_page=4294967296
   response:
     body:
-      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test
-        Package Content View Filter\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":15,"name":"Test
-        Package Content View Filter","description":null,"created_at":"2023-11-15 10:37:45
-        UTC","updated_at":"2023-11-15 10:37:45 UTC","content_view":{"composite":false,"component_ids":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"needs_publish":true,"filtered":true,"repository_ids":[21],"id":14,"name":"Test
-        Content View with Filter","label":"Test_Content_View_with_Filter","description":null,"organization_id":6,"organization":{"name":"Test
-        Organization","label":"Test_Organization","id":6},"created_at":"2023-11-15
-        10:37:44 UTC","updated_at":"2023-11-15 10:37:44 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":21,"name":"Test
+      string: '{"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":4294967296,"error":null,"search":"name=\"Test
+        Package Content View Filter\"","sort":{"by":"name","order":"asc"},"results":[{"inclusion":false,"id":1,"name":"Test
+        Package Content View Filter","description":null,"created_at":"2025-09-10 16:29:25
+        UTC","updated_at":"2025-09-10 16:29:25 UTC","content_view":{"composite":false,"rolling":false,"component_ids":[],"duplicate_repositories_to_publish":[],"default":false,"version_count":0,"latest_version":null,"latest_version_id":null,"auto_publish":false,"solve_dependencies":false,"import_only":false,"generated_for":"none","related_cv_count":0,"related_composite_cvs":[],"filtered":true,"needs_publish":true,"environment_ids":[],"repository_ids":[1],"id":5,"name":"Test
+        Content View with Filter","label":"Test_Content_View_with_Filter","description":null,"organization_id":3,"organization":{"name":"Test
+        Organization","label":"Test_Organization","id":3},"created_at":"2025-09-10
+        16:29:23 UTC","updated_at":"2025-09-10 16:29:23 UTC","last_task":null,"latest_version_environments":[],"repositories":[{"id":1,"name":"Test
         Repository","label":"Test_Repository","content_type":"yum"}],"versions":[],"components":[],"content_view_components":[],"activation_keys":[],"hosts":[],"next_version":"1.0","last_published":null,"environments":[]},"repositories":[],"type":"rpm","rules":[]}]}
 
         '
@@ -203,11 +209,7 @@ interactions:
       Connection:
       - Keep-Alive
       Content-Length:
-      - '1312'
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      - '1382'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -217,21 +219,27 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.7.1
+      - 3.17.0-develop
       Keep-Alive:
       - timeout=15, max=97
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
@@ -247,10 +255,10 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/content_view_filters/15/rules?search=name%3D%22bear%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/content_view_filters/1/rules?search=name%3D%22bear%22&per_page=4294967296
   response:
     body:
-      string: '{"total":0,"subtotal":0,"selectable":0,"page":1,"per_page":"4294967296","error":null,"search":"name=\"bear\"","sort":{"by":"id","order":"asc"},"results":[]}
+      string: '{"total":0,"subtotal":0,"selectable":0,"page":1,"per_page":4294967296,"error":null,"search":"name=\"bear\"","sort":{"by":"id","order":"asc"},"results":[]}
 
         '
     headers:
@@ -259,11 +267,7 @@ interactions:
       Connection:
       - Keep-Alive
       Content-Length:
-      - '157'
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      - '155'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -273,21 +277,27 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.7.1
+      - 3.17.0-develop
       Keep-Alive:
       - timeout=15, max=96
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
+      x-xss-protection:
+      - '0'
     status:
       code: 200
       message: OK
@@ -307,11 +317,11 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: POST
-    uri: https://foreman.example.org/katello/api/content_view_filters/15/rules
+    uri: https://foreman.example.org/katello/api/content_view_filters/1/rules
   response:
     body:
-      string: '  {"content_view_filter_id":15,"id":18,"name":"bear","created_at":"2023-11-15
-        10:37:46 UTC","updated_at":"2023-11-15 10:37:46 UTC"}
+      string: '  {"content_view_filter_id":1,"id":1,"name":"bear","created_at":"2025-09-10
+        16:29:27 UTC","updated_at":"2025-09-10 16:29:27 UTC"}
 
         '
     headers:
@@ -320,11 +330,7 @@ interactions:
       Connection:
       - Keep-Alive
       Content-Length:
-      - '132'
-      Content-Security-Policy:
-      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
-        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
-        style-src ''unsafe-inline'' ''self'''
+      - '130'
       Content-Type:
       - application/json; charset=utf-8
       Foreman_api_version:
@@ -334,21 +340,27 @@ interactions:
       Foreman_current_organization:
       - ; ANY
       Foreman_version:
-      - 3.7.1
+      - 3.17.0-develop
       Keep-Alive:
       - timeout=15, max=95
-      Strict-Transport-Security:
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      content-security-policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:;
+        img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self'';
+        style-src ''unsafe-inline'' ''self'''
+      strict-transport-security:
       - max-age=631139040; includeSubdomains
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
+      x-download-options:
       - noopen
-      X-Frame-Options:
+      x-frame-options:
       - sameorigin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      X-XSS-Protection:
-      - 1; mode=block
+      x-xss-protection:
+      - '0'
     status:
       code: 201
       message: Created

--- a/tests/test_playbooks/tasks/content_view.yml
+++ b/tests/test_playbooks/tasks/content_view.yml
@@ -13,6 +13,7 @@
     organization: "{{ organization_name }}"
     repositories: "{{ repositories | default(omit) }}"
     rolling: "{{ rolling | default(omit) }}"
+    lifecycle_environments: "{{ lifecycle_environments | default(omit) }}"
     composite: "{{ composite | default(omit) }}"
     components: "{{ components | default(omit) }}"
     auto_publish: "{{ auto_publish | default(omit) }}"


### PR DESCRIPTION
Add additional parameter to specify lifecycle-environments for rolling Content Views.

Requires https://github.com/Katello/katello/pull/11407

Draft until the Katello PR is merged.