### PR TITLE
Do not add content view filters rules on specific filters

### DIFF
--- a/roles/content_views/tasks/_create_content_view.yml
+++ b/roles/content_views/tasks/_create_content_view.yml
@@ -54,3 +54,6 @@
     architecture: "{{ item.architecture | default(omit) }}"
     rule_state: "{{ item.rule_state | default(omit) }}"
   loop: "{{ content_view.filters | default([]) }}"
+  when:
+    - not (item.original_packages | default(omit)) | bool
+    - not (item.original_module_streams | default(omit)) | bool


### PR DESCRIPTION
When using original_packages or original_module_streams filters we don't need to add rules.

Fix #1896