### PR TITLE
don't include "ansible" when looking for the ansible version

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -115,7 +115,7 @@ def run_playbook_vcr(tmpdir, module, extra_vars=None, limit=None, inventory=None
 
 
 def get_ansible_version():
-    for ansible_name in ['ansible', 'ansible-base', 'ansible-core']:
+    for ansible_name in ['ansible-base', 'ansible-core']:
         try:
             return version(ansible_name)
         except PackageNotFoundError:


### PR DESCRIPTION
We don't support Ansible 2.9 since 5ccdf18a3d775b1dbda91474edcbc9b0cb3f4fe9 and Ansible 2.9 was the last one that used "ansible" as the Python project name, 2.10 was "ansible-base" and 2.11+ is "ansible-core".
"ansible" is now used by the "Ansible Community Distribution" and has totally different versioning, which we don't care about as we don't depend on anything in that distribution.