### PR TITLE
automatically use system certs via truststore

### DIFF
--- a/plugins/inventory/foreman.py
+++ b/plugins/inventory/foreman.py
@@ -197,6 +197,12 @@ from ansible.plugins.inventory import BaseInventoryPlugin, Cacheable, to_safe_gr
 
 # 3rd party imports
 try:
+    import truststore
+    truststore.inject_into_ssl()
+except ImportError:
+    pass
+
+try:
     import requests
     if LooseVersion(requests.__version__) < LooseVersion('1.1.0'):
         raise ImportError

--- a/plugins/module_utils/_apypie.py
+++ b/plugins/module_utils/_apypie.py
@@ -235,6 +235,11 @@ class Action(object):
 Apypie Api module
 """
 
+try:
+    import truststore
+    truststore.inject_into_ssl()
+except ImportError:
+    pass
 
 import errno
 import glob

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests>=2.4.2
 PyYAML
+truststore ; python_version >= "3.10"


### PR DESCRIPTION
`requests` defaults to using the certificate trust provided by `certifi`, which precludes the inclusion of custom trusted certificates. Rather than needing to set the `REQUESTS_CA_BUNDLE` environment variable in every shell/config, use [`truststore`](https://github.com/sethmlarson/truststore) to override the way certs are read and automatically use the system trust store.

This will only happen transparently in environments using [Python >= 3.10](https://github.com/sethmlarson/truststore/blob/main/src/truststore/__init__.py) and is effectively a noop in any other scenario.