### PR TITLE
Don't expect changes during content_view_info setup

### DIFF
--- a/tests/test_playbooks/content_view_info.yml
+++ b/tests/test_playbooks/content_view_info.yml
@@ -31,7 +31,6 @@
       include_tasks: tasks/content_view.yml
       vars:
         content_view_state: present
-        expected_change: true
         repositories:
           - name: "Test Repository"
             product: "Test Product"


### PR DESCRIPTION
This was accidentally set to true here, but during setup we do not want to assert any changes, as it might have already happened in a previous run.