### PR TITLE
Add smart_proxy_sync module and smart_proxies_sync role

### DIFF
--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -79,6 +79,7 @@ action_groups:
     - smart_class_parameter_override_value
     - smart_proxy
     - smart_proxy_refresh
+    - smart_proxy_sync
     - snapshot
     - snapshot_info
     - status_info

--- a/plugins/modules/smart_proxy_sync.py
+++ b/plugins/modules/smart_proxy_sync.py
@@ -1,0 +1,153 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# (c) 2026, Pablo Méndez Hernández <pmendezh@redhat.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+DOCUMENTATION = '''
+---
+module: smart_proxy_sync
+version_added: 5.11.0
+short_description: Sync content on a Smart Proxy
+description:
+  - Synchronize content on a Smart Proxy.
+author:
+  - "Pablo Méndez Hernández (@pablomh)"
+options:
+  smart_proxy:
+    description:
+      - Name of the Smart Proxy to synchronize content on.
+    required: true
+    type: str
+  lifecycle_environment:
+    description:
+      - Name of the Lifecycle Environment to limit the synchronization on.
+    required: false
+    type: str
+  content_view:
+    description:
+      - Name of the Content View to limit the synchronization on.
+    required: false
+    type: str
+  product:
+    description:
+      - Name of the Product the I(repository) belongs to.
+      - Required when I(repository) is specified.
+    required: false
+    type: str
+  repository:
+    description:
+      - Name of the Repository to limit the synchronization on.
+      - Requires I(product) to be specified.
+    required: false
+    type: str
+  skip_metadata_check:
+    description:
+      - Skip metadata check on each repository on the Smart Proxy.
+    required: false
+    type: bool
+attributes:
+  check_mode:
+    support: none
+  diff_mode:
+    support: none
+extends_documentation_fragment:
+  - theforeman.foreman.foreman
+  - theforeman.foreman.foreman.organization
+...
+'''
+
+EXAMPLES = '''
+- name: "Sync all content on a Smart Proxy"
+  theforeman.foreman.smart_proxy_sync:
+    username: "admin"
+    password: "changeme"
+    server_url: "https://foreman.example.com"
+    organization: "Default Organization"
+    smart_proxy: "capsule.example.com"
+
+- name: "Sync a specific lifecycle environment on a Smart Proxy"
+  theforeman.foreman.smart_proxy_sync:
+    username: "admin"
+    password: "changeme"
+    server_url: "https://foreman.example.com"
+    organization: "Default Organization"
+    smart_proxy: "capsule.example.com"
+    lifecycle_environment: "Production"
+
+- name: "Sync a specific repository on a Smart Proxy"
+  theforeman.foreman.smart_proxy_sync:
+    username: "admin"
+    password: "changeme"
+    server_url: "https://foreman.example.com"
+    organization: "Default Organization"
+    smart_proxy: "capsule.example.com"
+    product: "Red Hat Enterprise Linux for x86_64"
+    repository: "Red Hat Enterprise Linux 9 for x86_64 - BaseOS RPMs 9"
+'''
+
+RETURN = ''' # '''
+
+from ansible_collections.theforeman.foreman.plugins.module_utils.foreman_helper import KatelloAnsibleModule
+
+
+def main():
+    module = KatelloAnsibleModule(
+        foreman_spec=dict(
+            smart_proxy=dict(type='entity', required=True),
+            lifecycle_environment=dict(type='entity', scope=['organization']),
+            content_view=dict(type='entity', scope=['organization']),
+            product=dict(type='entity', scope=['organization']),
+            repository=dict(type='entity', scope=['product']),
+            skip_metadata_check=dict(type='bool'),
+        ),
+        supports_check_mode=False,
+    )
+
+    if 'repository' in module.foreman_params and 'product' not in module.foreman_params:
+        module.fail_json(msg="'product' is required when 'repository' is specified")
+
+    module.task_timeout = 12 * 60 * 60
+
+    with module.api_connection():
+        smart_proxy = module.lookup_entity('smart_proxy')
+
+        payload = {'id': smart_proxy['id']}
+
+        if 'lifecycle_environment' in module.foreman_params:
+            lce = module.lookup_entity('lifecycle_environment')
+            payload['environment_id'] = lce['id']
+
+        if 'content_view' in module.foreman_params:
+            cv = module.lookup_entity('content_view')
+            payload['content_view_id'] = cv['id']
+
+        if 'repository' in module.foreman_params:
+            module.lookup_entity('product')
+            repo = module.lookup_entity('repository')
+            payload['repository_id'] = repo['id']
+
+        if 'skip_metadata_check' in module.foreman_params:
+            payload['skip_metadata_check'] = module.foreman_params['skip_metadata_check']
+
+        task = module.resource_action('capsule_content', 'sync', payload)
+        module.exit_json(task=task)
+
+
+if __name__ == '__main__':
+    main()

--- a/roles/smart_proxies_sync/README.md
+++ b/roles/smart_proxies_sync/README.md
@@ -1,0 +1,79 @@
+theforeman.foreman.smart_proxies_sync
+======================================
+
+Sync content on Smart Proxies.
+
+Role Variables
+--------------
+
+This role supports the [Common Role Variables](https://github.com/theforeman/foreman-ansible-modules/blob/develop/README.md#common-role-variables).
+
+### Required
+
+- `foreman_smart_proxies_sync`: List of Smart Proxies to sync content on. Each entry is a dictionary with the following keys:
+
+| Key | Required | Description |
+|-----|----------|-------------|
+| `name` | yes | Name of the Smart Proxy |
+| `organization` | no | Organization (defaults to `foreman_organization`) |
+| `lifecycle_environment` | no | Limit sync to this Lifecycle Environment |
+| `content_view` | no | Limit sync to this Content View |
+| `product` | no | Product the repository belongs to (required when `repository` is set) |
+| `repository` | no | Limit sync to this Repository |
+| `skip_metadata_check` | no | Skip metadata check on each repository |
+
+### Optional
+
+- `foreman_smart_proxies_sync_wait`: Whether to wait for the sync tasks to complete. Defaults to `true`.
+
+Example Playbook
+----------------
+
+### Sync all content on multiple Smart Proxies
+
+```yaml
+- hosts: localhost
+  roles:
+    - role: theforeman.foreman.smart_proxies_sync
+      vars:
+        foreman_server_url: https://foreman.example.com
+        foreman_username: "admin"
+        foreman_password: "changeme"
+        foreman_organization: "Default Organization"
+        foreman_smart_proxies_sync:
+          - name: capsule1.example.com
+          - name: capsule2.example.com
+```
+
+### Sync a specific lifecycle environment
+
+```yaml
+- hosts: localhost
+  roles:
+    - role: theforeman.foreman.smart_proxies_sync
+      vars:
+        foreman_server_url: https://foreman.example.com
+        foreman_username: "admin"
+        foreman_password: "changeme"
+        foreman_organization: "Default Organization"
+        foreman_smart_proxies_sync:
+          - name: capsule.example.com
+            lifecycle_environment: Production
+```
+
+### Sync a specific repository
+
+```yaml
+- hosts: localhost
+  roles:
+    - role: theforeman.foreman.smart_proxies_sync
+      vars:
+        foreman_server_url: https://foreman.example.com
+        foreman_username: "admin"
+        foreman_password: "changeme"
+        foreman_organization: "Default Organization"
+        foreman_smart_proxies_sync:
+          - name: capsule.example.com
+            product: "Red Hat Enterprise Linux for x86_64"
+            repository: "Red Hat Enterprise Linux 9 for x86_64 - BaseOS RPMs 9"
+```

--- a/roles/smart_proxies_sync/meta/main.yml
+++ b/roles/smart_proxies_sync/meta/main.yml
@@ -1,0 +1,4 @@
+---
+galaxy_info:
+  description: Sync content on Smart Proxies
+  standalone: false

--- a/roles/smart_proxies_sync/tasks/main.yml
+++ b/roles/smart_proxies_sync/tasks/main.yml
@@ -1,0 +1,30 @@
+---
+- name: 'Sync Smart Proxy content'
+  theforeman.foreman.smart_proxy_sync:
+    username: "{{ foreman_username | default(omit) }}"
+    password: "{{ foreman_password | default(omit) }}"
+    server_url: "{{ foreman_server_url | default(omit) }}"
+    validate_certs: "{{ foreman_validate_certs | default(omit) }}"
+    organization: "{{ foreman_smart_proxies_sync_item.organization | default(foreman_organization) }}"
+    smart_proxy: "{{ foreman_smart_proxies_sync_item.name }}"
+    lifecycle_environment: "{{ foreman_smart_proxies_sync_item.lifecycle_environment | default(omit) }}"
+    content_view: "{{ foreman_smart_proxies_sync_item.content_view | default(omit) }}"
+    product: "{{ foreman_smart_proxies_sync_item.product | default(omit) }}"
+    repository: "{{ foreman_smart_proxies_sync_item.repository | default(omit) }}"
+    skip_metadata_check: "{{ foreman_smart_proxies_sync_item.skip_metadata_check | default(omit) }}"
+  async: 43200
+  poll: 0
+  loop: "{{ foreman_smart_proxies_sync }}"
+  loop_control:
+    loop_var: foreman_smart_proxies_sync_item
+  register: __foreman_smart_proxies_sync_jobs
+
+- name: 'Wait for Smart Proxy sync tasks'  # noqa: args[module]
+  ansible.builtin.async_status:
+    jid: "{{ item.ansible_job_id }}"
+  loop: "{{ __foreman_smart_proxies_sync_jobs.results }}"
+  register: __foreman_smart_proxies_sync_result
+  until: __foreman_smart_proxies_sync_result is finished
+  retries: 99999
+  delay: 10
+  when: foreman_smart_proxies_sync_wait | default(true)

--- a/tests/test_playbooks/smart_proxy_sync.yml
+++ b/tests/test_playbooks/smart_proxy_sync.yml
@@ -1,0 +1,31 @@
+---
+- hosts: localhost
+  collections:
+    - theforeman.foreman
+  gather_facts: false
+  vars_files:
+    - vars/server.yml
+  tasks:
+    - include_tasks: tasks/organization.yml
+      vars:
+        organization_state: present
+
+- hosts: tests
+  collections:
+    - theforeman.foreman
+  gather_facts: false
+  vars_files:
+    - vars/server.yml
+  tasks:
+    - include_tasks: tasks/smart_proxy_sync.yml
+
+- hosts: localhost
+  collections:
+    - theforeman.foreman
+  gather_facts: false
+  vars_files:
+    - vars/server.yml
+  tasks:
+    - include_tasks: tasks/organization.yml
+      vars:
+        organization_state: absent

--- a/tests/test_playbooks/tasks/smart_proxy_sync.yml
+++ b/tests/test_playbooks/tasks/smart_proxy_sync.yml
@@ -1,0 +1,14 @@
+---
+- name: "Sync Smart Proxy '{{ foreman_proxy }}'"
+  theforeman.foreman.smart_proxy_sync:
+    username: "{{ foreman_username }}"
+    password: "{{ foreman_password }}"
+    server_url: "{{ foreman_server_url }}"
+    validate_certs: "{{ foreman_validate_certs }}"
+    organization: "Test Organization"
+    smart_proxy: "{{ foreman_proxy }}"
+  register: result
+- ansible.builtin.assert:
+    that:
+      - result.changed
+...


### PR DESCRIPTION
## Summary

- Adds `smart_proxy_sync` module to trigger content synchronization on a Smart Proxy via the Katello `capsule_content/sync` API
- Adds `smart_proxies_sync` role as a companion that fires all syncs in parallel and optionally waits for completion
- Exposes all optional API filters: `lifecycle_environment`, `content_view`, `repository` (requires `product`), and `skip_metadata_check`

## Test plan

- [ ] Verify module syncs all content on a Smart Proxy with no filters
- [ ] Verify `lifecycle_environment` filter limits the sync scope
- [ ] Verify `repository` + `product` filter limits the sync scope
- [ ] Verify `skip_metadata_check` is passed through correctly
- [ ] Verify role fires all syncs in parallel (`async: 43200`, `poll: 0`)
- [ ] Verify role waits for completion when `foreman_smart_proxies_sync_wait: true` (default)
- [ ] Verify role skips waiting when `foreman_smart_proxies_sync_wait: false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)