### PR TITLE
Add content_view_environment(s) params to host and hostgroup

### DIFF
--- a/changelogs/fragments/add-cve-params-host-hostgroup.yml
+++ b/changelogs/fragments/add-cve-params-host-hostgroup.yml
@@ -1,0 +1,14 @@
+minor_changes:
+  - host - add ``content_view_environments`` parameter to specify content view environments
+    as a list of labels, replacing the deprecated ``content_view``/``lifecycle_environment``
+    parameter pair
+    (https://github.com/theforeman/foreman-ansible-modules/pull/XXXX)
+  - hostgroup - add ``content_view_environment`` parameter to specify the content view
+    environment as a label, replacing the deprecated ``content_view``/``lifecycle_environment``
+    parameter pair
+    (https://github.com/theforeman/foreman-ansible-modules/pull/XXXX)
+deprecated_features:
+  - host, hostgroup - the ``content_view`` and ``lifecycle_environment`` parameters
+    are deprecated in favor of ``content_view_environments`` (hosts) and
+    ``content_view_environment`` (hostgroups)
+    (https://github.com/theforeman/foreman-ansible-modules/pull/XXXX)

--- a/plugins/doc_fragments/foreman.py
+++ b/plugins/doc_fragments/foreman.py
@@ -293,6 +293,7 @@ options:
     description:
       - Lifecycle environment.
       - Only available for Katello installations.
+      - "Deprecated: Use I(content_view_environments) for hosts or I(content_view_environment) for hostgroups instead."
     required: false
     type: str
   kickstart_repository:
@@ -307,6 +308,7 @@ options:
     description:
       - Content view.
       - Only available for Katello installations.
+      - "Deprecated: Use I(content_view_environments) for hosts or I(content_view_environment) for hostgroups instead."
     required: false
     type: str
   activation_keys:

--- a/plugins/module_utils/foreman_helper.py
+++ b/plugins/module_utils/foreman_helper.py
@@ -369,13 +369,16 @@ class HostMixin(ParametersMixin):
         )
 
         if entity:
-            entity_cves = entity.get('content_view_environments', [])
+            if resource == 'hosts':
+                entity_cves = entity.get('content_facet_attributes', {}).get('content_view_environments', [])
+            else:
+                entity_cves = entity.get('content_view_environments', [])
             if len(entity_cves) > 1:
                 self.fail_json(
                     msg="This {0} has multiple content view environments. "
                         "The 'content_view' and 'lifecycle_environment' parameters "
                         "cannot safely update it — they would overwrite the existing "
-                        "multi-CV assignment.".format(self.entity_name)
+                        "multi-CV assignment. Use '{1}' instead.".format(self.entity_name, replacement)
                 )
 
         cv = self.lookup_entity('content_view')
@@ -387,13 +390,19 @@ class HostMixin(ParametersMixin):
         if entity and cv_id is None:
             cv_id = entity.get('content_view_id')
             if cv_id is None:
-                entity_cves = entity.get('content_view_environments', [])
+                if resource == 'hosts':
+                    entity_cves = entity.get('content_facet_attributes', {}).get('content_view_environments', [])
+                else:
+                    entity_cves = entity.get('content_view_environments', [])
                 if entity_cves:
                     cv_id = entity_cves[0].get('content_view', {}).get('id')
         if entity and lce_id is None:
             lce_id = entity.get('lifecycle_environment_id')
             if lce_id is None:
-                entity_cves = entity.get('content_view_environments', [])
+                if resource == 'hosts':
+                    entity_cves = entity.get('content_facet_attributes', {}).get('content_view_environments', [])
+                else:
+                    entity_cves = entity.get('content_view_environments', [])
                 if entity_cves:
                     lce_id = entity_cves[0].get('lifecycle_environment', {}).get('id')
 
@@ -444,7 +453,7 @@ class HostMixin(ParametersMixin):
         search_params = {}
         if org_id:
             search_params['organization_id'] = org_id
-        cve = self.find_resource_by('content_view_environments', 'label', label, params=search_params)
+        cve = self.find_resource_by('content_view_environments', 'label', label, params=search_params, thin=True)
 
         current_cve_id = entity.get('content_view_environment_id') if entity else None
         if cve['id'] != current_cve_id:

--- a/plugins/module_utils/foreman_helper.py
+++ b/plugins/module_utils/foreman_helper.py
@@ -318,7 +318,8 @@ class HostMixin(ParametersMixin):
         )
         foreman_spec.update(kwargs.pop('foreman_spec', {}))
         required_plugins = kwargs.pop('required_plugins', []) + [
-            ('katello', ['activation_keys', 'content_source', 'lifecycle_environment', 'kickstart_repository', 'content_view']),
+            ('katello', ['activation_keys', 'content_source', 'lifecycle_environment', 'kickstart_repository', 'content_view',
+                        'content_view_environments', 'content_view_environment']),
             ('openscap', ['openscap_proxy']),
         ]
         mutually_exclusive = kwargs.pop('mutually_exclusive', []) + [['medium', 'kickstart_repository']]
@@ -328,7 +329,11 @@ class HostMixin(ParametersMixin):
         entity = self.lookup_entity('entity')
 
         if not self.desired_absent:
-            if 'content_view' in self.foreman_params or 'lifecycle_environment' in self.foreman_params:
+            if 'content_view_environments' in self.foreman_params:
+                self._handle_content_view_environments(entity)
+            elif 'content_view_environment' in self.foreman_params:
+                self._handle_content_view_environment(entity)
+            elif 'content_view' in self.foreman_params or 'lifecycle_environment' in self.foreman_params:
                 self._convert_cv_lce_to_cve(entity)
 
             if 'activation_keys' in self.foreman_params:
@@ -353,6 +358,15 @@ class HostMixin(ParametersMixin):
         _filtered, unsupported = self.foremanapi.validate_payload(resource, 'create', {'content_view_id': 1})
         if 'content_view_id' not in unsupported:
             return
+
+        if resource == 'hosts':
+            replacement = 'content_view_environments'
+        else:
+            replacement = 'content_view_environment'
+        self.warn(
+            "The 'content_view' and 'lifecycle_environment' parameters for {0} "
+            "are deprecated. Please use '{1}' instead.".format(self.entity_name, replacement)
+        )
 
         if entity:
             entity_cves = entity.get('content_view_environments', [])
@@ -405,6 +419,36 @@ class HostMixin(ParametersMixin):
             current_cve_id = entity.get('content_view_environment_id') if entity else None
             if cve['id'] != current_cve_id:
                 self.foreman_params['content_view_environment_id'] = cve['id']
+
+    def _handle_content_view_environments(self, entity):
+        content_view_environments = self.foreman_params.pop('content_view_environments')
+        desired = set(content_view_environments)
+        if entity:
+            current = set()
+            for cve in entity.get('content_facet_attributes', {}).get('content_view_environments', []):
+                label = cve.get('label')
+                if label:
+                    current.add(label)
+        else:
+            current = set()
+        if desired != current:
+            self.foreman_params['content_view_environments'] = sorted(list(desired))
+
+    def _handle_content_view_environment(self, entity):
+        label = self.foreman_params.pop('content_view_environment')
+
+        org_id = self.lookup_entity('organization')['id'] if 'organization' in self.foreman_params else None
+        if org_id is None and entity:
+            org_id = entity.get('organization_id')
+
+        search_params = {}
+        if org_id:
+            search_params['organization_id'] = org_id
+        cve = self.find_resource_by('content_view_environments', 'label', label, params=search_params)
+
+        current_cve_id = entity.get('content_view_environment_id') if entity else None
+        if cve['id'] != current_cve_id:
+            self.foreman_params['content_view_environment_id'] = cve['id']
 
 
 class ForemanAnsibleModule(AnsibleModule):

--- a/plugins/module_utils/foreman_helper.py
+++ b/plugins/module_utils/foreman_helper.py
@@ -319,7 +319,7 @@ class HostMixin(ParametersMixin):
         foreman_spec.update(kwargs.pop('foreman_spec', {}))
         required_plugins = kwargs.pop('required_plugins', []) + [
             ('katello', ['activation_keys', 'content_source', 'lifecycle_environment', 'kickstart_repository', 'content_view',
-                        'content_view_environments', 'content_view_environment']),
+                         'content_view_environments', 'content_view_environment']),
             ('openscap', ['openscap_proxy']),
         ]
         mutually_exclusive = kwargs.pop('mutually_exclusive', []) + [['medium', 'kickstart_repository']]

--- a/plugins/module_utils/foreman_helper.py
+++ b/plugins/module_utils/foreman_helper.py
@@ -445,6 +445,7 @@ class HostMixin(ParametersMixin):
 
     def _handle_content_view_environment(self, entity):
         label = self.foreman_params.pop('content_view_environment')
+        resource = inflector.pluralize(self.entity_name)
 
         org_id = self.lookup_entity('organization')['id'] if 'organization' in self.foreman_params else None
         if org_id is None and entity:
@@ -455,9 +456,20 @@ class HostMixin(ParametersMixin):
             search_params['organization_id'] = org_id
         cve = self.find_resource_by('content_view_environments', 'label', label, params=search_params, thin=True)
 
-        current_cve_id = entity.get('content_view_environment_id') if entity else None
-        if cve['id'] != current_cve_id:
-            self.foreman_params['content_view_environment_id'] = cve['id']
+        _filtered, unsupported = self.foremanapi.validate_payload(resource, 'create', {'content_view_environment_id': 1})
+        if 'content_view_environment_id' not in unsupported:
+            current_cve_id = entity.get('content_view_environment_id') if entity else None
+            if cve['id'] != current_cve_id:
+                self.foreman_params['content_view_environment_id'] = cve['id']
+        else:
+            current_cv_id = entity.get('content_view_id') if entity else None
+            current_lce_id = entity.get('lifecycle_environment_id') if entity else None
+            cv_id = cve.get('content_view', {}).get('id')
+            lce_id = cve.get('lifecycle_environment', {}).get('id')
+            if cv_id != current_cv_id:
+                self.foreman_params['content_view_id'] = cv_id
+            if lce_id != current_lce_id:
+                self.foreman_params['lifecycle_environment_id'] = lce_id
 
 
 class ForemanAnsibleModule(AnsibleModule):

--- a/plugins/modules/host.py
+++ b/plugins/modules/host.py
@@ -262,6 +262,15 @@ options:
           - When you provide a I(network) here and I(compute_resource) is set, the network id will be automatically looked up.
           - On oVirt/RHV I(cluster) is required in the hosts I(compute_attributes) for the lookup to work.
         type: dict
+  content_view_environments:
+    description:
+      - List of content view environments specified as labels.
+      - 'Labels have the format "lifecycle_environment_label/content_view_label",
+        for example "Library/Default_Organization_View".'
+      - Mutually exclusive with I(content_view) and I(lifecycle_environment).
+      - Only available for Katello installations.
+    type: list
+    elements: str
 extends_documentation_fragment:
   - theforeman.foreman.foreman
   - theforeman.foreman.foreman.entity_state
@@ -453,9 +462,12 @@ def main():
             image=dict(type='entity', scope=['compute_resource']),
             compute_attributes=dict(type='dict'),
             interfaces_attributes=dict(type='nested_list', foreman_spec=interfaces_spec, ensure=True),
+            content_view_environments=dict(type='list', elements='str'),
         ),
         mutually_exclusive=[
-            ['owner', 'owner_group']
+            ['owner', 'owner_group'],
+            ['content_view', 'content_view_environments'],
+            ['lifecycle_environment', 'content_view_environments'],
         ],
         required_by=dict(
             image=('compute_resource',),

--- a/plugins/modules/hostgroup.py
+++ b/plugins/modules/hostgroup.py
@@ -65,6 +65,14 @@ options:
     type: list
     elements: str
     version_added: 2.1.0
+  content_view_environment:
+    description:
+      - Content view environment specified as a label.
+      - 'Labels have the format "lifecycle_environment_label/content_view_label",
+        for example "Library/Default_Organization_View".'
+      - Mutually exclusive with I(content_view) and I(lifecycle_environment).
+      - Only available for Katello installations.
+    type: str
 extends_documentation_fragment:
   - theforeman.foreman.foreman
   - theforeman.foreman.foreman.entity_state
@@ -169,14 +177,20 @@ def main():
             parent=dict(type='entity'),
             ansible_roles=dict(type='entity_list', ensure=False),
             organization=dict(type='entity', required=False, ensure=False),
+            content_view_environment=dict(type='str'),
         ),
         argument_spec=dict(
             updated_name=dict(),
         ),
+        mutually_exclusive=[
+            ['content_view', 'content_view_environment'],
+            ['lifecycle_environment', 'content_view_environment'],
+        ],
         required_by=dict(
             content_source=('organization',),
             content_view=('organization',),
             lifecycle_environment=('organization',),
+            content_view_environment=('organization',),
         ),
         required_plugins=[('ansible', ['ansible_roles'])],
     )

--- a/tests/test_playbooks/tasks/host.yml
+++ b/tests/test_playbooks/tasks/host.yml
@@ -38,6 +38,7 @@
     content_source: "{{ host_content_source | default(omit) }}"
     lifecycle_environment: "{{ host_lifecycle_environment | default(omit) }}"
     content_view: "{{ host_content_view | default(omit) }}"
+    content_view_environments: "{{ host_content_view_environments | default(omit) }}"
     provision_method: "{{ host_provision_method | default(omit) }}"
     image: "{{ host_image | default(omit) }}"
     interfaces_attributes: "{{ host_interfaces_attributes | default(omit) }}"

--- a/tests/test_playbooks/tasks/hostgroup.yml
+++ b/tests/test_playbooks/tasks/hostgroup.yml
@@ -36,6 +36,7 @@
     content_source: "{{ hostgroup_content_source | default(omit) }}"
     lifecycle_environment: "{{ hostgroup_lifecycle_environment | default(omit) }}"
     content_view: "{{ hostgroup_content_view | default(omit) }}"
+    content_view_environment: "{{ hostgroup_content_view_environment | default(omit) }}"
     ansible_roles: "{{ hostgroup_ansible_roles | default(omit) }}"
     parameters: "{{ hostgroup_parameters | default(omit) }}"
     activation_keys: "{{ hostgroup_activation_keys | default(omit) }}"


### PR DESCRIPTION
## Summary

Follow-up to #1977. Adds user-facing content view environment parameters so the deprecated `content_view`/`lifecycle_environment` params have proper replacements:

- **host**: `content_view_environments` (list of labels, e.g. `["Library", "Dev/My_Content_View"]`) — passes labels to the API, which resolves them server-side (same approach as `activation_key`)
- **hostgroup**: `content_view_environment` (single label string) — resolves the label to a CVEnv ID via the `content_view_environments` API, since the hostgroup API only accepts `content_view_environment_id`

Also adds:
- Deprecation warnings when using old `content_view`/`lifecycle_environment` params on newer Katello
- Mutual exclusivity between old and new params
- Deprecation notices in `host_options` doc fragment
- Changelog entries
- Bugfix: multi-CVEnv guard in `_convert_cv_lce_to_cve` was checking `entity.get('content_view_environments')` at the top level, but for hosts CVEnvs are nested under `content_facet_attributes` — the guard never fired for hosts

## Test plan

- [x] Existing tests pass (354 passed, 2 pre-existing failures unrelated to this PR)
- [x] Manual test: set `content_view_environments` on a host, verify idempotency
- [x] Manual test: set `content_view_environment` on a hostgroup, verify idempotency
- [x] Verify old `content_view`/`lifecycle_environment` params still work with deprecation warning
- [x] Multi-CVEnv guard fires correctly when deprecated params used on a multi-CVEnv host
- [x] Mutual exclusivity rejects combining old and new params
- [ ] Record test fixtures against a real Katello instance

<details>
<summary>Test playbook</summary>

```yaml
---
# Manual test playbook for new content_view_environment(s) params on host/hostgroup.
# Idempotent: cleans up before and after, safe to re-run.
#
# Usage:
#   ansible-playbook test_cvenv_params.yml -e @test_cv_lce_vars.yml

- name: "Test content_view_environment(s) params on host and hostgroup"
  hosts: localhost
  collections:
    - theforeman.foreman
  gather_facts: false
  vars:
    foreman_conn: &foreman_conn
      server_url: "{{ foreman_server_url }}"
      username: "{{ foreman_username }}"
      password: "{{ foreman_password }}"
      validate_certs: "{{ foreman_validate_certs }}"
  tasks:

    # =========================================================================
    # CLEANUP (before tests)
    # =========================================================================

    - name: "Setup - Remove leftover test resources"
      block:
        - host:
            <<: *foreman_conn
            name: "test-cvenv-host.example.com"
            state: absent
          ignore_errors: true
        - hostgroup:
            <<: *foreman_conn
            name: "test-cvenv-hostgroup"
            state: absent
          ignore_errors: true

    # =========================================================================
    # HOST TESTS - content_view_environments (plural, list of labels)
    # =========================================================================

    - name: "Test 1 - Host create with content_view_environments"
      host:
        <<: *foreman_conn
        organization: "{{ test_organization }}"
        location: "{{ test_location | default('Default Location') }}"
        name: "test-cvenv-host.example.com"
        managed: false
        content_view_environments:
          - "{{ test_cve_label }}"
        state: present
      register: host_create
    - debug:
        msg: "Test 1: changed={{ host_create.changed }}"
    - assert:
        that: host_create.changed
        fail_msg: "Test 1 FAILED - Host should have been created"

    - name: "Test 2 - Host idempotency with content_view_environments"
      host:
        <<: *foreman_conn
        organization: "{{ test_organization }}"
        location: "{{ test_location | default('Default Location') }}"
        name: "test-cvenv-host.example.com"
        managed: false
        content_view_environments:
          - "{{ test_cve_label }}"
        state: present
      register: host_idempotent
    - debug:
        msg: "Test 2: changed={{ host_idempotent.changed }}"
    - assert:
        that: not host_idempotent.changed
        fail_msg: "Test 2 FAILED - Host should be idempotent (no change)"

    - name: "Test 3 - Host update to multi-CVEnv with content_view_environments"
      when: test_content_view_2 is defined and test_lifecycle_environment_2 is defined
      block:
        - host:
            <<: *foreman_conn
            organization: "{{ test_organization }}"
            location: "{{ test_location | default('Default Location') }}"
            name: "test-cvenv-host.example.com"
            managed: false
            content_view_environments:
              - "{{ test_cve_label }}"
              - "{{ test_lifecycle_environment_2 }}/{{ test_content_view_2 }}"
            state: present
          register: host_multi
        - debug:
            msg: "Test 3: changed={{ host_multi.changed }}"
        - assert:
            that: host_multi.changed
            fail_msg: "Test 3 FAILED - Host should have been updated to multi-CVEnv"

    - name: "Test 4 - Host multi-CVEnv idempotency (reorder should not change)"
      when: test_content_view_2 is defined and test_lifecycle_environment_2 is defined
      block:
        - host:
            <<: *foreman_conn
            organization: "{{ test_organization }}"
            location: "{{ test_location | default('Default Location') }}"
            name: "test-cvenv-host.example.com"
            managed: false
            content_view_environments:
              - "{{ test_lifecycle_environment_2 }}/{{ test_content_view_2 }}"
              - "{{ test_cve_label }}"
            state: present
          register: host_reorder
        - debug:
            msg: "Test 4: changed={{ host_reorder.changed }}"
        - assert:
            that: not host_reorder.changed
            fail_msg: "Test 4 FAILED - Reordering CVEnvs should be idempotent"

    - name: "Test 5 - Deprecated params on multi-CVEnv host should fail"
      when: test_content_view_2 is defined and test_lifecycle_environment_2 is defined
      block:
        - host:
            <<: *foreman_conn
            organization: "{{ test_organization }}"
            location: "{{ test_location | default('Default Location') }}"
            name: "test-cvenv-host.example.com"
            managed: false
            lifecycle_environment: "{{ test_lifecycle_environment }}"
            content_view: "{{ test_content_view }}"
            state: present
          register: host_deprecated_multi
          ignore_errors: true
        - debug:
            msg: >-
              Test 5: failed={{ host_deprecated_multi.failed }},
              msg={{ host_deprecated_multi.msg | default('') }}
        - assert:
            that: host_deprecated_multi.failed
            fail_msg: "Test 5 FAILED - Deprecated params on multi-CVEnv host should have failed"

    # =========================================================================
    # HOSTGROUP TESTS - content_view_environment (singular label)
    # =========================================================================

    - name: "Test 6 - Hostgroup create with content_view_environment"
      hostgroup:
        <<: *foreman_conn
        organization: "{{ test_organization }}"
        name: "test-cvenv-hostgroup"
        content_view_environment: "{{ test_cve_label }}"
        state: present
      register: hg_create
    - debug:
        msg: "Test 6: changed={{ hg_create.changed }}"
    - assert:
        that: hg_create.changed
        fail_msg: "Test 6 FAILED - Hostgroup should have been created"

    - name: "Test 7 - Hostgroup idempotency with content_view_environment"
      hostgroup:
        <<: *foreman_conn
        organization: "{{ test_organization }}"
        name: "test-cvenv-hostgroup"
        content_view_environment: "{{ test_cve_label }}"
        state: present
      register: hg_idempotent
    - debug:
        msg: "Test 7: changed={{ hg_idempotent.changed }}"
    - assert:
        that: not hg_idempotent.changed
        fail_msg: "Test 7 FAILED - Hostgroup should be idempotent (no change)"

    - name: "Test 8 - Hostgroup update content_view_environment to different CVEnv"
      when: test_content_view_2 is defined and test_lifecycle_environment_2 is defined
      block:
        - hostgroup:
            <<: *foreman_conn
            organization: "{{ test_organization }}"
            name: "test-cvenv-hostgroup"
            content_view_environment: "{{ test_lifecycle_environment_2 }}/{{ test_content_view_2 }}"
            state: present
          register: hg_update
        - debug:
            msg: "Test 8: changed={{ hg_update.changed }}"
        - assert:
            that: hg_update.changed
            fail_msg: "Test 8 FAILED - Hostgroup CVEnv should have been updated"

    - name: "Test 9 - Hostgroup idempotency after CVEnv update"
      when: test_content_view_2 is defined and test_lifecycle_environment_2 is defined
      block:
        - hostgroup:
            <<: *foreman_conn
            organization: "{{ test_organization }}"
            name: "test-cvenv-hostgroup"
            content_view_environment: "{{ test_lifecycle_environment_2 }}/{{ test_content_view_2 }}"
            state: present
          register: hg_idempotent2
        - debug:
            msg: "Test 9: changed={{ hg_idempotent2.changed }}"
        - assert:
            that: not hg_idempotent2.changed
            fail_msg: "Test 9 FAILED - Hostgroup should be idempotent after update"

    # =========================================================================
    # MUTUAL EXCLUSIVITY TESTS
    # =========================================================================

    - name: "Test 10 - Host mutual exclusivity (should fail)"
      host:
        <<: *foreman_conn
        name: "test-cvenv-host.example.com"
        managed: false
        content_view: "{{ test_content_view }}"
        content_view_environments:
          - "{{ test_cve_label }}"
        state: present
      register: host_mutex
      ignore_errors: true
    - debug:
        msg: "Test 10: failed={{ host_mutex.failed }}"
    - assert:
        that: host_mutex.failed
        fail_msg: "Test 10 FAILED - Mutual exclusivity should prevent using both params"

    - name: "Test 11 - Hostgroup mutual exclusivity (should fail)"
      hostgroup:
        <<: *foreman_conn
        organization: "{{ test_organization }}"
        name: "test-cvenv-hostgroup"
        content_view: "{{ test_content_view }}"
        content_view_environment: "{{ test_cve_label }}"
        state: present
      register: hg_mutex
      ignore_errors: true
    - debug:
        msg: "Test 11: failed={{ hg_mutex.failed }}"
    - assert:
        that: hg_mutex.failed
        fail_msg: "Test 11 FAILED - Mutual exclusivity should prevent using both params"

    # =========================================================================
    # CLEANUP (after tests)
    # =========================================================================

    - name: "Cleanup - Remove test host"
      host:
        <<: *foreman_conn
        name: "test-cvenv-host.example.com"
        state: absent
      ignore_errors: true

    - name: "Cleanup - Remove test hostgroup"
      hostgroup:
        <<: *foreman_conn
        name: "test-cvenv-hostgroup"
        state: absent
      ignore_errors: true
```

</details>