### PR TITLE
smart_proxy lifecycle environment scoping

### DIFF
--- a/changelogs/fragments/smart_proxy_lifecycle_environments_scope.yml
+++ b/changelogs/fragments/smart_proxy_lifecycle_environments_scope.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "smart_proxy - scope the ``lifecycle_environments`` lookup to the Smart Proxy's organization when it is assigned to exactly one, to avoid ambiguous matches against same-named Lifecycle Environments in unrelated organizations."

--- a/changelogs/fragments/smart_proxy_lifecycle_environments_scope.yml
+++ b/changelogs/fragments/smart_proxy_lifecycle_environments_scope.yml
@@ -1,2 +1,4 @@
 bugfixes:
-  - "smart_proxy - scope the ``lifecycle_environments`` lookup to the Smart Proxy's organization when it is assigned to exactly one, to avoid ambiguous matches against same-named Lifecycle Environments in unrelated organizations."
+  - >-
+    smart_proxy - scope the ``lifecycle_environments`` lookup to the Smart Proxy's organization when it is assigned to exactly one, to avoid ambiguous matches
+    against same-named Lifecycle Environments in unrelated organizations.

--- a/plugins/modules/content_view.py
+++ b/plugins/modules/content_view.py
@@ -200,7 +200,7 @@ def main():
             solve_dependencies=dict(type='bool'),
             import_only=dict(type='bool'),
             components=dict(type='nested_list', foreman_spec=cvc_foreman_spec, resolve=False),
-            lifecycle_environments=dict(type='entity_list', flat_name='environment_ids'),
+            lifecycle_environments=dict(type='entity_list', flat_name='environment_ids', scope=['organization']),
             repositories=dict(type='entity_list', elements='dict', resolve=False, options=dict(
                 name=dict(required=True),
                 product=dict(required=True),

--- a/plugins/modules/smart_proxy.py
+++ b/plugins/modules/smart_proxy.py
@@ -124,7 +124,10 @@ def main():
     with module.api_connection():
         handle_lifecycle_environments = not module.desired_absent and 'lifecycle_environments' in module.foreman_params
         if handle_lifecycle_environments:
-            module.lookup_entity('lifecycle_environments')
+            # LCE names are only unique within an organization, so scope the lookup when unambiguous
+            organizations = module.lookup_entity('organizations') or []
+            lce_params = {'organization_id': organizations[0]['id']} if len(organizations) == 1 else None
+            module.lookup_entity('lifecycle_environments', params=lce_params)
             lifecycle_environments = module.foreman_params.pop('lifecycle_environments', [])
 
         smart_proxy = module.lookup_entity('entity')

--- a/tests/test_playbooks/fixtures/content_view-20.yml
+++ b/tests/test_playbooks/fixtures/content_view-20.yml
@@ -311,7 +311,7 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/environments?search=name%3D%22QA%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/3/environments?search=name%3D%22QA%22&per_page=4294967296
   response:
     body:
       string: '{"total":5,"subtotal":1,"selectable":1,"page":1,"per_page":4294967296,"error":null,"search":"name=\"QA\"","sort":{"by":"name","order":"asc"},"results":[{"library":false,"registry_name_pattern":null,"registry_unauthenticated_pull":false,"id":4,"name":"QA","label":"qa","description":null,"organization_id":3,"organization":{"name":"Test
@@ -371,7 +371,7 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/environments?search=name%3D%22Test%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/3/environments?search=name%3D%22Test%22&per_page=4294967296
   response:
     body:
       string: '{"total":5,"subtotal":1,"selectable":1,"page":1,"per_page":4294967296,"error":null,"search":"name=\"Test\"","sort":{"by":"name","order":"asc"},"results":[{"library":false,"registry_name_pattern":null,"registry_unauthenticated_pull":false,"id":3,"name":"Test","label":"test","description":null,"organization_id":3,"organization":{"name":"Test
@@ -431,7 +431,7 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/environments?search=name%3D%22Prod%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/3/environments?search=name%3D%22Prod%22&per_page=4294967296
   response:
     body:
       string: '{"total":5,"subtotal":1,"selectable":1,"page":1,"per_page":4294967296,"error":null,"search":"name=\"Prod\"","sort":{"by":"name","order":"asc"},"results":[{"library":false,"registry_name_pattern":null,"registry_unauthenticated_pull":false,"id":5,"name":"Prod","label":"prod","description":null,"organization_id":3,"organization":{"name":"Test

--- a/tests/test_playbooks/fixtures/content_view-21.yml
+++ b/tests/test_playbooks/fixtures/content_view-21.yml
@@ -384,7 +384,7 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/environments?search=name%3D%22QA%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/3/environments?search=name%3D%22QA%22&per_page=4294967296
   response:
     body:
       string: '{"total":5,"subtotal":1,"selectable":1,"page":1,"per_page":4294967296,"error":null,"search":"name=\"QA\"","sort":{"by":"name","order":"asc"},"results":[{"library":false,"registry_name_pattern":null,"registry_unauthenticated_pull":false,"id":4,"name":"QA","label":"qa","description":null,"organization_id":3,"organization":{"name":"Test
@@ -445,7 +445,7 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/environments?search=name%3D%22Prod%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/3/environments?search=name%3D%22Prod%22&per_page=4294967296
   response:
     body:
       string: '{"total":5,"subtotal":1,"selectable":1,"page":1,"per_page":4294967296,"error":null,"search":"name=\"Prod\"","sort":{"by":"name","order":"asc"},"results":[{"library":false,"registry_name_pattern":null,"registry_unauthenticated_pull":false,"id":5,"name":"Prod","label":"prod","description":null,"organization_id":3,"organization":{"name":"Test
@@ -506,7 +506,7 @@ interactions:
       User-Agent:
       - apypie (https://github.com/Apipie/apypie)
     method: GET
-    uri: https://foreman.example.org/katello/api/environments?search=name%3D%22Test%22&per_page=4294967296
+    uri: https://foreman.example.org/katello/api/organizations/3/environments?search=name%3D%22Test%22&per_page=4294967296
   response:
     body:
       string: '{"total":5,"subtotal":1,"selectable":1,"page":1,"per_page":4294967296,"error":null,"search":"name=\"Test\"","sort":{"by":"name","order":"asc"},"results":[{"library":false,"registry_name_pattern":null,"registry_unauthenticated_pull":false,"id":3,"name":"Test","label":"test","description":null,"organization_id":3,"organization":{"name":"Test

--- a/tests/test_playbooks/fixtures/katello_smart_proxy-6.yml
+++ b/tests/test_playbooks/fixtures/katello_smart_proxy-6.yml
@@ -1,0 +1,378 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/status
+  response:
+    body:
+      string: '{"satellite_version":"6.16.0","result":"ok","status":200,"version":"3.12.0-develop","api_version":2}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Length:
+      - '100'
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:; img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.12.0-develop
+      Keep-Alive:
+      - timeout=15, max=100
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/katello/api/organizations?search=name%3D%22Test+Organization%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 1,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\": 4294967296,\n  \"search\": \"name=\\\"Test Organization\\\"\",\n  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"label\":\"Test_Organization\",\"created_at\":\"2024-07-10 14:13:09 UTC\",\"updated_at\":\"2024-07-10 14:13:09 UTC\",\"id\":6,\"name\":\"Test Organization\",\"title\":\"Test Organization\",\"description\":null}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Length:
+      - '371'
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:; img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.12.0-develop
+      Keep-Alive:
+      - timeout=15, max=99
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/katello/api/organizations/6/environments?search=name%3D%22Test%22&per_page=4294967296
+  response:
+    body:
+      string: '{"total":4,"subtotal":1,"selectable":1,"page":1,"per_page":"4294967296","error":null,"search":"name=\"Test\"","sort":{"by":"name","order":"asc"},"results":[{"library":false,"registry_name_pattern":null,"registry_unauthenticated_pull":false,"id":7,"name":"Test","label":"test","description":null,"organization_id":6,"organization":{"name":"Test Organization","label":"Test_Organization","id":6},"created_at":"2024-07-10 14:13:11 UTC","updated_at":"2024-07-10 14:13:11 UTC","prior":{"name":"Dev","id":6},"successor":null,"counts":{"content_hosts":0,"content_views":0},"permissions":{"create_lifecycle_environments":true,"view_lifecycle_environments":true,"edit_lifecycle_environments":true,"destroy_lifecycle_environments":true,"promote_or_remove_content_views_to_environments":true},"content_views":[]}]}
+
+        '
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Length:
+      - '804'
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:; img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.12.0-develop
+      Keep-Alive:
+      - timeout=15, max=98
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/smart_proxies?search=name%3D%22foreman-proxy.example.com%22&per_page=4294967296
+  response:
+    body:
+      string: "{\n  \"total\": 2,\n  \"subtotal\": 1,\n  \"page\": 1,\n  \"per_page\": 4294967296,\n  \"search\": \"name=\\\"foreman-proxy.example.com\\\"\",\n  \"sort\": {\n    \"by\": null,\n    \"order\": null\n  },\n  \"results\": [{\"created_at\":\"2024-07-10 14:13:12 UTC\",\"updated_at\":\"2024-07-10 14:13:18 UTC\",\"hosts_count\":0,\"name\":\"Smart Proxy\",\"id\":12,\"url\":\"https://foreman-proxy.example.com:9090\",\"remote_execution_pubkey\":\"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCkn5pNuZ47pHDMpL1or9cDtaDJaJXn2EdrmcQBiXQOhoWjSn3R2da7ThZkjXGTirQrMeU8FeDpZUso368rUGU4PFg8JHCwuNF7X+mcOeodK3EJyGHIfsj172xF8wAHUc4tK2MSIKDfVd8MvX4M3qPN80290wmhCh4YrKFA30az96eSP4RDt19m3/qxTXpcmSRyuw1NKr0DUs4lCG08uV4hMpheypT21HM8eb3NSic73fY0nTLOerTwo9BUdQugjdiBNjlA9o9MzSZ6acCiOqAxqYEnVlWKqfgsy/55uBCAi4rO78sIKptvb+g1i1l86HNj/6xtwlrsXNft1p6MwcGDb66naRDARhzNLWUlrM6yqXpOkHEK1w76zaNw0RfwsxFSbZx5TueQQ1QI/DIxcIX0bIBSiVsp39TneEwFQqXu0a7dvst4LAKIOii6GtEc6FIcuCX49x6qe0VsJvHBS3LgKBcfTUUvWkm67qNX3Xaik1MKjvredkcH+7byxL+TiDE=\
+        \ foreman-proxy@foreman-proxy.example.com\",\"download_policy\":\"immediate\",\"supported_pulp_types\":[\"ansible_collection\",\"docker\",\"file\",\"yum\"],\"lifecycle_environments\":[{\"id\":7,\"name\":\"Test\",\"description\":null,\"library\":false,\"organization_id\":6,\"created_at\":\"2024-07-10 14:13:11 UTC\",\"updated_at\":\"2024-07-10 14:13:11 UTC\",\"label\":\"test\",\"registry_name_pattern\":null,\"registry_unauthenticated_pull\":false,\"prior\":\"Dev\",\"prior_id\":6,\"organization\":\"Test Organization\"}],\"features\":[{\"capabilities\":[],\"name\":\"Container_Gateway\",\"id\":4},{\"capabilities\":[\"single\",\"ssh\"],\"name\":\"Dynflow\",\"id\":17},{\"capabilities\":[\"cockpit\"],\"name\":\"Script\",\"id\":19},{\"capabilities\":[\"ansible\",\"certguard\",\"container\",\"core\",\"file\",\"rpm\"],\"name\":\"Pulpcore\",\"id\":3},{\"capabilities\":[],\"name\":\"Templates\",\"id\":5},{\"capabilities\":[],\"name\":\"Logs\",\"id\":13},{\"capabilities\":[],\"name\":\"Registration\"\
+        ,\"id\":16}]}]\n}\n"
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Length:
+      - '1853'
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:; img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.12.0-develop
+      Keep-Alive:
+      - timeout=15, max=97
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/api/smart_proxies/12
+  response:
+    body:
+      string: '{"created_at":"2024-07-10 14:13:12 UTC","updated_at":"2024-07-10 14:13:18 UTC","hosts_count":0,"name":"foreman-proxy.example.com","id":12,"url":"https://foreman-proxy.example.com:9090","remote_execution_pubkey":"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCkn5pNuZ47pHDMpL1or9cDtaDJaJXn2EdrmcQBiXQOhoWjSn3R2da7ThZkjXGTirQrMeU8FeDpZUso368rUGU4PFg8JHCwuNF7X+mcOeodK3EJyGHIfsj172xF8wAHUc4tK2MSIKDfVd8MvX4M3qPN80290wmhCh4YrKFA30az96eSP4RDt19m3/qxTXpcmSRyuw1NKr0DUs4lCG08uV4hMpheypT21HM8eb3NSic73fY0nTLOerTwo9BUdQugjdiBNjlA9o9MzSZ6acCiOqAxqYEnVlWKqfgsy/55uBCAi4rO78sIKptvb+g1i1l86HNj/6xtwlrsXNft1p6MwcGDb66naRDARhzNLWUlrM6yqXpOkHEK1w76zaNw0RfwsxFSbZx5TueQQ1QI/DIxcIX0bIBSiVsp39TneEwFQqXu0a7dvst4LAKIOii6GtEc6FIcuCX49x6qe0VsJvHBS3LgKBcfTUUvWkm67qNX3Xaik1MKjvredkcH+7byxL+TiDE= foreman-proxy@foreman-proxy.example.com","download_policy":"immediate","supported_pulp_types":["ansible_collection","docker","file","yum"],"lifecycle_environments":[{"id":7,"name":"Test","description":null,"library":false,"organization_id":6,"created_at":"2024-07-10
+        14:13:11 UTC","updated_at":"2024-07-10 14:13:11 UTC","label":"test","registry_name_pattern":null,"registry_unauthenticated_pull":false,"prior":"Dev","prior_id":6,"organization":"Test Organization"}],"features":[{"capabilities":[],"name":"Container_Gateway","id":4},{"capabilities":["single","ssh"],"name":"Dynflow","id":17},{"capabilities":["cockpit"],"name":"Script","id":19},{"capabilities":["ansible","certguard","container","core","file","rpm"],"name":"Pulpcore","id":3},{"capabilities":[],"name":"Templates","id":5},{"capabilities":[],"name":"Logs","id":13},{"capabilities":[],"name":"Registration","id":16}],"locations":[],"organizations":[]}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Length:
+      - '1710'
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:; img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.12.0-develop
+      Keep-Alive:
+      - timeout=15, max=96
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"smart_proxy": {"organization_ids": [6]}}'
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '42'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: PUT
+    uri: https://foreman.example.org/api/smart_proxies/12
+  response:
+    body:
+      string: '{"created_at":"2024-07-10 14:13:12 UTC","updated_at":"2024-07-10 14:13:20 UTC","hosts_count":0,"name":"foreman-proxy.example.com","id":12,"url":"https://foreman-proxy.example.com:9090","remote_execution_pubkey":"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCkn5pNuZ47pHDMpL1or9cDtaDJaJXn2EdrmcQBiXQOhoWjSn3R2da7ThZkjXGTirQrMeU8FeDpZUso368rUGU4PFg8JHCwuNF7X+mcOeodK3EJyGHIfsj172xF8wAHUc4tK2MSIKDfVd8MvX4M3qPN80290wmhCh4YrKFA30az96eSP4RDt19m3/qxTXpcmSRyuw1NKr0DUs4lCG08uV4hMpheypT21HM8eb3NSic73fY0nTLOerTwo9BUdQugjdiBNjlA9o9MzSZ6acCiOqAxqYEnVlWKqfgsy/55uBCAi4rO78sIKptvb+g1i1l86HNj/6xtwlrsXNft1p6MwcGDb66naRDARhzNLWUlrM6yqXpOkHEK1w76zaNw0RfwsxFSbZx5TueQQ1QI/DIxcIX0bIBSiVsp39TneEwFQqXu0a7dvst4LAKIOii6GtEc6FIcuCX49x6qe0VsJvHBS3LgKBcfTUUvWkm67qNX3Xaik1MKjvredkcH+7byxL+TiDE= foreman-proxy@foreman-proxy.example.com","download_policy":"immediate","supported_pulp_types":["ansible_collection","docker","file","yum"],"lifecycle_environments":[{"id":7,"name":"Test","description":null,"library":false,"organization_id":6,"created_at":"2024-07-10
+        14:13:11 UTC","updated_at":"2024-07-10 14:13:11 UTC","label":"test","registry_name_pattern":null,"registry_unauthenticated_pull":false,"prior":"Dev","prior_id":6,"organization":"Test Organization"}],"features":[{"capabilities":[],"name":"Container_Gateway","id":4},{"capabilities":["single","ssh"],"name":"Dynflow","id":17},{"capabilities":["cockpit"],"name":"Script","id":19},{"capabilities":["ansible","certguard","container","core","file","rpm"],"name":"Pulpcore","id":3},{"capabilities":[],"name":"Templates","id":5},{"capabilities":[],"name":"Logs","id":13},{"capabilities":[],"name":"Registration","id":16}],"locations":[],"organizations":[{"id":6,"name":"Test Organization","title":"Test Organization"}]}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Length:
+      - '1743'
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:; img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.12.0-develop
+      Keep-Alive:
+      - timeout=15, max=95
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json;version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - apypie (https://github.com/Apipie/apypie)
+    method: GET
+    uri: https://foreman.example.org/katello/api/capsules/12/content/lifecycle_environments
+  response:
+    body:
+      string: '{"total":1,"subtotal":1,"selectable":1,"page":null,"per_page":null,"error":null,"search":null,"sort":{"by":null,"order":null},"results":[{"library":false,"registry_name_pattern":null,"registry_unauthenticated_pull":false,"id":7,"name":"Test","label":"test","description":null,"organization_id":6,"organization":{"name":"Test Organization","label":"Test_Organization","id":6},"created_at":"2024-07-10 14:13:11 UTC","updated_at":"2024-07-10 14:13:11 UTC","prior":{"name":"Dev","id":6},"successor":null,"counts":{"content_hosts":0,"content_views":0},"permissions":{"create_lifecycle_environments":true,"view_lifecycle_environments":true,"edit_lifecycle_environments":true,"destroy_lifecycle_environments":true,"promote_or_remove_content_views_to_environments":true},"content_views":[]}]}
+
+        '
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - Keep-Alive
+      Content-Length:
+      - '785'
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src ''self''; connect-src ''self'' ws: wss:; img-src ''self'' data:; script-src ''unsafe-eval'' ''unsafe-inline'' ''self''; style-src ''unsafe-inline'' ''self'''
+      Content-Type:
+      - application/json; charset=utf-8
+      Foreman_api_version:
+      - '2'
+      Foreman_current_location:
+      - ; ANY
+      Foreman_current_organization:
+      - ; ANY
+      Foreman_version:
+      - 3.12.0-develop
+      Keep-Alive:
+      - timeout=15, max=94
+      Strict-Transport-Security:
+      - max-age=631139040; includeSubdomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/test_playbooks/katello_smart_proxy.yml
+++ b/tests/test_playbooks/katello_smart_proxy.yml
@@ -91,4 +91,13 @@
         smart_proxy_download_policy: immediate
         smart_proxy_state: present
         expected_change: false
+    # Verify lifecycle_environments lookup is scoped when organizations resolves to exactly one
+    - include_tasks: tasks/smart_proxy.yml
+      vars:
+        smart_proxy_organizations:
+          - 'Test Organization'
+        smart_proxy_lifecycle_environments:
+          - 'Test'
+        smart_proxy_state: present
+        expected_change: true
 ...

--- a/tests/test_playbooks/tasks/smart_proxy.yml
+++ b/tests/test_playbooks/tasks/smart_proxy.yml
@@ -12,6 +12,7 @@
     url: "{{ smart_proxy_url }}"
     lifecycle_environments: "{{ smart_proxy_lifecycle_environments | default(omit) }}"
     download_policy: "{{ smart_proxy_download_policy | default(omit) }}"
+    organizations: "{{ smart_proxy_organizations | default(omit) }}"
     state: "{{ smart_proxy_state }}"
   register: result
 - assert:


### PR DESCRIPTION
Relates to: https://github.com/theforeman/foreman-ansible-modules/issues/1463

Lifecycle Environment names are only unique within an organization. smart_proxy's lifecycle_environments lookup didn't scope by organization at all, so if two orgs each had an LCE with the same name (e.g. library), the lookup could match the wrong one (or fail as ambiguous) depending on which org's LCE happened to resolve first.

This mirrors a bug already fixed for content_view https://github.com/theforeman/foreman-ansible-modules/pull/1980, which added scope=['organization'] to that module's declarative foreman_spec. 

smart_proxy can't use the same declarative approach because it pops lifecycle_environments out of foreman_params and applies it via a separate PUT .../capsules/:id/content/lifecycle_environments call rather than through the entity's own create/update payload.