### PR TITLE
don't call task.serialize() on Ansible 2.20+

### DIFF
--- a/plugins/callback/foreman.py
+++ b/plugins/callback/foreman.py
@@ -373,7 +373,10 @@ class CallbackModule(CallbackBase):
 
     def append_result(self, result, failed=False):
         result_info = result._result
-        task_info = result._task.serialize()
+        if hasattr(result._task, 'serialize'):
+            task_info = result._task.serialize()
+        else:
+            task_info = result._task.dump_attrs()
         task_info['args'] = None
         value = {}
         value['result'] = result_info

--- a/tests/test_callback.py
+++ b/tests/test_callback.py
@@ -42,7 +42,7 @@ def drop_incompatible_items(d):
     for k, v in d.items():
         if k in ['msg', 'start', 'end', 'delta', 'uuid', 'timeout', '_ansible_no_log', 'warn', 'connection',
                  'extended_allitems', 'loop_control', 'expand_argument_vars', 'retries', 'parent', 'parent_type', 'finalized', 'squashed', 'no_log',
-                 'listen', '_ansible_internal_redirect_list', 'exception', 'resolved_action', 'delay', '_resolved_action']:
+                 'listen', '_ansible_internal_redirect_list', 'exception', 'resolved_action', 'delay', '_resolved_action', 'is_handler']:
             continue
 
         if isinstance(v, dict):


### PR DESCRIPTION
This was removed in favor of dump_attrs() in https://github.com/ansible/ansible/pull/85724