### PR TITLE
Do not add content view filters rules on specific filters

### DIFF
--- a/roles/content_views/tasks/_create_content_view.yml
+++ b/roles/content_views/tasks/_create_content_view.yml
@@ -60,4 +60,6 @@
     rule_state: "{{ item.rule_state | default(omit) }}"
   when:
     - content_view.state is not defined or content_view.state != 'absent'
+    - not (item.original_packages | default(omit)) | bool
+    - not (item.original_module_streams | default(omit)) | bool
   loop: "{{ content_view.filters | default([]) }}"


### PR DESCRIPTION
When using original_packages or original_module_streams filters we don't need to add rules.
Updated to match Release 5.10.0

Fix theforeman#1896