### PR TITLE
clean up dev deps for python 3.6 and older

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,25 +1,21 @@
 pytest
 pytest-xdist
 pytest-forked
-pytest-clarity; python_version >= '3.6'
+pytest-clarity
 urllib3<2
 vcrpy
 ansible_runner<2.0; python_version < '3.8'
 ansible_runner; python_version >= '3.8'
 python-debian<0.1.40; python_version < '3.7'
 python-debian; python_version >= '3.7'
-rpm; python_version >= '3.6'
-rpm-py-installer; python_version < '3.6'
+rpm
 rstcheck==3.5.0 # from https://github.com/ansible/ansible/raw/devel/test/sanity/code-smell/rstcheck.requirements.txt
 docker
-ruamel.yaml.clib<0.2.3; python_version < '3.6'
 cryptography<3.1; python_version < '3.7'
 -r requirements.txt
 pylint==2.6.0; python_version > '3.0' and python_version <= '3.8' # py 3.8 is used for "stable" ansible, but only devel has pylint rules for newer pylints
 pylint==2.17.3; python_version >= '3.9' # from https://raw.githubusercontent.com/ansible/ansible/devel/test/lib/ansible_test/_data/requirements/sanity.pylint.txt
 voluptuous==0.13.1 # from https://github.com/ansible/ansible/raw/devel/test/lib/ansible_test/_data/requirements/sanity.validate-modules.txt
-pycodestyle==2.8.0; python_version < '3.6' # from https://github.com/ansible/ansible/raw/devel/test/lib/ansible_test/_data/requirements/sanity.pep8.txt
-pycodestyle==2.10.0; python_version >= '3.6' # from https://github.com/ansible/ansible/raw/devel/test/lib/ansible_test/_data/requirements/sanity.pep8.txt
-yamllint==1.26.3; python_version == '3.5' # from https://github.com/ansible/ansible/raw/devel/test/lib/ansible_test/_data/requirements/sanity.yamllint.txt
+pycodestyle==2.10.0 # from https://github.com/ansible/ansible/raw/devel/test/lib/ansible_test/_data/requirements/sanity.pep8.txt
 yamllint==1.28.0; python_version == '3.6' # from https://github.com/ansible/ansible/raw/devel/test/lib/ansible_test/_data/requirements/sanity.yamllint.txt
 yamllint==1.30.0; python_version >= '3.7' # from https://github.com/ansible/ansible/raw/devel/test/lib/ansible_test/_data/requirements/sanity.yamllint.txt


### PR DESCRIPTION
3.6 is our minimum version these days, so we can drop the constraints