### PR TITLE
activation_key: workaround to ensure LCE and CV are always sent together

### DIFF
--- a/changelogs/fragments/ak-always-send-lce-cv.yml
+++ b/changelogs/fragments/ak-always-send-lce-cv.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - activation_key - ensure LCE and CV are always sent together when updating one of them

--- a/plugins/module_utils/foreman_helper.py
+++ b/plugins/module_utils/foreman_helper.py
@@ -1087,6 +1087,11 @@ class ForemanAnsibleModule(AnsibleModule):
                 payload['lifecycle_environment_id'] = current_flat_entity['lifecycle_environment_id']
             elif 'lifecycle_environment_id' in payload and 'content_view_id' not in payload:
                 payload['content_view_id'] = current_flat_entity['content_view_id']
+        elif resource == 'activation_keys':
+            if 'content_view_id' in payload and 'environment_id' not in payload:
+                payload['environment_id'] = current_flat_entity['environment_id']
+            elif 'environment_id' in payload and 'content_view_id' not in payload:
+                payload['content_view_id'] = current_flat_entity['content_view_id']
         if self._validate_supported_payload(resource, 'update', payload):
             self.set_changed()
             payload['id'] = current_flat_entity['id']


### PR DESCRIPTION
With the introduction of Content View Environments in Katello, you need to either set a CVE or both LCE and CV to update where a host is consuming content from. As we currently don't have a way to correctly set the CVE, this workaround ensures LCE and CV are always sent so that Katello can correctly calculate the CVE for us in the background.