### PR TITLE
activation_keys: Fix typo in README

### DIFF
--- a/roles/activation_keys/README.md
+++ b/roles/activation_keys/README.md
@@ -21,7 +21,7 @@ The following fields are required for an activation key but have defaults which 
 The following fields are optional in the sense that the server will use default values when they are omitted:
 
 - `auto_attach`: Auto Attach behavior for the activation key. When true, it will attempt to attach a minimum of subscriptions (from the subset of assigned subscriptions on the activation key; selects from all subscriptions in the organization if none are assigned) to cover any present products on the host. When false, it will attempt to attach all subscriptions assigned on the activation key to the host at registration time. server defaults to true.
-- `unlimited_hosts`: Allow an unlimited number of hosts to register with the activation key when true. When false, the `max_hosts` parameter which sets a numerical limit on the nnumber of hosts that can be registered becomes required. server defaults to true.
+- `unlimited_hosts`: Allow an unlimited number of hosts to register with the activation key when true. When false, the `max_hosts` parameter which sets a numerical limit on the number of hosts that can be registered becomes required. server defaults to true.
 
 The following fields are optional and will be omitted by default:
 


### PR DESCRIPTION
s/nnumber/number/