### PR TITLE
Use ansible.module_utils.common.text.converters

### DIFF
--- a/plugins/callback/foreman.py
+++ b/plugins/callback/foreman.py
@@ -117,8 +117,8 @@ try:
 except ImportError:
     HAS_REQUESTS = False
 
-from ansible.module_utils._text import to_text
 from ansible.module_utils.common.json import AnsibleJSONEncoder
+from ansible.module_utils.common.text.converters import to_text
 from ansible.module_utils.parsing.convert_bool import boolean as to_bool
 from ansible.plugins.callback import CallbackBase
 

--- a/plugins/inventory/foreman.py
+++ b/plugins/inventory/foreman.py
@@ -191,8 +191,8 @@ import json
 from ansible_collections.theforeman.foreman.plugins.module_utils._version import LooseVersion
 from time import sleep
 from ansible.errors import AnsibleError
-from ansible.module_utils._text import to_bytes, to_native, to_text
 from ansible.module_utils.common._collections_compat import MutableMapping
+from ansible.module_utils.common.text.converters import to_bytes, to_native, to_text
 from ansible.plugins.inventory import BaseInventoryPlugin, Cacheable, to_safe_group_name, Constructable
 
 # 3rd party imports

--- a/plugins/inventory/foreman.py
+++ b/plugins/inventory/foreman.py
@@ -189,9 +189,9 @@ hostnames:
 import copy
 import json
 from ansible_collections.theforeman.foreman.plugins.module_utils._version import LooseVersion
+from collections.abc import MutableMapping
 from time import sleep
 from ansible.errors import AnsibleError
-from ansible.module_utils.common._collections_compat import MutableMapping
 from ansible.module_utils.common.text.converters import to_bytes, to_native, to_text
 from ansible.plugins.inventory import BaseInventoryPlugin, Cacheable, to_safe_group_name, Constructable
 

--- a/plugins/module_utils/foreman_helper.py
+++ b/plugins/module_utils/foreman_helper.py
@@ -21,7 +21,7 @@ from collections import defaultdict
 from functools import wraps
 
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib, env_fallback
-from ansible.module_utils._text import to_bytes, to_native
+from ansible.module_utils.common.text.converters import to_bytes, to_native
 from ansible.module_utils import six
 
 try:

--- a/plugins/modules/content_upload.py
+++ b/plugins/modules/content_upload.py
@@ -92,7 +92,7 @@ RETURN = ''' # '''
 import os
 import traceback
 
-from ansible.module_utils._text import to_bytes, to_native
+from ansible.module_utils.common.text.converters import to_bytes, to_native
 from ansible_collections.theforeman.foreman.plugins.module_utils.foreman_helper import KatelloAnsibleModule, missing_required_lib
 
 try:

--- a/plugins/modules/redhat_manifest.py
+++ b/plugins/modules/redhat_manifest.py
@@ -139,7 +139,7 @@ import tempfile
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.urls import fetch_url
-from ansible.module_utils._text import to_text, to_native
+from ansible.module_utils.common.text.converters import to_text, to_native
 
 
 REDHAT_UEP = '/etc/rhsm/ca/redhat-uep.pem'

--- a/tests/test_callback.py
+++ b/tests/test_callback.py
@@ -42,7 +42,7 @@ def drop_incompatible_items(d):
     for k, v in d.items():
         if k in ['msg', 'start', 'end', 'delta', 'uuid', 'timeout', '_ansible_no_log', 'warn', 'connection',
                  'extended_allitems', 'loop_control', 'expand_argument_vars', 'retries', 'parent', 'parent_type', 'finalized', 'squashed', 'no_log',
-                 'listen', '_ansible_internal_redirect_list', 'exception', 'resolved_action', 'delay']:
+                 'listen', '_ansible_internal_redirect_list', 'exception', 'resolved_action', 'delay', '_resolved_action']:
             continue
 
         if isinstance(v, dict):


### PR DESCRIPTION
Replace use of old `ansible.module_utils._text` which is deprecated in 2.20+ and will be removed in 2.24
ansible.module_utils.common.text.converters exists since 2.10, so it's safe to just replace our usage with it.