### PR TITLE
refactor too long lines in activation_keys role

### DIFF
--- a/roles/activation_keys/tasks/main.yml
+++ b/roles/activation_keys/tasks/main.yml
@@ -8,8 +8,18 @@
     organization: "{{ item.organization | default(foreman_organization) }}"
     name: "{{ item.name }}"
     description: "{{ item.description | default(omit) }}"
-    lifecycle_environment: "{{ item.lifecycle_environment | default(omit) if (item.content_view_environments | default([]) | length > 0) else item.lifecycle_environment | default('Library') }}"
-    content_view: "{{ item.content_view | default(omit) if (item.content_view_environments | default([]) | length > 0) else item.content_view | default('Default Organization View') }}"
+    lifecycle_environment: >-
+      {{
+        item.lifecycle_environment | default(omit)
+        if (item.content_view_environments | default([]) | length > 0)
+        else item.lifecycle_environment | default('Library')
+      }}
+    content_view: >-
+      {{
+        item.content_view | default(omit)
+        if (item.content_view_environments | default([]) | length > 0)
+        else item.content_view | default('Default Organization View')
+      }}
     content_view_environments: "{{ item.content_view_environments | default(omit) }}"
     host_collections: "{{ item.host_collections | default(omit) }}"
     subscriptions: "{{ item.subscriptions | default(omit) }}"


### PR DESCRIPTION
This commit fixes the lines that are too long (> 160 characters)