### PR TITLE
Fix idempotency of hostgroup module for child hostgroups.

### DIFF
--- a/changelogs/fragments/hostgroup_idempotency.yml
+++ b/changelogs/fragments/hostgroup_idempotency.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - hostgroup - fix idempotency of hostgroup module when assigning Ansible roles to a hostgroup with a parent hostgroup (https://github.com/theforeman/foreman-ansible-modules/issues/1865)
+...

--- a/plugins/modules/hostgroup.py
+++ b/plugins/modules/hostgroup.py
@@ -198,15 +198,31 @@ def main():
             ensure_puppetclasses(module, 'hostgroup', entity, expected_puppetclasses)
 
         ansible_roles = module_params.get('ansible_roles')
+
+        parent_ansible_role_ids = []
+
         if not module.desired_absent and ansible_roles is not None:
             desired_ansible_role_ids = [item['id'] for item in ansible_roles]
+
+            if entity.get('parent_id') is not None:
+                parent_ansible_role_ids = [
+                    item['id']
+                    for item in module.resource_action(
+                        'hostgroups',
+                        'ansible_roles',
+                        {'id': entity['parent_id']},
+                        ignore_check_mode=True,
+                        record_change=False,
+                    )
+                ]
+
             current_ansible_role_ids = [
                 item['id'] for item in module.resource_action(
                     'hostgroups', 'ansible_roles', {'id': entity['id']},
                     ignore_check_mode=True, record_change=False,
                 )
             ] if old_entity else []
-            if set(current_ansible_role_ids) != set(desired_ansible_role_ids):
+            if set(current_ansible_role_ids) != set(desired_ansible_role_ids + parent_ansible_role_ids):
                 module.resource_action(
                     'hostgroups', 'assign_ansible_roles',
                     {'id': entity['id'], 'ansible_role_ids': desired_ansible_role_ids},


### PR DESCRIPTION
Closes #1865 .

### Description

`theforeman.foreman.hostgroup` was always returning `changed` when using the `ansible_roles` parameter on a child hostgroup. (See the linked issue for a reproducer)

The root cause was that to determine the changed status we were comparing `desired_ansible_role_ids`, which contains only the roles explicitly assigned to the child hostgroup and not the ones inherited from the parent, with `current_ansible_role_ids`, which contains the child-specific as well as the inherited roles.

This led to the status always being `changed`.

### Changes

I have added an `if` condition which expands `desired_ansible_role_ids` to include the parent's roles when necessary.
