### PR TITLE
Assert default of login_text, not value in module_defaults tests

### DIFF
--- a/tests/test_playbooks/module_defaults.yml
+++ b/tests/test_playbooks/module_defaults.yml
@@ -33,4 +33,4 @@
       assert:
         that:
           - setting_info['setting']['name'] == "login_text"
-          - setting_info['setting']['value'] == 'Version $VERSION'
+          - setting_info['setting']['default'] == 'Version $VERSION'


### PR DESCRIPTION
That way the tests also pass on setups that have actually changed the value