### PR TITLE
add support for repo_data parameter in registration_command module

### DIFF
--- a/plugins/modules/registration_command.py
+++ b/plugins/modules/registration_command.py
@@ -204,7 +204,7 @@ def main():
             repo_gpg_key_url=dict(type='str', no_log=False),
             repo_data=dict(type='list', elements='dict', options=dict(
                 repo=dict(type='str', required=True),
-                repo_gpg_key_url=dict(type='str'),
+                repo_gpg_key_url=dict(type='str', no_log=False),
             )),
             remote_execution_interface=dict(type='str'),
             setup_remote_execution_pull=dict(type='bool'),

--- a/plugins/modules/registration_command.py
+++ b/plugins/modules/registration_command.py
@@ -91,7 +91,7 @@ options:
     - Repository URL (yum/dnf) or full sources.list entry (apt).
     - "Deprecated: Use the I(repo_data) option instead."
     required: false
-    type: str  
+    type: str
   repo_gpg_key_url:
     description:
     - URL of the GPG key for the repository.
@@ -108,7 +108,7 @@ options:
     suboptions:
       repo:
         description:
-        - Repository URL / details, for example, for Debian OS family C(deb deb.example.com/ buster 1.0), for Red Hat and SUSE OS family C(yum.theforeman.org/client/latest/el8/x86_64/).
+        - Repository URL or details (e.g., "deb http://deb.example.com/ buster 1.0" for Debian, "https://yum.example.com/el8/x86_64/ " for Red Hat/SUSE).
         required: true
         type: str
       repo_gpg_key_url:

--- a/plugins/modules/registration_command.py
+++ b/plugins/modules/registration_command.py
@@ -89,13 +89,33 @@ options:
   repo:
     description:
     - Repository URL (yum/dnf) or full sources.list entry (apt).
+    - "Deprecated: Use the I(repo_data) option instead."
     required: false
-    type: str
+    type: str  
   repo_gpg_key_url:
     description:
     - URL of the GPG key for the repository.
+    - "Deprecated: Use the I(repo_data) option instead."
     required: false
     type: str
+  repo_data:
+    description:
+    - Array with repository URL and corresponding GPG key URL.
+    - Each element is a dictionary with keys C(repo) and C(repo_gpg_key_url).
+    required: false
+    type: list
+    elements: dict
+    suboptions:
+      repo:
+        description:
+        - Repository URL / details, for example, for Debian OS family C(deb deb.example.com/ buster 1.0), for Red Hat and SUSE OS family C(yum.theforeman.org/client/latest/el8/x86_64/).
+        required: true
+        type: str
+      repo_gpg_key_url:
+        description:
+        - URL of the GPG key for the repository.
+        required: false
+        type: str
   setup_insights:
     description:
     - If this is set to C(true), C(insights-client) will be installed
@@ -182,6 +202,10 @@ def main():
             update_packages=dict(type='bool'),
             repo=dict(type='str'),
             repo_gpg_key_url=dict(type='str', no_log=False),
+            repo_data=dict(type='list', elements='dict', options=dict(
+                repo=dict(type='str', required=True),
+                repo_gpg_key_url=dict(type='str'),
+            )),
             remote_execution_interface=dict(type='str'),
             setup_remote_execution_pull=dict(type='bool'),
             activation_keys=dict(type='list', elements='str', no_log=False),

--- a/plugins/modules/registration_command.py
+++ b/plugins/modules/registration_command.py
@@ -89,13 +89,13 @@ options:
   repo:
     description:
     - Repository URL (yum/dnf) or full sources.list entry (apt).
-    - "Deprecated: Use the I(repo_data) option instead."
+    - "Deprecated: Use the I(repo_data) option instead. This option was deprecated in version Foreman 3.11."
     required: false
     type: str
   repo_gpg_key_url:
     description:
     - URL of the GPG key for the repository.
-    - "Deprecated: Use the I(repo_data) option instead."
+    - "Deprecated: Use the I(repo_data) option instead. This option was deprecated in version Foreman 3.11."
     required: false
     type: str
   repo_data:


### PR DESCRIPTION
Add repo_data parameter support to registration_command module

- Added repo_data parameter as a list of dictionaries
- Updated documentation with deprecation notices

Fixes #1938