### PR TITLE
Add org scoping to lifecycle_environments variable

### DIFF
--- a/plugins/modules/content_view.py
+++ b/plugins/modules/content_view.py
@@ -200,7 +200,7 @@ def main():
             solve_dependencies=dict(type='bool'),
             import_only=dict(type='bool'),
             components=dict(type='nested_list', foreman_spec=cvc_foreman_spec, resolve=False),
-            lifecycle_environments=dict(type='entity_list', flat_name='environment_ids'),
+            lifecycle_environments=dict(type='entity_list', flat_name='environment_ids', scope=['organization']),
             repositories=dict(type='entity_list', elements='dict', resolve=False, options=dict(
                 name=dict(required=True),
                 product=dict(required=True),

--- a/tests/test_playbooks/fixtures/content_view-20.yml
+++ b/tests/test_playbooks/fixtures/content_view-20.yml
@@ -311,7 +311,7 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/environments?search=name%3D%22QA%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/3/environments?search=name%3D%22QA%22&per_page=4294967296
   response:
     body:
       string: '{"total":5,"subtotal":1,"selectable":1,"page":1,"per_page":4294967296,"error":null,"search":"name=\"QA\"","sort":{"by":"name","order":"asc"},"results":[{"library":false,"registry_name_pattern":null,"registry_unauthenticated_pull":false,"id":4,"name":"QA","label":"qa","description":null,"organization_id":3,"organization":{"name":"Test
@@ -371,7 +371,7 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/environments?search=name%3D%22Test%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/3/environments?search=name%3D%22Test%22&per_page=4294967296
   response:
     body:
       string: '{"total":5,"subtotal":1,"selectable":1,"page":1,"per_page":4294967296,"error":null,"search":"name=\"Test\"","sort":{"by":"name","order":"asc"},"results":[{"library":false,"registry_name_pattern":null,"registry_unauthenticated_pull":false,"id":3,"name":"Test","label":"test","description":null,"organization_id":3,"organization":{"name":"Test
@@ -431,7 +431,7 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/environments?search=name%3D%22Prod%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/3/environments?search=name%3D%22Prod%22&per_page=4294967296
   response:
     body:
       string: '{"total":5,"subtotal":1,"selectable":1,"page":1,"per_page":4294967296,"error":null,"search":"name=\"Prod\"","sort":{"by":"name","order":"asc"},"results":[{"library":false,"registry_name_pattern":null,"registry_unauthenticated_pull":false,"id":5,"name":"Prod","label":"prod","description":null,"organization_id":3,"organization":{"name":"Test

--- a/tests/test_playbooks/fixtures/content_view-21.yml
+++ b/tests/test_playbooks/fixtures/content_view-21.yml
@@ -384,7 +384,7 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/environments?search=name%3D%22QA%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/3/environments?search=name%3D%22QA%22&per_page=4294967296
   response:
     body:
       string: '{"total":5,"subtotal":1,"selectable":1,"page":1,"per_page":4294967296,"error":null,"search":"name=\"QA\"","sort":{"by":"name","order":"asc"},"results":[{"library":false,"registry_name_pattern":null,"registry_unauthenticated_pull":false,"id":4,"name":"QA","label":"qa","description":null,"organization_id":3,"organization":{"name":"Test
@@ -445,7 +445,7 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/environments?search=name%3D%22Prod%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/3/environments?search=name%3D%22Prod%22&per_page=4294967296
   response:
     body:
       string: '{"total":5,"subtotal":1,"selectable":1,"page":1,"per_page":4294967296,"error":null,"search":"name=\"Prod\"","sort":{"by":"name","order":"asc"},"results":[{"library":false,"registry_name_pattern":null,"registry_unauthenticated_pull":false,"id":5,"name":"Prod","label":"prod","description":null,"organization_id":3,"organization":{"name":"Test
@@ -506,7 +506,7 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/environments?search=name%3D%22Test%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/3/environments?search=name%3D%22Test%22&per_page=4294967296
   response:
     body:
       string: '{"total":5,"subtotal":1,"selectable":1,"page":1,"per_page":4294967296,"error":null,"search":"name=\"Test\"","sort":{"by":"name","order":"asc"},"results":[{"library":false,"registry_name_pattern":null,"registry_unauthenticated_pull":false,"id":3,"name":"Test","label":"test","description":null,"organization_id":3,"organization":{"name":"Test


### PR DESCRIPTION
This fixes the `Found too many (3) results while searching for lifecycle_environments with name="Library"` error message seen when specifing lifecycle_environments for both the `content_view` and `smart_proxy modules`.

This related to [1463](https://github.com/theforeman/foreman-ansible-modules/issues/1463) _theforeman.foreman.smart_proxy lifecycle_environments not working with duplicate LCEs names_.