### PR TITLE
Fix user tests

### DIFF
--- a/tests/test_playbooks/user.yml
+++ b/tests/test_playbooks/user.yml
@@ -54,6 +54,7 @@
         foreman_password: s3cret
         user_state: present
         user_mail: "{{ omit }}"
+        user_auth_source: "{{ omit }}"
         expected_change: true
 
     # change password
@@ -71,6 +72,7 @@
         foreman_password: newp@ass
         user_state: present
         user_mail: test.user@example.com
+        user_auth_source: "{{ omit }}"
         expected_change: true
 
     # remove user


### PR DESCRIPTION
The user tests are failing with `"Found no results while searching for auth_sources with name=\"Internal\""`

auth_source is not needed while try to auth as a new user, hence omitting the `user_auth_source`