### PR TITLE
Only assert a lower bound for resource_info tests that can return many

### DIFF
--- a/tests/test_playbooks/resource_info.yml
+++ b/tests/test_playbooks/resource_info.yml
@@ -38,7 +38,7 @@
       include_tasks: tasks/resource_info.yml
       vars:
         resource: instance_hosts
-        return_length: 1
+        return_min: 1
     - name: Search for an organization and return full details
       include_tasks: tasks/resource_info.yml
       vars:

--- a/tests/test_playbooks/tasks/resource_info.yml
+++ b/tests/test_playbooks/tasks/resource_info.yml
@@ -15,4 +15,8 @@
     fail_msg: "Verification that '{{ return_length }}' '{{ resource }}' resources are found"
     that: result.resources | length == return_length
   when: return_length is defined
+- assert:
+    fail_msg: "Verification that at least '{{ return_min }}' '{{ resource }}' resources are found"
+    that: result.resources | length >= return_min
+  when: return_min is defined
 ...


### PR DESCRIPTION
We can't be sure how many results we get when we don't pass a search, so let's only assert a lower bound