### PR TITLE
ci: exclude markdown changes from triggering full ci

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,10 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - '**/*.md'
+  pull_request:
 
 env:
   COLORTERM: 'yes'


### PR DESCRIPTION
### Change Summary
Currently, the `CI` workflow will run even when a push changes **only markdown files** (e.g., README.md).

With these changes, a push that changes *only* markdown files will not trigger the workflow, thus **speeding up the project's CI** and **saving compute resources** 🌱 (see below for quantity).

### Example
Here is an example of the behaviour described above: the commit [`f909a92`](https://github.com/theforeman/foreman-ansible-modules/commit/f909a92e564cbd241a4afb57db9ec7ba363b8c74) changed these files: `roles/manifest/README.md` and, when pushed, triggered [this](https://github.com/theforeman/foreman-ansible-modules/actions/runs/11054596028) workflow run, which ran for ~2 CPU hours. With the proposed changes, these 2 CPU hours would have been saved, clearing the queue for other workflows and speeding up the CI of the project, while also saving resources in general 🌱. 

Note that this 1 out of 2 examples over the last few months; a lower estimate for the accumulated gain over the last few months is 4 CPU hours, but the actual number could be higher because our cutoff date is late May and our data go only a few months back.

This only affects the `push` trigger and not the `pull_request` trigger, so the actions related to pull requests (opening, pushing new commits on an open PR, closing) will not be affected, only the pushes to branches which do not have an open pull request.


<details>
<summary>Click here to see all the recent CI runs triggered by markdown files.</summary>

[commit f909a92](https://github.com/theforeman/foreman-ansible-modules/commit/f909a92) => [run url](https://github.com/theforeman/foreman-ansible-modules/actions/runs/11054596028)
[commit 5b3c81f](https://github.com/theforeman/foreman-ansible-modules/commit/5b3c81f) => [run url](https://github.com/theforeman/foreman-ansible-modules/actions/runs/9281462043)

</details>

### Context
Hi,

We are a team of [researchers](https://www.ifi.uzh.ch/en/zest.html) from University of Zurich and we are currently working on optimizations in GitHub Actions workflows.

Thanks for your time on this.

Kindly let us know (here or in the email below) if you would like to ignore other file types or apply the filter to other workflows/triggers, or if you have any question whatsoever.

Best regards,  
[Konstantinos Kitsios](https://www.ifi.uzh.ch/en/zest/team/konstantinos_kitsios.html)  
konstantinos.kitsios@uzh.ch