### PR TITLE
Replace pkg_resources with importlib.metadata

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -113,6 +113,9 @@ jobs:
       - name: Install required collections for ansible 2.10
         run: ansible-galaxy collection install https://galaxy.ansible.com/api/v3/plugin/ansible/content/published/collections/artifacts/community-docker-2.7.12.tar.gz
         if: matrix.ansible == 'v2.10.4'
+      - name: Install importlib-metadata for python_version < '3.8'
+        run: pip install importlib-metadata
+        if: matrix.python in ['3.7', '3.8']
       - name: Run crud tests
         run: make test-crud
       - name: Run other tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -113,9 +113,6 @@ jobs:
       - name: Install required collections for ansible 2.10
         run: ansible-galaxy collection install https://galaxy.ansible.com/api/v3/plugin/ansible/content/published/collections/artifacts/community-docker-2.7.12.tar.gz
         if: matrix.ansible == 'v2.10.4'
-      - name: Install importlib-metadata for python_version < '3.8'
-        run: pip install importlib-metadata
-        if: matrix.python in ['3.7', '3.8']
       - name: Run crud tests
         run: make test-crud
       - name: Run other tests

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,6 +12,7 @@ rpm; python_version >= '3.12'
 rstcheck==3.5.0 # from https://github.com/ansible/ansible/raw/devel/test/sanity/code-smell/rstcheck.requirements.txt
 docker
 cryptography<3.1; python_version < '3.7'
+importlib-metadata; python_version < '3.8'
 -r requirements.txt
 pylint==2.6.0; python_version > '3.0' and python_version <= '3.8' # py 3.8 is used for "stable" ansible, but only devel has pylint rules for newer pylints
 pylint==2.17.3; python_version >= '3.9' # from https://raw.githubusercontent.com/ansible/ansible/devel/test/lib/ansible_test/_data/requirements/sanity.pylint.txt

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@ import json
 import os
 
 import ansible_runner
-import pkg_resources
+from importlib.metadata import version, PackageNotFoundError
 import pytest
 import py.path
 import yaml
@@ -112,13 +112,12 @@ def run_playbook_vcr(tmpdir, module, extra_vars=None, limit=None, inventory=None
 
 
 def get_ansible_version():
-    ansible_version = '2.14.0'
     for ansible_name in ['ansible', 'ansible-base', 'ansible-core']:
         try:
-            ansible_version = pkg_resources.get_distribution(ansible_name).version
-        except pkg_resources.DistributionNotFound:
+            return version(ansible_name)
+        except PackageNotFoundError:
             pass
-    return ansible_version
+    return '2.14.0'
 
 
 def assert_no_warnings(run):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,10 @@ import json
 import os
 
 import ansible_runner
-from importlib.metadata import version, PackageNotFoundError
+try:
+    from importlib.metadata import version, PackageNotFoundError
+except ModuleNotFoundError:
+    from importlib_metadata import version, PackageNotFoundError
 import pytest
 import py.path
 import yaml


### PR DESCRIPTION
While running tests, we're seeing a following warning for pkg_resources deprecation, which will be removed soon, so replacing pkg_resources with importlib.metadata 
```
=========================================================== warnings summary ===========================================================
tests/conftest.py:5
  /Users/gtalreja/my_workspace/foreman-ansible-modules/tests/conftest.py:5: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
    import pkg_resources

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================================================== 1 warning in 0.02s ==========================================================
```
