### PR TITLE
Fix content_view_filter_rule to consider versions for deb filters

### DIFF
--- a/changelogs/fragments/deb_filter_rule.yml
+++ b/changelogs/fragments/deb_filter_rule.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - content_view_filter_rule - fix content_filter_rule_deb_spec to take into account desired versions

--- a/plugins/modules/content_view_filter_rule.py
+++ b/plugins/modules/content_view_filter_rule.py
@@ -230,6 +230,9 @@ content_filter_rule_docker_spec = {
 content_filter_rule_deb_spec = {
     'id': {},
     'rule_name': {'flat_name': 'name'},
+    'max_version': {},
+    'min_version': {},
+    'version': {},
     'architecture': {},
 }
 


### PR DESCRIPTION
# Description
When creating a filter rule for a filter of type `deb`, like in the following example, the result did not take into account the `min_version`, `version` and `max_version` parameters and always included all versions instead (see screenshot below).

```yaml
    - name: "Ensure presence of CV filter rules"
      theforeman.foreman.content_view_filter_rule:
        content_view: "Salt deb - example"
        content_view_filter: "Salt 3006"
        min_version: "3007"
        name: "*"
        organization: "default"
```
<img width="605" height="246" alt="before_fix_1" src="https://github.com/user-attachments/assets/3df2281e-0093-43d9-97ed-eaf77259b7ca" />


The issue was that  the dictionary `content_filter_rule_deb_spec` did not include these entries and thus they were being ignored.