### PR TITLE
Switch default Python to 3.13 and fix 2.21+ callback tests

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: "3.13"
       - name: Install dependencies
         run: make doc-setup
       - name: Generate changelog

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,10 +48,8 @@ jobs:
       fail-fast: false
       matrix:
         python:
-          - "3.12"
+          - "3.13"
         ansible:
-          - stable-2.16
-          - stable-2.17
           - stable-2.18
           - stable-2.19
           - stable-2.20
@@ -76,8 +74,10 @@ jobs:
             ansible: "stable-2.14"
           - python: "3.11"
             ansible: "stable-2.15"
-          - python: "3.13"
-            ansible: "devel"
+          - python: "3.12"
+            ansible: "stable-2.16"
+          - python: "3.12"
+            ansible: "stable-2.17"
           - python: "3.14"
             ansible: "devel"
     steps:
@@ -129,7 +129,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: "3.13"
           cache: 'pip'
           cache-dependency-path: '**/requirements*.txt'
       - name: Install system dependencies
@@ -156,7 +156,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: "3.13"
           cache: 'pip'
           cache-dependency-path: '**/requirements*.txt'
       - name: Install dependencies
@@ -178,7 +178,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: "3.13"
           cache: 'pip'
           cache-dependency-path: '**/requirements*.txt'
       - name: Install dependencies
@@ -193,7 +193,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: "3.13"
           cache: 'pip'
           cache-dependency-path: '**/requirements*.txt'
       - name: Install dependencies
@@ -215,7 +215,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: "3.13"
           cache: 'pip'
           cache-dependency-path: '**/requirements*.txt'
       - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: "3.13"
       - name: Install Ansible
         run: pip install --upgrade ansible py antsibull-changelog
       - name: Build Ansible Collection

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -4,6 +4,7 @@ inventory = tests/inventory/hosts
 retry_files_enabled = False
 devel_warning = False
 collections_on_ansible_version_mismatch = ignore
+inject_invocation = True
 
 [inventory]
 host_pattern_mismatch = ignore


### PR DESCRIPTION
Ansible devel (and 2.22+) requires Python 3.13.
Keep 2.16/2.17 on 3.12, as they do not support 3.13.