### PR TITLE
Deprecate content_view and lifecycle_environment for activation_key

### DIFF
--- a/changelogs/fragments/deprecate-ak-cv-lce-params.yml
+++ b/changelogs/fragments/deprecate-ak-cv-lce-params.yml
@@ -1,0 +1,9 @@
+deprecated_features:
+  - activation_key - the ``content_view`` and ``lifecycle_environment`` parameters
+    are deprecated, please use ``content_view_environments`` instead
+    (https://github.com/theforeman/foreman-ansible-modules/pull/1982)
+minor_changes:
+  - activation_key - internally convert deprecated
+    ``content_view``/``lifecycle_environment`` to content view environment labels
+    for compatibility with newer Katello API versions
+    (https://github.com/theforeman/foreman-ansible-modules/pull/1982)

--- a/plugins/module_utils/foreman_helper.py
+++ b/plugins/module_utils/foreman_helper.py
@@ -742,6 +742,21 @@ class ForemanAnsibleModule(AnsibleModule):
     def find_resources_by_name(self, resource, names, **kwargs):
         return [self.find_resource_by_name(resource, name, **kwargs) for name in names]
 
+    def find_content_view_environment(self, content_view_id, lifecycle_environment_id, organization_id=None):
+        params = {
+            'content_view_id': content_view_id,
+            'lifecycle_environment_id': lifecycle_environment_id,
+        }
+        if organization_id:
+            params['organization_id'] = organization_id
+        results = self.list_resource('content_view_environments', params=params)
+        if len(results) != 1:
+            self.fail_json(
+                msg="Expected one ContentViewEnvironment for content_view_id={0} "
+                    "and lifecycle_environment_id={1}, found {2}".format(
+                        content_view_id, lifecycle_environment_id, len(results)))
+        return results[0]
+
     def find_operatingsystem(self, name, failsafe=False, **kwargs):
         result = self.find_resource_by_title('operatingsystems', name, failsafe=True, **kwargs)
         if not result:
@@ -1097,16 +1112,25 @@ class ForemanAnsibleModule(AnsibleModule):
                 payload[key] = value
         # workaround to ensure LCE and CV are always sent together, even if only one changed
         # using the values from the existing entity, so the user doesn't need to pass it in their playbook
+        # Uses .get() because newer Katello versions may not include these fields in the API response
         if resource == 'hosts':
             if 'content_view_id' in payload and 'lifecycle_environment_id' not in payload:
-                payload['lifecycle_environment_id'] = current_flat_entity['lifecycle_environment_id']
+                lce_id = current_flat_entity.get('lifecycle_environment_id')
+                if lce_id is not None:
+                    payload['lifecycle_environment_id'] = lce_id
             elif 'lifecycle_environment_id' in payload and 'content_view_id' not in payload:
-                payload['content_view_id'] = current_flat_entity['content_view_id']
+                cv_id = current_flat_entity.get('content_view_id')
+                if cv_id is not None:
+                    payload['content_view_id'] = cv_id
         elif resource == 'activation_keys':
             if 'content_view_id' in payload and 'environment_id' not in payload:
-                payload['environment_id'] = current_flat_entity['environment_id']
+                env_id = current_flat_entity.get('environment_id')
+                if env_id is not None:
+                    payload['environment_id'] = env_id
             elif 'environment_id' in payload and 'content_view_id' not in payload:
-                payload['content_view_id'] = current_flat_entity['content_view_id']
+                cv_id = current_flat_entity.get('content_view_id')
+                if cv_id is not None:
+                    payload['content_view_id'] = cv_id
         if self._validate_supported_payload(resource, 'update', payload):
             self.set_changed()
             payload['id'] = current_flat_entity['id']

--- a/plugins/modules/activation_key.py
+++ b/plugins/modules/activation_key.py
@@ -40,10 +40,12 @@ options:
   lifecycle_environment:
     description:
       - Name of the lifecycle environment
+      - "Deprecated: Use I(content_view_environments) instead."
     type: str
   content_view:
     description:
       - Name of the content view
+      - "Deprecated: Use I(content_view_environments) instead."
     type: str
   content_view_environments:
     description:
@@ -307,8 +309,56 @@ def main():
         content_view_environments = module.foreman_params.pop('content_view_environments', None)
         content_view = module.foreman_params.get("content_view")
         lifecycle_environment = module.foreman_params.get("lifecycle_environment")
-        # only use content view environments if content view and lifecycle environment are not specified
-        if content_view_environments is not None and content_view is None and lifecycle_environment is None:
+        converted_from_deprecated = False
+
+        if (content_view is not None or lifecycle_environment is not None) and content_view_environments is None:
+            _filtered, unsupported = module.foremanapi.validate_payload('activation_keys', 'create', {'content_view_id': 1})
+            if 'content_view_id' in unsupported:
+                if entity:
+                    entity_cves = entity.get('content_view_environments', [])
+                    if len(entity_cves) > 1:
+                        module.fail_json(
+                            msg="This activation key has multiple content view environments. "
+                                "The deprecated 'content_view' and 'lifecycle_environment' "
+                                "parameters cannot safely update it — they would overwrite "
+                                "the existing multi-CV assignment. Use "
+                                "'content_view_environments' instead."
+                        )
+
+                module.warn(
+                    "The 'content_view' and 'lifecycle_environment' parameters for activation_key "
+                    "are deprecated. Please use 'content_view_environments' instead."
+                )
+
+                module.lookup_entity('content_view')
+                module.lookup_entity('lifecycle_environment')
+
+                cv = module.foreman_params.get('content_view')
+                lce = module.foreman_params.get('lifecycle_environment')
+
+                cv_id = cv['id'] if cv else None
+                lce_id = lce['id'] if lce else None
+
+                if entity and cv_id is None:
+                    entity_cves = entity.get('content_view_environments', [])
+                    if entity_cves:
+                        cv_id = entity_cves[0]['content_view']['id']
+                if entity and lce_id is None:
+                    entity_cves = entity.get('content_view_environments', [])
+                    if entity_cves:
+                        lce_id = entity_cves[0]['lifecycle_environment']['id']
+
+                if cv_id is None or lce_id is None:
+                    module.fail_json(msg="Both 'content_view' and 'lifecycle_environment' must be provided together.")
+
+                cve = module.find_content_view_environment(cv_id, lce_id, scope['organization_id'])
+                content_view_environments = [cve['label']]
+                converted_from_deprecated = True
+
+                module.foreman_spec['content_view']['ensure'] = False
+                module.foreman_spec['lifecycle_environment']['ensure'] = False
+
+        if content_view_environments is not None and (converted_from_deprecated or (content_view is None and lifecycle_environment is None)):
             desired_content_view_environments = set(content_view_environments)
             if not entity:
                 current_content_view_environments = set()


### PR DESCRIPTION
## Summary

- Deprecate the `content_view` and `lifecycle_environment` parameters on the `activation_key` module in favor of `content_view_environments`
- On newer Katello versions (where `content_view_id`/`environment_id` API params are removed), internally convert the deprecated params to content view environment labels
- Multi-CV activation keys are protected from accidental overwrite — using deprecated params against a multi-CV AK fails with a clear error
- Use safe `.get()` access in the `_update_entity` workaround to prevent KeyError on newer Katello API responses
- Backward compatible: old Katello versions work unchanged (conversion is skipped)

Split out from #1977 per review feedback. Host/hostgroup changes will follow separately.

Related Katello PR: https://github.com/Katello/katello/pull/11753

🤖 Generated with [Claude Code](https://claude.com/claude-code)