### PR TITLE
Support content_view_environment_id for host and hostgroup

### DIFF
--- a/changelogs/fragments/deprecate-cv-lce-params.yml
+++ b/changelogs/fragments/deprecate-cv-lce-params.yml
@@ -1,0 +1,4 @@
+minor_changes:
+  - host, hostgroup - internally convert ``content_view``/``lifecycle_environment``
+    to content view environment ID for compatibility with newer Katello API versions
+    (https://github.com/theforeman/foreman-ansible-modules/pull/1977)

--- a/plugins/module_utils/foreman_helper.py
+++ b/plugins/module_utils/foreman_helper.py
@@ -312,6 +312,8 @@ class HostMixin(ParametersMixin):
             kickstart_repository=dict(type='entity', scope=['organization'], optional_scope=['lifecycle_environment', 'content_view'],
                                       resource_type='repositories'),
             content_view=dict(type='entity', scope=['organization'], optional_scope=['lifecycle_environment']),
+            content_view_environment_id=dict(type='int', invisible=True),
+            content_view_environment_ids=dict(type='list', elements='int', invisible=True),
             activation_keys=dict(no_log=False),
         )
         foreman_spec.update(kwargs.pop('foreman_spec', {}))
@@ -326,6 +328,9 @@ class HostMixin(ParametersMixin):
         entity = self.lookup_entity('entity')
 
         if not self.desired_absent:
+            if 'content_view' in self.foreman_params or 'lifecycle_environment' in self.foreman_params:
+                self._convert_cv_lce_to_cve(entity)
+
             if 'activation_keys' in self.foreman_params:
                 if 'parameters' not in self.foreman_params:
                     parameters = [param for param in (entity or {}).get('parameters', []) if param['name'] != 'kt_activation_keys']
@@ -342,6 +347,64 @@ class HostMixin(ParametersMixin):
         self.validate_parameters()
 
         return super(HostMixin, self).run(**kwargs)
+
+    def _convert_cv_lce_to_cve(self, entity):
+        resource = inflector.pluralize(self.entity_name)
+        _filtered, unsupported = self.foremanapi.validate_payload(resource, 'create', {'content_view_id': 1})
+        if 'content_view_id' not in unsupported:
+            return
+
+        if entity:
+            entity_cves = entity.get('content_view_environments', [])
+            if len(entity_cves) > 1:
+                self.fail_json(
+                    msg="This {0} has multiple content view environments. "
+                        "The 'content_view' and 'lifecycle_environment' parameters "
+                        "cannot safely update it — they would overwrite the existing "
+                        "multi-CV assignment.".format(self.entity_name)
+                )
+
+        cv = self.lookup_entity('content_view')
+        lce = self.lookup_entity('lifecycle_environment')
+
+        cv_id = cv['id'] if cv else None
+        lce_id = lce['id'] if lce else None
+
+        if entity and cv_id is None:
+            cv_id = entity.get('content_view_id')
+            if cv_id is None:
+                entity_cves = entity.get('content_view_environments', [])
+                if entity_cves:
+                    cv_id = entity_cves[0].get('content_view', {}).get('id')
+        if entity and lce_id is None:
+            lce_id = entity.get('lifecycle_environment_id')
+            if lce_id is None:
+                entity_cves = entity.get('content_view_environments', [])
+                if entity_cves:
+                    lce_id = entity_cves[0].get('lifecycle_environment', {}).get('id')
+
+        if cv_id is None or lce_id is None:
+            self.fail_json(msg="Both 'content_view' and 'lifecycle_environment' must be provided together.")
+
+        org_id = self.lookup_entity('organization')['id'] if 'organization' in self.foreman_params else None
+        if org_id is None and entity:
+            org_id = entity.get('organization_id')
+
+        cve = self.find_content_view_environment(cv_id, lce_id, org_id)
+
+        self.foreman_spec['content_view']['ensure'] = False
+        self.foreman_spec['lifecycle_environment']['ensure'] = False
+
+        if resource == 'hosts':
+            current_cve_ids = []
+            if entity:
+                current_cve_ids = [e['id'] for e in entity.get('content_facet_attributes', {}).get('content_view_environments', [])]
+            if [cve['id']] != current_cve_ids:
+                self.foreman_params['content_view_environment_ids'] = [cve['id']]
+        else:
+            current_cve_id = entity.get('content_view_environment_id') if entity else None
+            if cve['id'] != current_cve_id:
+                self.foreman_params['content_view_environment_id'] = cve['id']
 
 
 class ForemanAnsibleModule(AnsibleModule):

--- a/plugins/modules/activation_key.py
+++ b/plugins/modules/activation_key.py
@@ -330,11 +330,8 @@ def main():
                     "are deprecated. Please use 'content_view_environments' instead."
                 )
 
-                module.lookup_entity('content_view')
-                module.lookup_entity('lifecycle_environment')
-
-                cv = module.foreman_params.get('content_view')
-                lce = module.foreman_params.get('lifecycle_environment')
+                cv = module.lookup_entity('content_view')
+                lce = module.lookup_entity('lifecycle_environment')
 
                 cv_id = cv['id'] if cv else None
                 lce_id = lce['id'] if lce else None


### PR DESCRIPTION
## Summary

On newer Katello versions where the `content_view_id`/`lifecycle_environment_id` API params have been removed, the host and hostgroup modules internally convert `content_view`/`lifecycle_environment` to the new API params:
- Hostgroups: `content_view_environment_id` (singular)
- Hosts: `content_view_environment_ids` (array in `content_facet_attributes`)

Multi-CV entities are protected from accidental overwrite. Backward compatible — on older Katello versions the conversion is skipped and old params flow through natively.

Split from #1982 (activation_key changes, merged). Related Katello PR: https://github.com/Katello/katello/pull/11753

## Test plan

All 9 tests pass against both old and new Katello:

| Test | Description |
|------|-------------|
| 1 | AK create with deprecated params |
| 2 | AK idempotency with deprecated params |
| 3 | AK create with `content_view_environments` |
| 4 | AK `content_view_environments` idempotency |
| 5 | Multi-CV AK protection |
| 6 | Hostgroup create with deprecated params |
| 7 | Hostgroup idempotency with deprecated params |
| 8 | Host create with deprecated params |
| 9 | Host idempotency with deprecated params |

<details>
<summary>Test vars (test_cv_lce_vars.yml)</summary>

```yaml
foreman_server_url: "https://your-foreman.example.com"
foreman_username: "admin"
foreman_password: "changeme"
foreman_validate_certs: false
test_organization: "Default Organization"
test_lifecycle_environment: "Library"
test_content_view: "Default Organization View"
# The default CVE label is just the LCE label (e.g. "Library"),
# not "Library/Default_Organization_View". Non-default CVEs use "lce_label/cv_label".
test_cve_label: "Library"
test_lifecycle_environment_2: "dev"
test_content_view_2: "cv1"
```

</details>

<details>
<summary>Test playbook (test_deprecate_cv_lce.yml)</summary>

Run with: `ansible-playbook test_deprecate_cv_lce.yml -e @test_cv_lce_vars.yml`

Prerequisites: `allow_multiple_content_views` setting enabled + a second CV promoted to a second LCE (for test 5)

```yaml
---
- name: "Test deprecated CV/LCE param handling"
  hosts: localhost
  collections:
    - theforeman.foreman
  gather_facts: false
  vars:
    foreman_conn: &foreman_conn
      server_url: "{{ foreman_server_url }}"
      username: "{{ foreman_username }}"
      password: "{{ foreman_password }}"
      validate_certs: "{{ foreman_validate_certs }}"
  tasks:

    # =========================================================================
    # CLEANUP (before tests, so playbook is re-runnable)
    # =========================================================================

    - name: "Setup - Remove leftover test resources"
      block:
        - host:
            <<: *foreman_conn
            name: "test-deprecated-cv-lce-host.example.com"
            state: absent
          ignore_errors: true
        - activation_key:
            <<: *foreman_conn
            organization: "{{ test_organization }}"
            name: "{{ item }}"
            state: absent
          loop:
            - "test-deprecated-cv-lce"
            - "test-new-cve-param"
            - "test-multi-cv-ak"
          ignore_errors: true
        - hostgroup:
            <<: *foreman_conn
            name: "test-deprecated-cv-lce-hg"
            state: absent
          ignore_errors: true

    # =========================================================================
    # ACTIVATION KEY TESTS
    # =========================================================================

    - name: "Test 1 - AK create with deprecated params (should warn + succeed)"
      activation_key:
        <<: *foreman_conn
        organization: "{{ test_organization }}"
        name: "test-deprecated-cv-lce"
        lifecycle_environment: "{{ test_lifecycle_environment }}"
        content_view: "{{ test_content_view }}"
        state: present
      register: ak_create
    - debug:
        msg: "Test 1: changed={{ ak_create.changed }}, warnings={{ ak_create.warnings | default([]) }}"
    - assert:
        that: ak_create.changed
        fail_msg: "Test 1 FAILED - AK should have been created"

    - name: "Test 2 - AK idempotency with deprecated params (should not change)"
      activation_key:
        <<: *foreman_conn
        organization: "{{ test_organization }}"
        name: "test-deprecated-cv-lce"
        lifecycle_environment: "{{ test_lifecycle_environment }}"
        content_view: "{{ test_content_view }}"
        state: present
      register: ak_idempotent
    - debug:
        msg: "Test 2: changed={{ ak_idempotent.changed }}"
    - assert:
        that: not ak_idempotent.changed
        fail_msg: "Test 2 FAILED - AK should be idempotent (no change)"

    - name: "Test 3 - AK create with content_view_environments param (no deprecation warning)"
      activation_key:
        <<: *foreman_conn
        organization: "{{ test_organization }}"
        name: "test-new-cve-param"
        content_view_environments:
          - "{{ test_cve_label }}"
        state: present
      register: ak_cve
    - debug:
        msg: "Test 3: changed={{ ak_cve.changed }}, warnings={{ ak_cve.warnings | default([]) }}"
    - assert:
        that: ak_cve.changed
        fail_msg: "Test 3 FAILED - AK with content_view_environments should have been created"

    - name: "Test 4 - AK with content_view_environments idempotency"
      activation_key:
        <<: *foreman_conn
        organization: "{{ test_organization }}"
        name: "test-new-cve-param"
        content_view_environments:
          - "{{ test_cve_label }}"
        state: present
      register: ak_cve_idempotent
    - debug:
        msg: "Test 4: changed={{ ak_cve_idempotent.changed }}"
    - assert:
        that: not ak_cve_idempotent.changed
        fail_msg: "Test 4 FAILED - AK with content_view_environments should be idempotent"

    - name: "Test 5 - AK multi-CV protection (should FAIL if multi-CV)"
      when: test_content_view_2 is defined and test_lifecycle_environment_2 is defined
      block:
        - name: "Test 5a - Set up multi-CV activation key"
          activation_key:
            <<: *foreman_conn
            organization: "{{ test_organization }}"
            name: "test-multi-cv-ak"
            content_view_environments:
              - "{{ test_cve_label }}"
              - "{{ test_lifecycle_environment_2 }}/{{ test_content_view_2 }}"
            state: present

        - name: "Test 5b - Try deprecated params on multi-CV AK"
          activation_key:
            <<: *foreman_conn
            organization: "{{ test_organization }}"
            name: "test-multi-cv-ak"
            lifecycle_environment: "{{ test_lifecycle_environment }}"
            content_view: "{{ test_content_view }}"
            state: present
          register: ak_multi_cv
          ignore_errors: true
        - debug:
            msg: >-
              Test 5: failed={{ ak_multi_cv.failed }},
              changed={{ ak_multi_cv.changed | default('N/A') }},
              msg={{ ak_multi_cv.msg | default('') }}
        # New API: should fail with multi-CV protection error
        # Old API: should succeed but not change (old API silently ignores single params on multi-CV AKs)
        - assert:
            that: ak_multi_cv.failed or not ak_multi_cv.changed
            fail_msg: "Test 5 FAILED - Should either fail (new API) or be a no-op (old API), not change the AK"

    # =========================================================================
    # HOSTGROUP TESTS
    # =========================================================================

    - name: "Test 6 - Hostgroup create with deprecated params (should warn + succeed)"
      hostgroup:
        <<: *foreman_conn
        organization: "{{ test_organization }}"
        name: "test-deprecated-cv-lce-hg"
        lifecycle_environment: "{{ test_lifecycle_environment }}"
        content_view: "{{ test_content_view }}"
        state: present
      register: hg_create
    - debug:
        msg: "Test 6: changed={{ hg_create.changed }}, warnings={{ hg_create.warnings | default([]) }}"
    - assert:
        that: hg_create.changed
        fail_msg: "Test 6 FAILED - Hostgroup should have been created"

    - name: "Test 7 - Hostgroup idempotency with deprecated params"
      hostgroup:
        <<: *foreman_conn
        organization: "{{ test_organization }}"
        name: "test-deprecated-cv-lce-hg"
        lifecycle_environment: "{{ test_lifecycle_environment }}"
        content_view: "{{ test_content_view }}"
        state: present
      register: hg_idempotent
    - debug:
        msg: "Test 7: changed={{ hg_idempotent.changed }}"
    - assert:
        that: not hg_idempotent.changed
        fail_msg: "Test 7 FAILED - Hostgroup should be idempotent (no change)"

    # =========================================================================
    # HOST TESTS
    # =========================================================================

    - name: "Test 8 - Host create with deprecated params (should succeed)"
      host:
        <<: *foreman_conn
        organization: "{{ test_organization }}"
        location: "{{ test_location | default('Default Location') }}"
        name: "test-deprecated-cv-lce-host.example.com"
        managed: false
        lifecycle_environment: "{{ test_lifecycle_environment }}"
        content_view: "{{ test_content_view }}"
        state: present
      register: host_create
    - debug:
        msg: "Test 8: changed={{ host_create.changed }}, warnings={{ host_create.warnings | default([]) }}"
    - assert:
        that: host_create.changed
        fail_msg: "Test 8 FAILED - Host should have been created"

    - name: "Test 9 - Host idempotency with deprecated params"
      host:
        <<: *foreman_conn
        organization: "{{ test_organization }}"
        location: "{{ test_location | default('Default Location') }}"
        name: "test-deprecated-cv-lce-host.example.com"
        managed: false
        lifecycle_environment: "{{ test_lifecycle_environment }}"
        content_view: "{{ test_content_view }}"
        state: present
      register: host_idempotent
    - debug:
        msg: "Test 9: changed={{ host_idempotent.changed }}"
    - assert:
        that: not host_idempotent.changed
        fail_msg: "Test 9 FAILED - Host should be idempotent (no change)"

    # =========================================================================
    # CLEANUP (after tests)
    # =========================================================================

    - name: "Cleanup - Remove test host"
      host:
        <<: *foreman_conn
        name: "test-deprecated-cv-lce-host.example.com"
        state: absent
      ignore_errors: true

    - name: "Cleanup - Remove test activation keys"
      activation_key:
        <<: *foreman_conn
        organization: "{{ test_organization }}"
        name: "{{ item }}"
        state: absent
      loop:
        - "test-deprecated-cv-lce"
        - "test-new-cve-param"
        - "test-multi-cv-ak"
      ignore_errors: true

    - name: "Cleanup - Remove test hostgroup"
      hostgroup:
        <<: *foreman_conn
        name: "test-deprecated-cv-lce-hg"
        state: absent
      ignore_errors: true
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)