### PR TITLE
Add support for setup_container_registry_certs in registration_command

### DIFF
--- a/changelogs/fragments/registration_command_setup_container_registry_certs.yml
+++ b/changelogs/fragments/registration_command_setup_container_registry_certs.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - registration_command - add support for the setup_container_registry_certs parameter (https://github.com/theforeman/foreman-ansible-modules/pull/1966)

--- a/plugins/modules/registration_command.py
+++ b/plugins/modules/registration_command.py
@@ -132,6 +132,12 @@ options:
     - If this is set to true, pull provider client will be deployed on the host.
     required: false
     type: bool
+  setup_container_registry_certs:
+    description:
+    - If this is set to C(true), container registry certificates will be installed on the host.
+    required: false
+    type: bool
+    version_added: 5.11.0
   smart_proxy:
     description:
     - Name of Smart Proxy.
@@ -208,6 +214,7 @@ def main():
             )),
             remote_execution_interface=dict(type='str'),
             setup_remote_execution_pull=dict(type='bool'),
+            setup_container_registry_certs=dict(type='bool'),
             activation_keys=dict(type='list', elements='str', no_log=False),
             lifecycle_environment=dict(type='entity'),
             force=dict(type='bool'),
@@ -216,7 +223,7 @@ def main():
             location=dict(type='entity'),
         ),
         required_plugins=[
-            ('katello', ['activation_key', 'activation_keys', 'lifecycle_environment', 'ignore_subman_errors', 'force']),
+            ('katello', ['activation_key', 'activation_keys', 'lifecycle_environment', 'ignore_subman_errors', 'force', 'setup_container_registry_certs']),
             ('remote_execution', ['remote_execution_interface', 'setup_remote_execution_pull']),
         ],
     )


### PR DESCRIPTION
## Summary

- Add `setup_container_registry_certs` parameter to the `registration_command` module
- When set to `true`, container registry certificates will be installed on the host during registration
- Marked as requiring the Katello plugin, as it depends on subscription-manager entitlement certificates

## Test plan

- [ ] Updated `tasks/registration_command.yml` to accept `setup_container_registry_certs`
- [ ] Added a second test invocation in `registration_command.yml` with `setup_container_registry_certs: true`
- [ ] VCR fixture `registration_command-1.yml` needs to be recorded against a real Foreman+Katello instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)