### PR TITLE
Update smart_proxy module to allow sycing Lifecycle Environments that share names across Orgnizations

### DIFF
--- a/plugins/modules/smart_proxy.py
+++ b/plugins/modules/smart_proxy.py
@@ -39,8 +39,10 @@ options:
     description:
       - Lifecycle Environments synced to the Smart Proxy.
       - Only available for Katello installations.
+      - Each entry is either the name of a Lifecycle Environment, or a dictionary with the keys C(name) and C(organization)
+        to select a Lifecycle Environment from a specific Organization.
     required: false
-    elements: str
+    elements: raw
     type: list
   url:
     description:
@@ -88,6 +90,21 @@ EXAMPLES = '''
     locations:
       - "Default Location"
     state: present
+
+# Sync Lifecycle Environments that share a name across Organizations
+- name: "Sync per-Organization Lifecycle Environments to a Smart Proxy"
+  theforeman.foreman.smart_proxy:
+    username: "admin"
+    password: "changeme"
+    server_url: "https://{{ ansible_fqdn }}"
+    name: "{{ ansible_fqdn }}"
+    url: "https://{{ ansible_fqdn }}:9090"
+    lifecycle_environments:
+      - name: "Production"
+        organization: "Default Organization"
+      - name: "Production"
+        organization: "My Cool new Organization"
+    state: present
 '''
 
 RETURN = '''
@@ -115,7 +132,7 @@ def main():
         foreman_spec=dict(
             name=dict(required=True),
             url=dict(required=True),
-            lifecycle_environments=dict(required=False, type='entity_list'),
+            lifecycle_environments=dict(required=False, type='entity_list', elements='raw', resolve=False),
             download_policy=dict(required=False, choices=['background', 'immediate', 'on_demand', 'streamed', 'inherit']),
         ),
         required_plugins=[('katello', ['lifecycle_environments', 'download_policy'])],
@@ -124,8 +141,19 @@ def main():
     with module.api_connection():
         handle_lifecycle_environments = not module.desired_absent and 'lifecycle_environments' in module.foreman_params
         if handle_lifecycle_environments:
-            module.lookup_entity('lifecycle_environments')
-            lifecycle_environments = module.foreman_params.pop('lifecycle_environments', [])
+            desired_environment_ids = set()
+            for lifecycle_environment in module.foreman_params.pop('lifecycle_environments'):
+                if isinstance(lifecycle_environment, dict):
+                    name = lifecycle_environment.get('name')
+                    organization = lifecycle_environment.get('organization')
+                    if not name or not organization:
+                        module.fail_json(msg="Lifecycle Environments must be specified either by name, "
+                                             "or as a dict providing both 'name' and 'organization'.")
+                    scope = {'organization_id': module.find_resource_by_name('organizations', organization, thin=True)['id']}
+                else:
+                    name = lifecycle_environment
+                    scope = {}
+                desired_environment_ids.add(module.find_resource_by_name('lifecycle_environments', name, params=scope, thin=True)['id'])
 
         smart_proxy = module.lookup_entity('entity')
         new_smart_proxy = module.run()
@@ -140,7 +168,6 @@ def main():
             else:
                 current_lces = {'results': []}
 
-            desired_environment_ids = set(lifecycle_environment['id'] for lifecycle_environment in lifecycle_environments)
             current_environment_ids = set(lifecycle_environment['id'] for lifecycle_environment in current_lces['results']) if current_lces else set()
 
             module.record_before('smart_proxy_content/lifecycle_environment_ids', current_environment_ids)

--- a/plugins/modules/smart_proxy.py
+++ b/plugins/modules/smart_proxy.py
@@ -41,6 +41,7 @@ options:
       - Only available for Katello installations.
       - Each entry is either the name of a Lifecycle Environment, or a dictionary with the keys C(name) and C(organization)
         to select a Lifecycle Environment from a specific Organization.
+      - Any Lifecycle Environment currently synced to the Smart Proxy, but not listed here, is removed.
     required: false
     elements: raw
     type: list

--- a/plugins/modules/smart_proxy.py
+++ b/plugins/modules/smart_proxy.py
@@ -42,6 +42,7 @@ options:
       - Each entry is either the name of a Lifecycle Environment, or a dictionary with the keys C(name) and C(organization)
         to select a Lifecycle Environment from a specific Organization.
       - Any Lifecycle Environment currently synced to the Smart Proxy, but not listed here, is removed.
+      - Listing a plain name without specifying an Organization fails if Lifecycle Environments of that name exist in more than one Organization.
     required: false
     elements: raw
     type: list

--- a/tests/test_playbooks/katello_smart_proxy.yml
+++ b/tests/test_playbooks/katello_smart_proxy.yml
@@ -35,11 +35,15 @@
         location_state: "present"
     - include_tasks: tasks/organization.yml
       vars:
-        organization_name: "Test Organization"
+        organization_name: "{{ item }}"
         organization_state: "present"
+      loop:
+        - "Test Organization"
+        - "Test Organization 2"
     - include_tasks: tasks/lifecycle_environment.yml
       vars:
         lifecycle_environment_state: present
+        organization_name: "{{ item.organization }}"
         lifecycle_environment_name: "{{ item.name }}"
         lifecycle_environment_label: "{{ item.label }}"
         lifecycle_environment_prior: "{{ item.prior }}"
@@ -47,9 +51,19 @@
         - name: Dev
           label: dev
           prior: Library
+          organization: "Test Organization"
         - name: Test
           label: test
           prior: Dev
+          organization: "Test Organization"
+        - name: Prod
+          label: prod
+          prior: Test
+          organization: "Test Organization"
+        - name: Prod
+          label: prod
+          prior: Library
+          organization: "Test Organization 2"
 
 - hosts: tests
   collections:
@@ -91,4 +105,34 @@
         smart_proxy_download_policy: immediate
         smart_proxy_state: present
         expected_change: false
+    - include_tasks: tasks/smart_proxy.yml
+      vars:
+        smart_proxy_state: present
+        smart_proxy_lifecycle_environments:
+          - name: 'Prod'
+            organization: 'Test Organization'
+        expected_change: true
+    - include_tasks: tasks/smart_proxy.yml
+      vars:
+        smart_proxy_state: present
+        smart_proxy_lifecycle_environments:
+          - name: 'Prod'
+            organization: 'Test Organization'
+        expected_change: false
+    - include_tasks: tasks/smart_proxy.yml
+      vars:
+        smart_proxy_state: present
+        smart_proxy_lifecycle_environments:
+          - name: 'Prod'
+            organization: 'Test Organization'
+          - name: 'Prod'
+            organization: 'Test Organization 2'
+        expected_change: true
+    - include_tasks: tasks/smart_proxy.yml
+      vars:
+        smart_proxy_state: present
+        smart_proxy_lifecycle_environments:
+          - name: 'Prod'
+            organization: 'Test Organization 2'
+        expected_change: true
 ...


### PR DESCRIPTION
Closes #1463 

I did find a similar implementation in #1984, but I work with smart proxies that have several organizations assigned to them, so it did not work for me.

This change allows specifying a list dicts with `name` and `organization` to disambiguate lifecycle environments, like so:
```
lifecycle_environments:
  - name: "Production"
    organization: "Default Organization"
  - name: "Production"
    organization: "My Cool New Organization"
```

It does not break the current way of listing lifecycle environments with a simple list, so all existing usage of the module should continue to work as expected.

I tried updating the tests as well, but I am not able to run them or record new cassettes (?), so they will probably fail. Let me know if I should update or revert those changes.