### PR TITLE
disable bullseye-security in the container

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -89,6 +89,9 @@ jobs:
           cache: 'pip'
           cache-dependency-path: '**/requirements*.txt'
         if: matrix.container == null
+      - name: disable bullseye-security
+        run: sed -i '/bullseye-security/d' /etc/apt/sources.list
+        if: matrix.container == 'python:3.6'
       - name: Install sudo
         run: apt-get update && apt-get install -y sudo
         if: matrix.container != null


### PR DESCRIPTION
bullseye is EOL and the security sig expired, but we still want to install sudo from there so that our scripts keep working